### PR TITLE
feat(core/event): SSE/WS 이벤트 redis pub/sub 크로스파드 fan-out

### DIFF
--- a/packages/core/src/event/README.md
+++ b/packages/core/src/event/README.md
@@ -477,15 +477,22 @@ regardless of cache.
 > `Date` arrives as an ISO string; a void event arrives as `null` on remote pods (vs
 > `undefined` in-process). `bigint`/circular payloads can't serialize — see degrade below.
 >
-> **Ordering needs sequential `await`.** Per-channel order is preserved end-to-end only if
-> the producer awaits each emit in turn (`for (const c of chunks) await event.emit(c)`).
-> Fire-and-forget (`chunks.forEach(c => event.emit(c))`) races the publishes and can reorder
-> a token stream. The transport adds no sequence number.
+> **Ordering needs sequential `await` _and_ healthy publishes.** Per-channel order is preserved
+> end-to-end only if the producer awaits each emit in turn (`for (const c of chunks) await
+> event.emit(c)`). Fire-and-forget (`chunks.forEach(c => event.emit(c))`) races the publishes
+> and can reorder a token stream. Also: a mid-stream publish **failure** delivers its event via
+> the synchronous local fallback, which can land ahead of an earlier successful emit whose echo
+> is still in flight — so a Redis blip mid-stream may reorder relative to in-flight emits. The
+> transport adds no sequence number; if strict order matters across failures, carry one in the
+> payload and reorder on the client.
 >
-> **Channel isolation.** The default prefix `spfn:sse:` is shared by every SPFN app, so apps
-> sharing **one** Redis with a colliding event name would cross-talk. Set `channelPrefix` /
-> `SPFN_SSE_CHANNEL_PREFIX` per app (the server logs a WARN at startup if you're on the
-> default). Separate `CACHE_URL`s per app are isolated already.
+> **Channel isolation & receive-side trust.** The default prefix `spfn:sse:` is shared by every
+> SPFN app, so apps sharing **one** Redis with a colliding event name would cross-talk. Set
+> `channelPrefix` / `SPFN_SSE_CHANNEL_PREFIX` per app (the server logs a WARN at startup if
+> you're on the default); separate `CACHE_URL`s per app are isolated already. Note the receiving
+> pod does **not** re-validate a payload against the event schema before delivering it to
+> `filter`/handlers — anything with Redis access can publish to a channel, so treat Redis access
+> as a trust boundary (same level as the one-time-token store).
 
 **Degrade**: SSE is lossy (at-most-once). If a publish can't reach Redis (a blip) or the
 payload can't serialize, the event is **still delivered to this pod's own subscribers**

--- a/packages/core/src/event/README.md
+++ b/packages/core/src/event/README.md
@@ -477,6 +477,11 @@ regardless of cache.
 > `Date` arrives as an ISO string; a void event arrives as `null` on remote pods (vs
 > `undefined` in-process). `bigint`/circular payloads can't serialize — see degrade below.
 >
+> **Ordering needs sequential `await`.** Per-channel order is preserved end-to-end only if
+> the producer awaits each emit in turn (`for (const c of chunks) await event.emit(c)`).
+> Fire-and-forget (`chunks.forEach(c => event.emit(c))`) races the publishes and can reorder
+> a token stream. The transport adds no sequence number.
+>
 > **Channel isolation.** The default prefix `spfn:sse:` is shared by every SPFN app, so apps
 > sharing **one** Redis with a colliding event name would cross-talk. Set `channelPrefix` /
 > `SPFN_SSE_CHANNEL_PREFIX` per app (the server logs a WARN at startup if you're on the
@@ -485,7 +490,7 @@ regardless of cache.
 **Degrade**: SSE is lossy (at-most-once). If a publish can't reach Redis (a blip) or the
 payload can't serialize, the event is **still delivered to this pod's own subscribers**
 (local fallback) and logged; only **remote** pods miss it. A publish never crashes `emit` or
-kills a stream. ioredis auto-reconnects and re-subscribes. A per-event SUBSCRIBE failure at
+kills a stream. ioredis auto-reconnects and re-subscribes (autoResubscribe, default true). A per-event SUBSCRIBE failure at
 startup degrades that event to in-process (logged) rather than aborting boot. Same-pod
 delivery costs one Redis round-trip — for a single-replica deploy with a cache, prefer
 `multiInstance: false` to skip it.

--- a/packages/core/src/event/README.md
+++ b/packages/core/src/event/README.md
@@ -496,8 +496,12 @@ regardless of cache.
 
 **Degrade**: SSE is lossy (at-most-once). If a publish can't reach Redis (a blip) or the
 payload can't serialize, the event is **still delivered to this pod's own subscribers**
-(local fallback) and logged; only **remote** pods miss it. A publish never crashes `emit` or
-kills a stream. ioredis auto-reconnects and re-subscribes (autoResubscribe, default true). A per-event SUBSCRIBE failure at
+(local fallback) and logged; only **remote** pods miss it. The same local fallback covers the
+asymmetric case where the publish succeeds but **this pod's subscriber socket is down** (its
+echo — the only path to same-pod streams — wouldn't arrive). A sustained publish outage trips
+a short circuit breaker so emits fast-path to local instead of each paying the publish timeout.
+A publish never crashes `emit` or kills a stream. ioredis auto-reconnects and re-subscribes
+(autoResubscribe, default true). A per-event SUBSCRIBE failure at
 startup degrades that event to in-process (logged) rather than aborting boot. Same-pod
 delivery costs one Redis round-trip — for a single-replica deploy with a cache, prefer
 `multiInstance: false` to skip it.

--- a/packages/core/src/event/README.md
+++ b/packages/core/src/event/README.md
@@ -174,13 +174,24 @@ export default defineServerConfig()
 // Custom path + ping interval:
 .events(eventRouter, {
     path: '/sse',                     // default: '/events/stream'
-    pingInterval: 30000,              // keep-alive interval, ms (default: 30000)
+    pingInterval: 10000,              // keep-alive interval, ms (default: 10000 — under proxy idle timeouts)
 })
 ```
 
 `.events(router, config)` accepts `Omit<SSEHandlerConfig, 'auth'> & { path?, auth?:
 SSEAuthConfig<TRouter> }`. The `auth` field is the **generic** `SSEAuthConfig<TRouter>` so
 `authorize`/`filter` get full event-name and payload inference from your router.
+
+`config` also carries the cross-pod transport knobs (see
+[Multi-instance broadcast](#multi-instance-broadcast-cross-pod-fan-out)):
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `multiInstance` | `boolean` | `true` | auto-wire Redis pub/sub when a cache is configured; `false` forces in-process |
+| `channelPrefix` | `string` | env `SPFN_SSE_CHANNEL_PREFIX` or `spfn:sse:` | pub/sub channel prefix; set distinct prefixes to isolate apps sharing one Redis |
+
+> `.websockets(router, config)` accepts the same `multiInstance` / `channelPrefix` knobs.
+> Events shared by both routers are wired once.
 
 > `SSEHandlerConfig` also declares a `headers` field, but the current handler only reads
 > `pingInterval` and `auth`. Setting custom `headers` here is a no-op — set response headers
@@ -427,11 +438,63 @@ It creates a throwaway client and subscribes once. For auth, prefer `createAuthS
 
 ---
 
-## Multi-instance broadcast (`useCache`)
+## Multi-instance broadcast (cross-pod fan-out)
 
-By default `emit` only reaches handlers in the **same process**. For multiple
-instances/pods, attach a `PubSubCache` so an emit on one instance fans out to all. **`await`
-`useCache` before emitting** — it must finish subscribing first.
+By default `emit` only reaches handlers in the **same process**. Across multiple pods, an
+`emit` on the pod that handles the chat POST must still reach the SSE stream pinned to a
+**different** pod — otherwise the stream silently stalls.
+
+**This is automatic.** When a cache is configured (`CACHE_URL` / `getCache()` returns a
+client), `.events(router)` and `.websockets(router)` wire every event to a Redis/Valkey
+pub/sub transport at startup. No code change in your app — register the router as usual and
+multi-pod fan-out just works. Without a cache it is a no-op and events stay in-process, so a
+single pod (or local dev) behaves exactly as before.
+
+```typescript
+export default defineServerConfig()
+    .events(eventRouter)          // CACHE_URL set → cross-pod fan-out; unset → in-process
+    .build();
+
+// Force in-process even when a cache is present, or set an isolation prefix:
+.events(eventRouter, {
+    multiInstance: false,         // default true
+    channelPrefix: 'my-app:',     // default: env SPFN_SSE_CHANNEL_PREFIX, else 'spfn:sse:'
+})
+```
+
+Mechanics (from `event.ts`): once a cache is wired, `emit` calls `cache.publish(name,
+payload)` **instead of** triggering local handlers directly — local handlers (including the
+SSE stream on the same pod) fire when the message comes back through the pub/sub `subscribe`
+callback. Auth `filter` still runs per-subscriber on the **receiving** pod's SSE handler —
+the transport only fans out by event name. Job queues receive the payload on every emit
+regardless of cache.
+
+> **Process-global.** `multiInstance` and `channelPrefix` are resolved **once per process**
+> (first `.events()`/`.websockets()` wiring wins); a second router can't change them. That's
+> correct because one process serves one app. An event shared by both routers is wired once.
+>
+> **Payloads must be JSON-serializable** when fan-out is on (they cross Redis as JSON). A
+> `Date` arrives as an ISO string; a void event arrives as `null` on remote pods (vs
+> `undefined` in-process). `bigint`/circular payloads can't serialize — see degrade below.
+>
+> **Channel isolation.** The default prefix `spfn:sse:` is shared by every SPFN app, so apps
+> sharing **one** Redis with a colliding event name would cross-talk. Set `channelPrefix` /
+> `SPFN_SSE_CHANNEL_PREFIX` per app (the server logs a WARN at startup if you're on the
+> default). Separate `CACHE_URL`s per app are isolated already.
+
+**Degrade**: SSE is lossy (at-most-once). If a publish can't reach Redis (a blip) or the
+payload can't serialize, the event is **still delivered to this pod's own subscribers**
+(local fallback) and logged; only **remote** pods miss it. A publish never crashes `emit` or
+kills a stream. ioredis auto-reconnects and re-subscribes. A per-event SUBSCRIBE failure at
+startup degrades that event to in-process (logged) rather than aborting boot. Same-pod
+delivery costs one Redis round-trip — for a single-replica deploy with a cache, prefer
+`multiInstance: false` to skip it.
+
+### Manual `useCache` (advanced)
+
+You rarely need this — the server wires it for you. `EventDef.useCache(cache)` is the
+underlying primitive if you drive events outside `defineServerConfig` (e.g. a worker). The
+`PubSubCache` shape it expects:
 
 ```typescript
 import { getCache } from '@spfn/core/cache';
@@ -459,10 +522,10 @@ if (cache)
 await userCreated.emit({ userId: '123', email: 'a@b.com' }); // broadcasts to all instances
 ```
 
-Mechanics (from `event.ts`): once a cache is set, `emit` calls `cache.publish(name, payload)`
-**instead of** triggering local handlers directly — local handlers fire only when the
-message comes back through the cache `subscribe` callback. Job queues still receive the
-payload on every emit regardless of cache.
+**`await` `useCache` before emitting** — it must finish subscribing first. A direct second
+call on the same `EventDef` logs `Cache already configured` and is ignored. (Separately, the
+server's auto-wiring dedups by **event name** across the SSE and WS routers — tracked in the
+transport, so a shared event's `useCache` is invoked only once and the warn never fires.)
 
 ---
 

--- a/packages/core/src/event/__tests__/cache-transport.test.ts
+++ b/packages/core/src/event/__tests__/cache-transport.test.ts
@@ -24,6 +24,7 @@ import { getCache } from '@spfn/core/cache';
 // Reset the global transport singleton between tests (wired set, cached pubSubCache).
 afterEach(async () =>
 {
+    vi.useRealTimers(); // restore before closeEventTransport (which uses a real timer race)
     await closeEventTransport();
     (getCache as unknown as Mock).mockReturnValue(undefined);
 });
@@ -265,6 +266,102 @@ describe('createRedisPubSubCache', () =>
         expect(received[0]).toBe(fn); // delivered locally (live object)
     });
 
+    it('falls back to local delivery when publish hangs (timeout-bound)', async () =>
+    {
+        vi.useFakeTimers();
+
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };
+        const client = {
+            publish: vi.fn(() => new Promise(() => undefined)), // never settles (wedged socket)
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        const received: unknown[] = [];
+        await cache.subscribe('x', (payload) =>
+        {
+            received.push(payload);
+        });
+
+        const pending = cache.publish('x', { a: 1 });
+        await vi.advanceTimersByTimeAsync(5000); // trip the publish timeout
+        await expect(pending).resolves.toBeUndefined(); // emit never hangs
+
+        expect(received).toEqual([{ a: 1 }]); // delivered locally after the timeout
+    });
+
+    it('rejects (degrades) when SUBSCRIBE hangs (timeout-bound)', async () =>
+    {
+        vi.useFakeTimers();
+
+        const subscriberStub = {
+            subscribe: vi.fn(() => new Promise(() => undefined)), // never settles
+            on: vi.fn(),
+            quit: vi.fn().mockResolvedValue('OK'),
+        };
+        const client = {
+            publish: vi.fn(),
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        const pending = cache.subscribe('x', () => undefined);
+        const assertion = expect(pending).rejects.toThrow(/timed out/);
+        await vi.advanceTimersByTimeAsync(5000);
+        await assertion;
+
+        expect(subscriberStub.quit).toHaveBeenCalled(); // half-open connection torn down
+    });
+
+    it('drops malformed and unknown-channel redis messages without throwing', async () =>
+    {
+        let onMessage: ((channel: string, raw: string) => void) | undefined;
+        let onError: ((err: Error) => void) | undefined;
+        const subscriberStub = {
+            subscribe: vi.fn().mockResolvedValue(undefined),
+            on: vi.fn((event: string, fn: any) =>
+            {
+                if (event === 'message') onMessage = fn;
+                if (event === 'error') onError = fn;
+            }),
+        };
+        const client = {
+            publish: vi.fn(),
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        const received: unknown[] = [];
+        await cache.subscribe('known', (payload) =>
+        {
+            received.push(payload);
+        });
+
+        // Listeners were attached.
+        expect(onMessage).toBeTypeOf('function');
+        expect(onError).toBeTypeOf('function');
+
+        // No handler for this channel → ignored, no throw.
+        expect(() => onMessage!('spfn:sse:unknown', '{"a":1}')).not.toThrow();
+        // Malformed JSON on a known channel → parse fails → dropped, no throw.
+        expect(() => onMessage!('spfn:sse:known', 'not json{')).not.toThrow();
+        // Subscriber error → logged (throttled), no throw.
+        expect(() => onError!(new Error('ECONNRESET'))).not.toThrow();
+        // A valid message still gets through.
+        onMessage!('spfn:sse:known', '{"a":2}');
+
+        expect(received).toEqual([{ a: 2 }]);
+    });
+
     it('tears down the subscriber when the first SUBSCRIBE fails so a retry rebuilds', async () =>
     {
         const deadSub = {
@@ -461,7 +558,7 @@ describe('closeEventTransport', () =>
     it('quits the subscriber connection and is a no-op when none was opened', async () =>
     {
         const quit = vi.fn().mockResolvedValue('OK');
-        const subscriber = { subscribe: vi.fn(), on: vi.fn(), quit };
+        const subscriber = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn(), quit };
         const client = {
             publish: vi.fn().mockResolvedValue(1),
             duplicate: vi.fn().mockReturnValue(subscriber),
@@ -483,5 +580,28 @@ describe('closeEventTransport', () =>
         // closeEventTransport only quits the singleton subscriber, not this local one,
         // so a bare call with nothing wired must not throw.
         await expect(closeEventTransport()).resolves.toBeUndefined();
+    });
+
+    it('does not hang shutdown when the subscriber quit() never resolves', async () =>
+    {
+        vi.useFakeTimers();
+
+        const hangingSub = {
+            subscribe: vi.fn().mockResolvedValue(undefined),
+            on: vi.fn(),
+            quit: vi.fn(() => new Promise(() => undefined)), // never settles (wedged socket)
+        };
+        const client = new FakeRedis(new FakeBus());
+        vi.spyOn(client, 'duplicate').mockReturnValue(hangingSub as any);
+        (getCache as unknown as Mock).mockReturnValue(client);
+
+        const evt = defineEvent('quitHang', Type.Object({}));
+        await wireEventRouterCache(defineEventRouter({ evt }));
+
+        const pending = closeEventTransport();
+        await vi.advanceTimersByTimeAsync(5000); // trip the quit timeout
+        await expect(pending).resolves.toBeUndefined(); // shutdown proceeds anyway
+
+        expect(hangingSub.quit).toHaveBeenCalled();
     });
 });

--- a/packages/core/src/event/__tests__/cache-transport.test.ts
+++ b/packages/core/src/event/__tests__/cache-transport.test.ts
@@ -309,6 +309,57 @@ describe('createRedisPubSubCache', () =>
         expect(received).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]); // all delivered locally
     });
 
+    it('delivers same-pod locally on publish success when the subscriber connection is down', async () =>
+    {
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn(), status: 'close' };
+        const client = {
+            status: 'ready', // write client healthy
+            publish: vi.fn().mockResolvedValue(1), // PUBLISH succeeds (remote pods get it)
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        const received: unknown[] = [];
+        await cache.subscribe('x', (payload) =>
+        {
+            received.push(payload);
+        });
+
+        await cache.publish('x', { n: 1 });
+
+        expect(client.publish).toHaveBeenCalledOnce(); // cross-pod send still happened
+        expect(received).toEqual([{ n: 1 }]); // same-pod covered locally (echo can't arrive)
+    });
+
+    it('does not double-deliver on publish success when the subscriber is healthy', async () =>
+    {
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn(), status: 'ready' };
+        const client = {
+            status: 'ready',
+            publish: vi.fn().mockResolvedValue(1),
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        const received: unknown[] = [];
+        await cache.subscribe('x', (payload) =>
+        {
+            received.push(payload);
+        });
+
+        await cache.publish('x', { n: 1 });
+
+        // Healthy subscriber → delivery comes via the echo, not local — no local push here.
+        expect(client.publish).toHaveBeenCalledOnce();
+        expect(received).toEqual([]);
+    });
+
     it('skips publish (no offline-queue duplicate) when the client is not connected', async () =>
     {
         const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };

--- a/packages/core/src/event/__tests__/cache-transport.test.ts
+++ b/packages/core/src/event/__tests__/cache-transport.test.ts
@@ -240,6 +240,31 @@ describe('createRedisPubSubCache', () =>
         expect(received).toEqual([{ big: 10n }]); // but local subscriber still got it
     });
 
+    it('never rejects nor publishes when the payload serializes to undefined (function/symbol)', async () =>
+    {
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };
+        const client = {
+            publish: vi.fn().mockResolvedValue(1),
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        const received: unknown[] = [];
+        await cache.subscribe('fn', (payload) =>
+        {
+            received.push(payload);
+        });
+
+        const fn = () => 'token';
+        // Must not reject (publish-never-kills-emit invariant) and must not reach the wire.
+        await expect(cache.publish('fn', fn)).resolves.toBeUndefined();
+        expect(client.publish).not.toHaveBeenCalled();
+        expect(received[0]).toBe(fn); // delivered locally (live object)
+    });
+
     it('tears down the subscriber when the first SUBSCRIBE fails so a retry rebuilds', async () =>
     {
         const deadSub = {
@@ -356,6 +381,24 @@ describe('wireEventRouterCache', () =>
         expect(pub2).toHaveBeenCalled();
         expect(pub1).not.toHaveBeenCalled();
         expect(received).toEqual([{ n: 7 }]);
+    });
+
+    it('keeps the first wiring channelPrefix process-global (a later, different prefix is ignored)', async () =>
+    {
+        const client = new FakeRedis(new FakeBus());
+        const pubSpy = vi.spyOn(client, 'publish');
+        (getCache as unknown as Mock).mockReturnValue(client);
+
+        const e1 = defineEvent('pfx1', Type.Object({}));
+        const e2 = defineEvent('pfx2', Type.Object({}));
+
+        await wireEventRouterCache(defineEventRouter({ e1 }), { channelPrefix: 'app-a:' });
+        await wireEventRouterCache(defineEventRouter({ e2 }), { channelPrefix: 'app-b:' });
+
+        await e2.emit({});
+
+        // e2 publishes on the FIRST prefix (app-a:), not its own app-b: — process-global.
+        expect(pubSpy).toHaveBeenCalledWith('app-a:pfx2', expect.any(String));
     });
 
     it('degrades a single event to in-process when its useCache rejects, without throwing', async () =>

--- a/packages/core/src/event/__tests__/cache-transport.test.ts
+++ b/packages/core/src/event/__tests__/cache-transport.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Event cache transport (Redis pub/sub) tests
+ *
+ * Simulates multiple pods sharing one Redis bus and asserts that an `emit` on
+ * one pod fans out to subscribers on another, that channel prefixes isolate
+ * apps, that publish/serialization failures degrade to local delivery rather
+ * than dropping or crashing, and that router wiring dedups + degrades gracefully.
+ */
+
+import { describe, it, expect, vi, afterEach, type Mock } from 'vitest';
+import { Type } from '@sinclair/typebox';
+// Import from src (not the '@spfn/core/event' package specifier, which resolves to
+// built dist) so these tests exercise the current source and share ONE event-module
+// instance with cache-transport — no stale-dist false confidence, no dual singleton.
+import { defineEvent } from '../event';
+import { defineEventRouter } from '../router';
+import { createRedisPubSubCache, wireEventRouterCache, closeEventTransport } from '../cache-transport';
+
+// Mock the cache module so wireEventRouterCache's dynamic getCache() is steerable.
+// Defaults to "no cache" (in-process); individual tests opt into a fake client.
+vi.mock('@spfn/core/cache', () => ({ getCache: vi.fn(() => undefined) }));
+import { getCache } from '@spfn/core/cache';
+
+// Reset the global transport singleton between tests (wired set, cached pubSubCache).
+afterEach(async () =>
+{
+    await closeEventTransport();
+    (getCache as unknown as Mock).mockReturnValue(undefined);
+});
+
+// ── Fake Redis bus (shared backend for several client connections) ──
+
+class FakeBus
+{
+    private channels = new Map<string, Set<(channel: string, message: string) => void>>();
+
+    publish(channel: string, message: string): number
+    {
+        const subs = this.channels.get(channel);
+        if (!subs)
+        {
+            return 0;
+        }
+
+        for (const cb of subs)
+        {
+            cb(channel, message);
+        }
+
+        return subs.size;
+    }
+
+    subscribe(channel: string, cb: (channel: string, message: string) => void): void
+    {
+        let set = this.channels.get(channel);
+        if (!set)
+        {
+            set = new Set();
+            this.channels.set(channel, set);
+        }
+
+        set.add(cb);
+    }
+}
+
+class FakeRedis
+{
+    private listeners: ((channel: string, message: string) => void)[] = [];
+
+    constructor(private bus: FakeBus)
+    {}
+
+    async publish(channel: string, message: string): Promise<number>
+    {
+        return this.bus.publish(channel, message);
+    }
+
+    duplicate(): FakeRedis
+    {
+        return new FakeRedis(this.bus);
+    }
+
+    async subscribe(channel: string): Promise<void>
+    {
+        this.bus.subscribe(channel, (ch, msg) =>
+        {
+            for (const l of this.listeners)
+            {
+                l(ch, msg);
+            }
+        });
+    }
+
+    on(event: string, listener: (channel: string, message: string) => void): void
+    {
+        if (event === 'message')
+        {
+            this.listeners.push(listener);
+        }
+    }
+}
+
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+describe('createRedisPubSubCache', () =>
+{
+    it('fans out an emit from one pod to a subscriber on another pod', async () =>
+    {
+        const bus = new FakeBus();
+        const schema = Type.Object({ text: Type.String() });
+
+        // Two independent event instances with the same name = two pods.
+        const podA = defineEvent('chatChunk', schema);
+        const podB = defineEvent('chatChunk', schema);
+
+        await podA.useCache(createRedisPubSubCache(new FakeRedis(bus), 'spfn:sse:'));
+        await podB.useCache(createRedisPubSubCache(new FakeRedis(bus), 'spfn:sse:'));
+
+        const received: { text: string }[] = [];
+        podB.subscribe((payload) =>
+        {
+            received.push(payload);
+        });
+
+        await podA.emit({ text: 'hello' });
+        await flush();
+
+        expect(received).toEqual([{ text: 'hello' }]);
+    });
+
+    it('fans out a void-payload event without dropping it', async () =>
+    {
+        const bus = new FakeBus();
+
+        const podA = defineEvent('serverStarted');
+        const podB = defineEvent('serverStarted');
+
+        await podA.useCache(createRedisPubSubCache(new FakeRedis(bus), 'spfn:sse:'));
+        await podB.useCache(createRedisPubSubCache(new FakeRedis(bus), 'spfn:sse:'));
+
+        let received = 0;
+        podB.subscribe(() =>
+        {
+            received++;
+        });
+
+        await podA.emit();
+        await flush();
+
+        expect(received).toBe(1);
+    });
+
+    it('isolates pods that use a different channel prefix', async () =>
+    {
+        const bus = new FakeBus();
+        const schema = Type.Object({ text: Type.String() });
+
+        const podA = defineEvent('chatChunk', schema);
+        const podB = defineEvent('chatChunk', schema);
+
+        await podA.useCache(createRedisPubSubCache(new FakeRedis(bus), 'app-a:'));
+        await podB.useCache(createRedisPubSubCache(new FakeRedis(bus), 'app-b:'));
+
+        const received: unknown[] = [];
+        podB.subscribe((payload) =>
+        {
+            received.push(payload);
+        });
+
+        await podA.emit({ text: 'hello' });
+        await flush();
+
+        expect(received).toEqual([]);
+    });
+
+    it('swallows publish failures so emit never throws', async () =>
+    {
+        const failing = {
+            publish: vi.fn().mockRejectedValue(new Error('redis down')),
+            duplicate: vi.fn(),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(failing as any, 'spfn:sse:');
+
+        await expect(cache.publish('chatChunk', { text: 'hi' })).resolves.toBeUndefined();
+        expect(failing.publish).toHaveBeenCalledOnce();
+    });
+
+    it('delivers locally when publish fails (same-pod stream survives a Redis blip)', async () =>
+    {
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };
+        const client = {
+            publish: vi.fn().mockRejectedValue(new Error('redis down')),
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const event = defineEvent('chatChunk', Type.Object({ text: Type.String() }));
+        await event.useCache(createRedisPubSubCache(client as any, 'spfn:sse:'));
+
+        const received: { text: string }[] = [];
+        event.subscribe((payload) =>
+        {
+            received.push(payload);
+        });
+
+        const original = { text: 'hi' };
+        await event.emit(original);
+        await flush();
+
+        expect(client.publish).toHaveBeenCalledOnce();
+        expect(received).toEqual([{ text: 'hi' }]); // delivered despite the publish failure
+        expect(received[0]).not.toBe(original); // a JSON copy, same shape as the echo path
+    });
+
+    it('delivers locally when the payload is not JSON-serializable', async () =>
+    {
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };
+        const client = {
+            publish: vi.fn().mockResolvedValue(1),
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        const received: unknown[] = [];
+        await cache.subscribe('weird', (payload) =>
+        {
+            received.push(payload);
+        });
+
+        await cache.publish('weird', { big: 10n }); // bigint → JSON.stringify throws
+
+        expect(client.publish).not.toHaveBeenCalled(); // never reached the wire
+        expect(received).toEqual([{ big: 10n }]); // but local subscriber still got it
+    });
+
+    it('tears down the subscriber when the first SUBSCRIBE fails so a retry rebuilds', async () =>
+    {
+        const deadSub = {
+            subscribe: vi.fn().mockRejectedValue(new Error('SUBSCRIBE failed')),
+            on: vi.fn(),
+            quit: vi.fn().mockResolvedValue('OK'),
+        };
+        const goodSub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };
+        const client = {
+            publish: vi.fn(),
+            duplicate: vi.fn().mockReturnValueOnce(deadSub).mockReturnValueOnce(goodSub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        await expect(cache.subscribe('a', () => undefined)).rejects.toThrow('SUBSCRIBE failed');
+        expect(deadSub.quit).toHaveBeenCalled(); // half-open connection torn down
+
+        // Retry rebuilds a fresh subscriber rather than reusing the dead one.
+        await cache.subscribe('a', () => undefined);
+        expect(client.duplicate).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('wireEventRouterCache', () =>
+{
+    it('stays in-process when multiInstance is disabled', async () =>
+    {
+        const router = defineEventRouter({
+            ping: defineEvent('ping', Type.Object({})),
+        });
+
+        const transport = await wireEventRouterCache(router, { multiInstance: false });
+
+        expect(transport).toBe('in-process');
+    });
+
+    it('stays in-process when no cache is configured', async () =>
+    {
+        const router = defineEventRouter({
+            ping: defineEvent('ping', Type.Object({})),
+        });
+
+        // getCache mock returns undefined → falls back to in-process.
+        const transport = await wireEventRouterCache(router);
+
+        expect(transport).toBe('in-process');
+    });
+
+    it('wires events to redis when a cache is present and dedups a shared event across routers', async () =>
+    {
+        const bus = new FakeBus();
+        const client = new FakeRedis(bus);
+        const duplicateSpy = vi.spyOn(client, 'duplicate');
+        (getCache as unknown as Mock).mockReturnValue(client);
+
+        // Same event instance registered on two routers (SSE + WS).
+        const shared = defineEvent('sharedEvt', Type.Object({ n: Type.Number() }));
+        const sseRouter = defineEventRouter({ shared });
+        const wsRouter = defineEventRouter({ shared });
+
+        expect(await wireEventRouterCache(sseRouter)).toBe('redis');
+        expect(await wireEventRouterCache(wsRouter)).toBe('redis');
+
+        // Shared event wired exactly once → one subscriber connection, not two.
+        expect(duplicateSpy).toHaveBeenCalledTimes(1);
+
+        const received: { n: number }[] = [];
+        shared.subscribe((payload) =>
+        {
+            received.push(payload);
+        });
+
+        await shared.emit({ n: 5 });
+        await flush();
+
+        expect(received).toEqual([{ n: 5 }]);
+    });
+
+    it('rebinds events to a fresh cache after closeEventTransport (same-process restart)', async () =>
+    {
+        // Server #1: wire with client C1.
+        const client1 = new FakeRedis(new FakeBus());
+        (getCache as unknown as Mock).mockReturnValue(client1);
+
+        const evt = defineEvent('restartEvt', Type.Object({ n: Type.Number() }));
+        const router = defineEventRouter({ evt });
+        expect(await wireEventRouterCache(router)).toBe('redis');
+
+        // Shutdown server #1 (clears transport state AND resets the EventDef binding).
+        await closeEventTransport();
+
+        // Server #2: a brand-new client C2 (C1 is gone).
+        const bus2 = new FakeBus();
+        const client2 = new FakeRedis(bus2);
+        (getCache as unknown as Mock).mockReturnValue(client2);
+        expect(await wireEventRouterCache(router)).toBe('redis');
+
+        const pub1 = vi.spyOn(client1, 'publish');
+        const pub2 = vi.spyOn(client2, 'publish');
+
+        const received: { n: number }[] = [];
+        evt.subscribe((payload) =>
+        {
+            received.push(payload);
+        });
+
+        await evt.emit({ n: 7 });
+        await flush();
+
+        // Rebound to C2 — without _resetCache the event would stay latched on dead C1.
+        expect(pub2).toHaveBeenCalled();
+        expect(pub1).not.toHaveBeenCalled();
+        expect(received).toEqual([{ n: 7 }]);
+    });
+
+    it('degrades a single event to in-process when its useCache rejects, without throwing', async () =>
+    {
+        const client = new FakeRedis(new FakeBus());
+        (getCache as unknown as Mock).mockReturnValue(client);
+
+        const ok = defineEvent('okEvt', Type.Object({}));
+        const bad = defineEvent('badEvt', Type.Object({}));
+        // Force this event's wiring to fail at subscribe time.
+        bad.useCache = vi.fn().mockRejectedValue(new Error('SUBSCRIBE failed')) as typeof bad.useCache;
+
+        const router = defineEventRouter({ ok, bad });
+
+        // Must not throw — startup survives a per-event SUBSCRIBE failure.
+        await expect(wireEventRouterCache(router)).resolves.toBe('redis');
+    });
+});
+
+describe('useCache failure recovery', () =>
+{
+    it('leaves the event in-process after a failed useCache and allows a later retry', async () =>
+    {
+        const event = defineEvent('retryEvt', Type.Object({ n: Type.Number() }));
+
+        const failingCache = {
+            publish: vi.fn(),
+            subscribe: vi.fn().mockRejectedValue(new Error('SUBSCRIBE failed')),
+        };
+
+        await expect(event.useCache(failingCache as any)).rejects.toThrow('SUBSCRIBE failed');
+
+        // Degraded to in-process: emit reaches local handlers directly, not the cache.
+        const received: { n: number }[] = [];
+        event.subscribe((payload) =>
+        {
+            received.push(payload);
+        });
+
+        await event.emit({ n: 1 });
+        await flush();
+
+        expect(received).toEqual([{ n: 1 }]);
+        expect(failingCache.publish).not.toHaveBeenCalled(); // never entered cache mode
+
+        // Retry with a working cache succeeds — cacheSubscribed was not latched.
+        const bus = new FakeBus();
+        await event.useCache(createRedisPubSubCache(new FakeRedis(bus), 'spfn:sse:'));
+
+        received.length = 0;
+        await event.emit({ n: 2 });
+        await flush();
+
+        expect(received).toEqual([{ n: 2 }]); // now delivered via the cache round-trip
+    });
+});
+
+describe('closeEventTransport', () =>
+{
+    it('quits the subscriber connection and is a no-op when none was opened', async () =>
+    {
+        const quit = vi.fn().mockResolvedValue('OK');
+        const subscriber = { subscribe: vi.fn(), on: vi.fn(), quit };
+        const client = {
+            publish: vi.fn().mockResolvedValue(1),
+            duplicate: vi.fn().mockReturnValue(subscriber),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const stored: any[] = [];
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:', (conn) =>
+        {
+            stored.push(conn);
+        });
+
+        // No subscriber until the first subscribe.
+        expect(stored).toHaveLength(0);
+        await cache.subscribe('chatChunk', () => undefined);
+        expect(stored[0]).toBe(subscriber);
+
+        // closeEventTransport only quits the singleton subscriber, not this local one,
+        // so a bare call with nothing wired must not throw.
+        await expect(closeEventTransport()).resolves.toBeUndefined();
+    });
+});

--- a/packages/core/src/event/__tests__/cache-transport.test.ts
+++ b/packages/core/src/event/__tests__/cache-transport.test.ts
@@ -291,7 +291,7 @@ describe('createRedisPubSubCache', () =>
 
         const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
 
-        const received: { n: number }[] = [];
+        const received: unknown[] = [];
         await cache.subscribe('x', (payload) =>
         {
             received.push(payload);
@@ -356,9 +356,44 @@ describe('createRedisPubSubCache', () =>
 
         await cache.publish('x', { n: 1 }); // attempt → fail → WARN #1 (also opens breaker for 10s)
         await vi.advanceTimersByTimeAsync(11000); // breaker expires; throttle window (30s) still open
-        await cache.publish('x', { n: 2 }); // attempt → fail → throttled (suppressed)
+        await cache.publish('x', { n: 2 }); // half-open probe → attempt → fail → throttled (suppressed)
 
+        // Pin the throttle path: publish #2 must have reached the wire (not skipped by an
+        // open breaker — otherwise a lengthened cooldown would silently pass this test).
+        expect(client.publish).toHaveBeenCalledTimes(2);
         expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('admits a single probe after cooldown — concurrent emits do not each re-probe', async () =>
+    {
+        vi.useFakeTimers();
+
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };
+        const client = {
+            status: 'ready',
+            publish: vi.fn(() => new Promise(() => undefined)), // hangs every time (sustained outage)
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+        await cache.subscribe('x', () => undefined);
+
+        const first = cache.publish('x', { n: 1 }); // probe #1
+        await vi.advanceTimersByTimeAsync(5000); // times out → breaker opens
+        await first;
+        expect(client.publish).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(10000); // cooldown elapses → half-open
+
+        // Fire many emits concurrently the instant the breaker reopens.
+        const burst = Promise.all([1, 2, 3, 4, 5].map((n) => cache.publish('x', { n })));
+        await vi.advanceTimersByTimeAsync(5000);
+        await burst;
+
+        // Exactly one of the burst probed; the rest fast-pathed to local.
+        expect(client.publish).toHaveBeenCalledTimes(2);
     });
 
     it('falls back to local delivery when publish hangs (timeout-bound)', async () =>

--- a/packages/core/src/event/__tests__/cache-transport.test.ts
+++ b/packages/core/src/event/__tests__/cache-transport.test.ts
@@ -21,6 +21,16 @@ import { createRedisPubSubCache, wireEventRouterCache, closeEventTransport } fro
 vi.mock('@spfn/core/cache', () => ({ getCache: vi.fn(() => undefined) }));
 import { getCache } from '@spfn/core/cache';
 
+// Mock the logger so the warn-throttle can be observed (single shared sink).
+vi.mock('@spfn/core/logger', () =>
+{
+    const sink: any = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
+    sink.child = () => sink;
+
+    return { logger: sink };
+});
+import { logger } from '@spfn/core/logger';
+
 // Reset the global transport singleton between tests (wired set, cached pubSubCache).
 afterEach(async () =>
 {
@@ -264,6 +274,91 @@ describe('createRedisPubSubCache', () =>
         await expect(cache.publish('fn', fn)).resolves.toBeUndefined();
         expect(client.publish).not.toHaveBeenCalled();
         expect(received[0]).toBe(fn); // delivered locally (live object)
+    });
+
+    it('trips a circuit breaker so a sustained outage costs one timeout, not one per emit', async () =>
+    {
+        vi.useFakeTimers();
+
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };
+        const client = {
+            status: 'ready',
+            publish: vi.fn(() => new Promise(() => undefined)), // hangs every time
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        const received: { n: number }[] = [];
+        await cache.subscribe('x', (payload) =>
+        {
+            received.push(payload);
+        });
+
+        const first = cache.publish('x', { n: 1 });
+        await vi.advanceTimersByTimeAsync(5000); // chunk1 trips the timeout, opens the breaker
+        await first;
+
+        // chunk2 & 3 within the cooldown → breaker open → skip publish → instant local.
+        await cache.publish('x', { n: 2 });
+        await cache.publish('x', { n: 3 });
+
+        expect(client.publish).toHaveBeenCalledTimes(1); // breaker prevented re-attempts
+        expect(received).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]); // all delivered locally
+    });
+
+    it('skips publish (no offline-queue duplicate) when the client is not connected', async () =>
+    {
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };
+        const client = {
+            status: 'connecting', // not ready
+            publish: vi.fn().mockResolvedValue(1),
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+
+        const received: unknown[] = [];
+        await cache.subscribe('x', (payload) =>
+        {
+            received.push(payload);
+        });
+
+        await cache.publish('x', { n: 1 });
+
+        expect(client.publish).not.toHaveBeenCalled(); // never queued → no late echo duplicate
+        expect(received).toEqual([{ n: 1 }]); // delivered locally
+    });
+
+    it('throttles repeated publish-failure warnings to one per window', async () =>
+    {
+        vi.useFakeTimers();
+
+        const subscriberStub = { subscribe: vi.fn().mockResolvedValue(undefined), on: vi.fn() };
+        const client = {
+            status: 'ready',
+            publish: vi.fn().mockRejectedValue(new Error('down')),
+            duplicate: vi.fn().mockReturnValue(subscriberStub),
+            subscribe: vi.fn(),
+            on: vi.fn(),
+        };
+
+        const cache = createRedisPubSubCache(client as any, 'spfn:sse:');
+        await cache.subscribe('x', () => undefined);
+
+        const warn = (logger as unknown as { warn: Mock }).warn;
+        vi.advanceTimersByTime(31000); // expire any throttle state from earlier tests
+        warn.mockClear();
+
+        await cache.publish('x', { n: 1 }); // attempt → fail → WARN #1 (also opens breaker for 10s)
+        await vi.advanceTimersByTimeAsync(11000); // breaker expires; throttle window (30s) still open
+        await cache.publish('x', { n: 2 }); // attempt → fail → throttled (suppressed)
+
+        expect(warn).toHaveBeenCalledTimes(1);
     });
 
     it('falls back to local delivery when publish hangs (timeout-bound)', async () =>
@@ -512,6 +607,20 @@ describe('wireEventRouterCache', () =>
 
         // Must not throw — startup survives a per-event SUBSCRIBE failure.
         await expect(wireEventRouterCache(router)).resolves.toBe('redis');
+    });
+
+    it('returns in-process (not a false redis) when every event degrades', async () =>
+    {
+        const client = new FakeRedis(new FakeBus());
+        (getCache as unknown as Mock).mockReturnValue(client);
+
+        const a = defineEvent('allBadA', Type.Object({}));
+        const b = defineEvent('allBadB', Type.Object({}));
+        a.useCache = vi.fn().mockRejectedValue(new Error('SUBSCRIBE failed')) as typeof a.useCache;
+        b.useCache = vi.fn().mockRejectedValue(new Error('SUBSCRIBE failed')) as typeof b.useCache;
+
+        // No event wired → honest 'in-process', not a misleading 'redis'.
+        await expect(wireEventRouterCache(defineEventRouter({ a, b }))).resolves.toBe('in-process');
     });
 });
 

--- a/packages/core/src/event/cache-transport.ts
+++ b/packages/core/src/event/cache-transport.ts
@@ -280,11 +280,22 @@ export function createRedisPubSubCache(
             // twice (local fallback now + echo later). Treat a status-less client (test
             // mocks) as ready so behavior is unchanged there.
             const ready = client.status === undefined || client.status === 'ready';
-            if (!ready || Date.now() < degradedUntil)
+            const now = Date.now();
+            if (!ready || (degradedUntil > 0 && now < degradedUntil))
             {
+                // Not connected, or breaker open → skip Redis, deliver locally.
                 deliverLocal(channel, JSON.parse(serialized));
 
                 return;
+            }
+
+            // Healthy (degradedUntil === 0) → publish directly; concurrent emits all
+            // fan out. Half-open (breaker tripped but cooldown elapsed) → this emit is
+            // the single probe: arm the breaker for the probe's duration so CONCURRENT
+            // emits fast-path to local instead of each launching their own 5s probe.
+            if (degradedUntil > 0)
+            {
+                degradedUntil = now + PUBLISH_TIMEOUT_MS;
             }
 
             try

--- a/packages/core/src/event/cache-transport.ts
+++ b/packages/core/src/event/cache-transport.ts
@@ -33,6 +33,13 @@ const SUBSCRIBE_TIMEOUT_MS = 5000;
 const WARN_THROTTLE_MS = 30000;
 
 /**
+ * After a publish failure, skip Redis entirely (deliver locally) for this long before
+ * probing again. Without it, a streaming `emit` loop pays the full PUBLISH_TIMEOUT_MS per
+ * chunk during a sustained outage (50 chunks × 5s = minutes of request hang).
+ */
+const PUBLISH_BREAKER_COOLDOWN_MS = 10000;
+
+/**
  * Reject if `promise` doesn't settle within `ms`. ioredis has no command timeout by
  * default, so a half-open socket leaves publish/subscribe pending indefinitely; this
  * bounds it so the caller can fall back instead of hanging.
@@ -98,6 +105,8 @@ type PubSubClient = {
     subscribe(...channels: string[]): Promise<unknown>;
     on(event: string, listener: (...args: any[]) => void): unknown;
     quit?(): Promise<unknown>;
+    /** ioredis connection status ('ready' | 'connecting' | 'close' | ...). */
+    status?: string;
 };
 
 type MessageHandler = (message: unknown) => void | Promise<void>;
@@ -155,6 +164,8 @@ export function createRedisPubSubCache(
 {
     let subscriber: PubSubClient | undefined;
     const handlers = new Map<string, MessageHandler>();
+    // Circuit breaker: epoch-ms until which Redis is treated as down (skip publish).
+    let degradedUntil = 0;
 
     const ensureSubscriber = (): PubSubClient =>
     {
@@ -262,19 +273,36 @@ export function createRedisPubSubCache(
                 return;
             }
 
+            // Skip Redis when the breaker is open (recent failure) or the client isn't
+            // connected. This (a) bounds a sustained outage to one timeout per cooldown
+            // instead of one per emit, and (b) avoids ioredis's offline queue buffering
+            // the publish and re-sending it on reconnect — which would deliver the event
+            // twice (local fallback now + echo later). Treat a status-less client (test
+            // mocks) as ready so behavior is unchanged there.
+            const ready = client.status === undefined || client.status === 'ready';
+            if (!ready || Date.now() < degradedUntil)
+            {
+                deliverLocal(channel, JSON.parse(serialized));
+
+                return;
+            }
+
             try
             {
                 // Timeout-bound: a wedged socket would otherwise leave this pending
                 // forever and hang `emit` (and the request that called it).
                 await withTimeout(client.publish(channel, serialized), PUBLISH_TIMEOUT_MS, 'pub/sub publish');
+                degradedUntil = 0; // success → close the breaker
             }
             catch (err)
             {
-                // Redis blip/timeout: the cross-pod echo won't arrive, so deliver to
-                // this pod's subscribers directly instead of dropping the event. Parse
-                // the serialized copy so handlers see the SAME shape as the echo path
-                // (a JSON round-trip), never the live mutable object. Throttled — a
-                // sustained outage emits one WARN per window, not one per chunk.
+                // Redis blip/timeout: open the breaker so subsequent emits fast-path to
+                // local delivery instead of each paying the timeout. The cross-pod echo
+                // won't arrive, so deliver to this pod's subscribers directly. Parse the
+                // serialized copy so handlers see the SAME shape as the echo path (a JSON
+                // round-trip), never the live mutable object. Throttled WARN — a sustained
+                // outage emits one line per window, not one per chunk.
+                degradedUntil = Date.now() + PUBLISH_BREAKER_COOLDOWN_MS;
                 throttledWarn('publish-failed', 'Pub/sub publish failed — local delivery only', {
                     channel,
                     error: err instanceof Error ? err.message : String(err),
@@ -349,7 +377,21 @@ export async function wireEventRouterCache(
     // whether cross-pod fan-out is actually live, and whether any event degraded.
     if (options.multiInstance === false)
     {
-        transportLogger.info('Event transport: in-process (multiInstance disabled)');
+        // A sibling router may have already wired shared events to Redis — this flag
+        // is process-global and can't un-wire them, so be honest about that.
+        const events = router.events as Record<string, WirableEvent>;
+        const stillRedis = Object.keys(events).filter(k => state.wired.has(events[k].name)).length;
+
+        if (stillRedis > 0)
+        {
+            transportLogger.warn('multiInstance:false has no effect on events already wired to redis by another router', {
+                redisWired: stillRedis,
+            });
+        }
+        else
+        {
+            transportLogger.info('Event transport: in-process (multiInstance disabled)');
+        }
 
         return 'in-process';
     }

--- a/packages/core/src/event/cache-transport.ts
+++ b/packages/core/src/event/cache-transport.ts
@@ -55,6 +55,7 @@ interface TransportState
 {
     pubSubCache: PubSubCache | undefined;
     subscriber: PubSubClient | undefined;
+    channelPrefix: string | undefined;
     wired: Map<string, WirableEvent>;
 }
 
@@ -63,6 +64,7 @@ const STATE_KEY = Symbol.for('@spfn/core:event-transport');
 const state: TransportState = ((globalThis as any)[STATE_KEY] ??= {
     pubSubCache: undefined,
     subscriber: undefined,
+    channelPrefix: undefined,
     wired: new Map<string, WirableEvent>(),
 });
 
@@ -158,7 +160,10 @@ export function createRedisPubSubCache(
         {
             const channel = channelPrefix + name;
 
-            let serialized: string;
+            // `string | undefined`: JSON.stringify returns undefined (no throw) for a
+            // top-level function/symbol, and throws for bigint/circular. Both mean
+            // "can't cross Redis" — handle each as a local-only delivery.
+            let serialized: string | undefined;
             try
             {
                 // `?? null` so void-payload events serialize to "null" rather than
@@ -173,6 +178,19 @@ export function createRedisPubSubCache(
                 transportLogger.warn('Pub/sub payload serialization failed — local delivery only', {
                     channel,
                     error: err instanceof Error ? err.message : String(err),
+                });
+                deliverLocal(channel, message ?? null);
+
+                return;
+            }
+
+            if (serialized === undefined)
+            {
+                // Top-level function/symbol payload — JSON.stringify yields undefined.
+                // Publishing that is meaningless and re-parsing it later would throw,
+                // so deliver locally and stop (guards the "publish never kills emit").
+                transportLogger.warn('Pub/sub payload not serializable (function/symbol) — local delivery only', {
+                    channel,
                 });
                 deliverLocal(channel, message ?? null);
 
@@ -324,8 +342,21 @@ export async function wireEventRouterCache(
  */
 async function resolvePubSubCache(channelPrefix?: string): Promise<PubSubCache | undefined>
 {
+    const resolvedPrefix = resolveChannelPrefix(channelPrefix);
+
     if (state.pubSubCache)
     {
+        // The transport (and its prefix) is process-global, resolved once on the
+        // first wiring. Warn if a later router (.websockets() after .events())
+        // asks for a different prefix — it's silently ignored, not applied.
+        if (state.channelPrefix !== resolvedPrefix)
+        {
+            transportLogger.warn('Conflicting channelPrefix ignored — the transport prefix is process-global (first wiring wins).', {
+                active: state.channelPrefix,
+                ignored: resolvedPrefix,
+            });
+        }
+
         return state.pubSubCache;
     }
 
@@ -357,9 +388,10 @@ async function resolvePubSubCache(channelPrefix?: string): Promise<PubSubCache |
         );
     }
 
+    state.channelPrefix = resolvedPrefix;
     state.pubSubCache = createRedisPubSubCache(
         client,
-        resolveChannelPrefix(channelPrefix),
+        resolvedPrefix,
         (connection) =>
         {
             state.subscriber = connection;
@@ -392,6 +424,7 @@ export async function closeEventTransport(): Promise<void>
 
     state.subscriber = undefined;
     state.pubSubCache = undefined;
+    state.channelPrefix = undefined;
     state.wired.clear();
 
     if (!subscriber?.quit)

--- a/packages/core/src/event/cache-transport.ts
+++ b/packages/core/src/event/cache-transport.ts
@@ -23,6 +23,70 @@ const DEFAULT_CHANNEL_PREFIX = 'spfn:sse:';
 /** Cap on the subscriber `quit()` during shutdown so a wedged socket can't stall it. */
 const SUBSCRIBER_QUIT_TIMEOUT_MS = 5000;
 
+/** Cap a Redis PUBLISH so a wedged socket (half-open, no FIN) can't hang `emit` forever. */
+const PUBLISH_TIMEOUT_MS = 5000;
+
+/** Cap a Redis SUBSCRIBE so a wedged socket can't hang server startup; degrades to in-process. */
+const SUBSCRIBE_TIMEOUT_MS = 5000;
+
+/** Fold repeated transport warnings during a sustained outage into one line per window. */
+const WARN_THROTTLE_MS = 30000;
+
+/**
+ * Reject if `promise` doesn't settle within `ms`. ioredis has no command timeout by
+ * default, so a half-open socket leaves publish/subscribe pending indefinitely; this
+ * bounds it so the caller can fall back instead of hanging.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T>
+{
+    return new Promise<T>((resolve, reject) =>
+    {
+        const timer = setTimeout(() =>
+        {
+            reject(new Error(`${label} timed out after ${ms}ms`));
+        }, ms);
+        timer.unref?.();
+
+        promise.then(
+            (value) =>
+            {
+                clearTimeout(timer);
+                resolve(value);
+            },
+            (err) =>
+            {
+                clearTimeout(timer);
+                reject(err);
+            },
+        );
+    });
+}
+
+const warnThrottle = new Map<string, { last: number; suppressed: number }>();
+
+/**
+ * Warn at most once per {@link WARN_THROTTLE_MS} per key, folding the suppressed count
+ * into the next line — a sustained Redis outage must not flood logs (one WARN per emit
+ * × a fast stream = thousands/sec).
+ */
+function throttledWarn(key: string, message: string, fields: Record<string, unknown>): void
+{
+    const now = Date.now();
+    const entry = warnThrottle.get(key);
+
+    if (entry && now - entry.last < WARN_THROTTLE_MS)
+    {
+        entry.suppressed++;
+
+        return;
+    }
+
+    transportLogger.warn(message, entry && entry.suppressed > 0
+        ? { ...fields, suppressedSinceLast: entry.suppressed }
+        : fields);
+    warnThrottle.set(key, { last: now, suppressed: 0 });
+}
+
 /**
  * Minimal pub/sub client interface (compatible with ioredis Redis | Cluster).
  * A duplicated connection is required for SUBSCRIBE — ioredis puts a connection
@@ -131,10 +195,11 @@ export function createRedisPubSubCache(
         });
 
         // ioredis auto-reconnects (and re-subscribes via autoResubscribe above);
-        // just surface the blip.
+        // surface the blip, throttled so a sustained outage's reconnect loop can't
+        // flood logs.
         subscriber.on('error', (err: Error) =>
         {
-            transportLogger.warn('Pub/sub subscriber error', { error: err.message });
+            throttledWarn('subscriber-error', 'Pub/sub subscriber error', { error: err.message });
         });
 
         return subscriber;
@@ -199,15 +264,18 @@ export function createRedisPubSubCache(
 
             try
             {
-                await client.publish(channel, serialized);
+                // Timeout-bound: a wedged socket would otherwise leave this pending
+                // forever and hang `emit` (and the request that called it).
+                await withTimeout(client.publish(channel, serialized), PUBLISH_TIMEOUT_MS, 'pub/sub publish');
             }
             catch (err)
             {
-                // Redis blip: the cross-pod echo won't arrive, so deliver to this
-                // pod's subscribers directly instead of dropping the event. Parse
-                // the serialized copy so handlers see the SAME shape as the echo
-                // path (a JSON round-trip), never the live mutable object.
-                transportLogger.warn('Pub/sub publish failed — local delivery only', {
+                // Redis blip/timeout: the cross-pod echo won't arrive, so deliver to
+                // this pod's subscribers directly instead of dropping the event. Parse
+                // the serialized copy so handlers see the SAME shape as the echo path
+                // (a JSON round-trip), never the live mutable object. Throttled — a
+                // sustained outage emits one WARN per window, not one per chunk.
+                throttledWarn('publish-failed', 'Pub/sub publish failed — local delivery only', {
                     channel,
                     error: err instanceof Error ? err.message : String(err),
                 });
@@ -222,7 +290,9 @@ export function createRedisPubSubCache(
 
             try
             {
-                await sub.subscribe(channel);
+                // Timeout-bound: at startup this is awaited before the HTTP listener,
+                // so a wedged subscriber would otherwise hang the entire boot.
+                await withTimeout(sub.subscribe(channel), SUBSCRIBE_TIMEOUT_MS, 'pub/sub subscribe');
             }
             catch (err)
             {
@@ -261,9 +331,6 @@ export interface WireEventCacheOptions
      * Use distinct prefixes to isolate apps/tenants sharing one Redis.
      */
     channelPrefix?: string;
-
-    /** Emit a debug log line describing the chosen transport. */
-    debug?: boolean;
 }
 
 /**
@@ -278,12 +345,11 @@ export async function wireEventRouterCache(
     options: WireEventCacheOptions = {},
 ): Promise<'in-process' | 'redis'>
 {
+    // Logged at INFO (not debug): operators must be able to confirm from prod logs
+    // whether cross-pod fan-out is actually live, and whether any event degraded.
     if (options.multiInstance === false)
     {
-        if (options.debug)
-        {
-            transportLogger.info('Event transport: in-process (multiInstance disabled)');
-        }
+        transportLogger.info('Event transport: in-process (multiInstance disabled)');
 
         return 'in-process';
     }
@@ -291,21 +357,22 @@ export async function wireEventRouterCache(
     const pubSubCache = await resolvePubSubCache(options.channelPrefix);
     if (!pubSubCache)
     {
-        if (options.debug)
-        {
-            transportLogger.info('Event transport: in-process (no cache configured)');
-        }
+        transportLogger.info('Event transport: in-process (no cache configured)');
 
         return 'in-process';
     }
 
     const events = router.events as Record<string, WirableEvent>;
+    let wired = 0;
+    let degraded = 0;
+    let alreadyWired = 0;
 
     for (const key of Object.keys(events))
     {
         const event = events[key];
         if (state.wired.has(event.name))
         {
+            alreadyWired++; // e.g. an event shared by the SSE and WS routers
             continue;
         }
 
@@ -313,12 +380,14 @@ export async function wireEventRouterCache(
         {
             await event.useCache(pubSubCache);
             state.wired.set(event.name, event);
+            wired++;
         }
         catch (err)
         {
             // Degrade this event to in-process rather than aborting startup — a
             // transient SUBSCRIBE failure must not crash the pod. Not marked
             // wired, so a later wiring pass can retry it.
+            degraded++;
             transportLogger.warn('Event cache wiring failed — staying in-process for this event', {
                 event: event.name,
                 error: err instanceof Error ? err.message : String(err),
@@ -326,12 +395,24 @@ export async function wireEventRouterCache(
         }
     }
 
-    if (options.debug)
+    // Every event degraded (and none were already wired) → fan-out is effectively
+    // dead for this router; report in-process honestly instead of a false 'redis'.
+    if (wired + alreadyWired === 0)
     {
-        transportLogger.info('Event transport: redis (cross-pod fan-out enabled)', {
-            events: Object.keys(events).length,
+        transportLogger.warn('Event transport: redis configured but no event wired — running in-process', {
+            total: Object.keys(events).length,
+            degraded,
         });
+
+        return 'in-process';
     }
+
+    transportLogger.info('Event transport: redis (cross-pod fan-out)', {
+        total: Object.keys(events).length,
+        wired,
+        degraded,
+        alreadyWired,
+    });
 
     return 'redis';
 }

--- a/packages/core/src/event/cache-transport.ts
+++ b/packages/core/src/event/cache-transport.ts
@@ -222,6 +222,13 @@ export function createRedisPubSubCache(
     // race — Redis broadcast, then the publisher's reply dropped — can deliver
     // both here and via the echo. We accept that rare duplicate over dropping,
     // since SSE is lossy and a frozen stream is worse than a repeated chunk.
+    // Same-pod subscribers are fed ONLY by the echo on the subscriber connection
+    // (a separate socket from the write client). If it isn't connected, a successful
+    // publish still won't reach this pod's own streams — so they need the local
+    // fallback. A status-less subscriber (test mocks) is treated as healthy.
+    const subscriberHealthy = (): boolean =>
+        !!subscriber && (subscriber.status === undefined || subscriber.status === 'ready');
+
     const deliverLocal = (channel: string, message: unknown): void =>
     {
         const handler = handlers.get(channel);
@@ -304,6 +311,18 @@ export function createRedisPubSubCache(
                 // forever and hang `emit` (and the request that called it).
                 await withTimeout(client.publish(channel, serialized), PUBLISH_TIMEOUT_MS, 'pub/sub publish');
                 degradedUntil = 0; // success → close the breaker
+
+                // Publish reached Redis (remote pods get it via their echo), but if THIS
+                // pod's subscriber socket is down its echo won't arrive — cover same-pod
+                // subscribers locally. No double-delivery: Redis doesn't buffer for a
+                // disconnected subscriber, so the missed echo never arrives later.
+                if (!subscriberHealthy())
+                {
+                    throttledWarn('subscriber-down', 'Subscriber connection down — same-pod local fallback', {
+                        channel,
+                    });
+                    deliverLocal(channel, JSON.parse(serialized));
+                }
             }
             catch (err)
             {

--- a/packages/core/src/event/cache-transport.ts
+++ b/packages/core/src/event/cache-transport.ts
@@ -1,0 +1,412 @@
+/**
+ * Event cache transport (Redis/Valkey pub/sub)
+ *
+ * Wires each event in a router to a shared {@link PubSubCache} so that an
+ * `emit` on one pod fans out to subscribers on every pod. This is the runtime
+ * glue behind `EventDef.useCache` — applications don't call it directly; the
+ * server's `.events()` / `.websockets()` registration calls it at startup when
+ * a cache (`CACHE_URL`) is configured. Without a cache, events stay in-process
+ * and this is a no-op.
+ *
+ * Mirrors the auto-detection pattern used by `CacheTokenStore` for SSE tokens.
+ */
+
+import { logger } from '@spfn/core/logger';
+import type { EventRouterDef } from './router';
+import type { PubSubCache } from './types';
+
+const transportLogger = logger.child('@spfn/core:event-transport');
+
+/** Default channel prefix; isolates SPFN event channels from other Redis keys. */
+const DEFAULT_CHANNEL_PREFIX = 'spfn:sse:';
+
+/** Cap on the subscriber `quit()` during shutdown so a wedged socket can't stall it. */
+const SUBSCRIBER_QUIT_TIMEOUT_MS = 5000;
+
+/**
+ * Minimal pub/sub client interface (compatible with ioredis Redis | Cluster).
+ * A duplicated connection is required for SUBSCRIBE — ioredis puts a connection
+ * into subscriber mode, where regular commands are rejected.
+ */
+type PubSubClient = {
+    publish(channel: string, message: string): Promise<unknown>;
+    duplicate(): PubSubClient;
+    subscribe(...channels: string[]): Promise<unknown>;
+    on(event: string, listener: (...args: any[]) => void): unknown;
+    quit?(): Promise<unknown>;
+};
+
+type MessageHandler = (message: unknown) => void | Promise<void>;
+
+/** The slice of EventDef this module wires (kept minimal + duck-typed). */
+type WirableEvent = {
+    name: string;
+    useCache: (cache: PubSubCache) => Promise<unknown>;
+    _resetCache?: () => void;
+};
+
+// ── globalThis singleton ──────────────────────────────────────────
+// Survives the CJS/ESM dual-package hazard (same pattern as cache-manager):
+// one subscriber connection and one wired-event registry per process. The
+// registry holds the EventDefs (not just names) so closeEventTransport can
+// reset their cache binding — otherwise the per-event cacheSubscribed latch
+// and this state would diverge across a restart in the same process.
+interface TransportState
+{
+    pubSubCache: PubSubCache | undefined;
+    subscriber: PubSubClient | undefined;
+    wired: Map<string, WirableEvent>;
+}
+
+const STATE_KEY = Symbol.for('@spfn/core:event-transport');
+
+const state: TransportState = ((globalThis as any)[STATE_KEY] ??= {
+    pubSubCache: undefined,
+    subscriber: undefined,
+    wired: new Map<string, WirableEvent>(),
+});
+
+/**
+ * Resolve the channel prefix: explicit option → env override → default.
+ */
+function resolveChannelPrefix(override?: string): string
+{
+    return override ?? process.env.SPFN_SSE_CHANNEL_PREFIX ?? DEFAULT_CHANNEL_PREFIX;
+}
+
+/**
+ * Build a {@link PubSubCache} backed by a Redis/Valkey client.
+ *
+ * One duplicated connection is created lazily and shared across every channel.
+ * Publish failures are logged and swallowed — SSE is lossy (at-most-once), so a
+ * dropped event during a Redis blip must never crash `emit` or kill a stream.
+ */
+export function createRedisPubSubCache(
+    client: PubSubClient,
+    channelPrefix: string,
+    onSubscriber?: (connection: PubSubClient) => void,
+): PubSubCache
+{
+    let subscriber: PubSubClient | undefined;
+    const handlers = new Map<string, MessageHandler>();
+
+    const ensureSubscriber = (): PubSubClient =>
+    {
+        if (subscriber)
+        {
+            return subscriber;
+        }
+
+        // ioredis re-issues SUBSCRIBE after a reconnect (autoResubscribe, default
+        // true). Don't pass it as a duplicate() option — Cluster.duplicate()'s
+        // first positional arg is the startup-nodes array, so an options object
+        // lands in the wrong slot and is silently dropped. The 'message' listener
+        // is attached once and survives reconnects.
+        subscriber = client.duplicate();
+        onSubscriber?.(subscriber);
+
+        subscriber.on('message', (channel: string, raw: string) =>
+        {
+            const handler = handlers.get(channel);
+            if (!handler)
+            {
+                return;
+            }
+
+            let payload: unknown;
+            try
+            {
+                payload = JSON.parse(raw);
+            }
+            catch
+            {
+                transportLogger.warn('Pub/sub message parse failed — dropped', { channel });
+
+                return;
+            }
+
+            void handler(payload);
+        });
+
+        // ioredis auto-reconnects (and re-subscribes via autoResubscribe above);
+        // just surface the blip.
+        subscriber.on('error', (err: Error) =>
+        {
+            transportLogger.warn('Pub/sub subscriber error', { error: err.message });
+        });
+
+        return subscriber;
+    };
+
+    // Deliver to this pod's own subscribers without the Redis round-trip — the
+    // fallback when publish can't reach Redis. Mostly avoids double-delivery (a
+    // failed publish usually means Redis never echoed back), but a reply-lost
+    // race — Redis broadcast, then the publisher's reply dropped — can deliver
+    // both here and via the echo. We accept that rare duplicate over dropping,
+    // since SSE is lossy and a frozen stream is worse than a repeated chunk.
+    const deliverLocal = (channel: string, message: unknown): void =>
+    {
+        const handler = handlers.get(channel);
+        if (handler)
+        {
+            void handler(message);
+        }
+    };
+
+    return {
+        publish: async (name: string, message: unknown): Promise<void> =>
+        {
+            const channel = channelPrefix + name;
+
+            let serialized: string;
+            try
+            {
+                // `?? null` so void-payload events serialize to "null" rather than
+                // `undefined` (JSON.stringify(undefined) → undefined → publish breaks).
+                serialized = JSON.stringify(message ?? null);
+            }
+            catch (err)
+            {
+                // Non-serializable payload (bigint, circular ref). Cross-pod is
+                // impossible; deliver the live object locally (best effort — a
+                // downstream JSON.stringify may re-throw, but better than dropping).
+                transportLogger.warn('Pub/sub payload serialization failed — local delivery only', {
+                    channel,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+                deliverLocal(channel, message ?? null);
+
+                return;
+            }
+
+            try
+            {
+                await client.publish(channel, serialized);
+            }
+            catch (err)
+            {
+                // Redis blip: the cross-pod echo won't arrive, so deliver to this
+                // pod's subscribers directly instead of dropping the event. Parse
+                // the serialized copy so handlers see the SAME shape as the echo
+                // path (a JSON round-trip), never the live mutable object.
+                transportLogger.warn('Pub/sub publish failed — local delivery only', {
+                    channel,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+                deliverLocal(channel, JSON.parse(serialized));
+            }
+        },
+
+        subscribe: async (name: string, handler: MessageHandler): Promise<void> =>
+        {
+            const channel = channelPrefix + name;
+            const sub = ensureSubscriber();
+
+            try
+            {
+                await sub.subscribe(channel);
+            }
+            catch (err)
+            {
+                // SUBSCRIBE failed. If nothing else is live on this connection it
+                // may be half-open — drop the memo (and quit it) so a later retry
+                // rebuilds a fresh subscriber instead of reusing a dead one.
+                if (handlers.size === 0 && subscriber === sub)
+                {
+                    subscriber = undefined;
+                    void sub.quit?.().catch(() => undefined);
+                }
+
+                throw err;
+            }
+
+            // Register only after a confirmed subscribe — never leave a handler
+            // bound to a channel the broker hasn't acknowledged.
+            handlers.set(channel, handler);
+        },
+    };
+}
+
+/**
+ * Options controlling event cache transport wiring.
+ */
+export interface WireEventCacheOptions
+{
+    /**
+     * Force in-process mode even when a cache is configured.
+     * @default true (auto: Redis when CACHE_URL is set, else in-process)
+     */
+    multiInstance?: boolean;
+
+    /**
+     * Channel prefix override (env `SPFN_SSE_CHANNEL_PREFIX`, else `spfn:sse:`).
+     * Use distinct prefixes to isolate apps/tenants sharing one Redis.
+     */
+    channelPrefix?: string;
+
+    /** Emit a debug log line describing the chosen transport. */
+    debug?: boolean;
+}
+
+/**
+ * Wire every event in a router to the shared Redis pub/sub cache.
+ *
+ * Returns the transport that ended up active. Idempotent per event name across
+ * routers (an event shared by the SSE and WS routers is wired once), so it is
+ * safe to call for both `.events()` and `.websockets()`.
+ */
+export async function wireEventRouterCache(
+    router: EventRouterDef<any>,
+    options: WireEventCacheOptions = {},
+): Promise<'in-process' | 'redis'>
+{
+    if (options.multiInstance === false)
+    {
+        if (options.debug)
+        {
+            transportLogger.info('Event transport: in-process (multiInstance disabled)');
+        }
+
+        return 'in-process';
+    }
+
+    const pubSubCache = await resolvePubSubCache(options.channelPrefix);
+    if (!pubSubCache)
+    {
+        if (options.debug)
+        {
+            transportLogger.info('Event transport: in-process (no cache configured)');
+        }
+
+        return 'in-process';
+    }
+
+    const events = router.events as Record<string, WirableEvent>;
+
+    for (const key of Object.keys(events))
+    {
+        const event = events[key];
+        if (state.wired.has(event.name))
+        {
+            continue;
+        }
+
+        try
+        {
+            await event.useCache(pubSubCache);
+            state.wired.set(event.name, event);
+        }
+        catch (err)
+        {
+            // Degrade this event to in-process rather than aborting startup — a
+            // transient SUBSCRIBE failure must not crash the pod. Not marked
+            // wired, so a later wiring pass can retry it.
+            transportLogger.warn('Event cache wiring failed — staying in-process for this event', {
+                event: event.name,
+                error: err instanceof Error ? err.message : String(err),
+            });
+        }
+    }
+
+    if (options.debug)
+    {
+        transportLogger.info('Event transport: redis (cross-pod fan-out enabled)', {
+            events: Object.keys(events).length,
+        });
+    }
+
+    return 'redis';
+}
+
+/**
+ * Resolve (and cache) the shared pub/sub cache from the global cache instance.
+ * Returns undefined when no cache is available.
+ */
+async function resolvePubSubCache(channelPrefix?: string): Promise<PubSubCache | undefined>
+{
+    if (state.pubSubCache)
+    {
+        return state.pubSubCache;
+    }
+
+    let client: PubSubClient | undefined;
+    try
+    {
+        const { getCache } = await import('@spfn/core/cache');
+        client = getCache() as PubSubClient | undefined;
+    }
+    catch
+    {
+        // Cache module unavailable — fall back to in-process.
+        return undefined;
+    }
+
+    if (!client)
+    {
+        return undefined;
+    }
+
+    // Cross-app isolation depends on the channel prefix. The default is shared by
+    // every SPFN app, so warn (once, on first resolve) when running on it — apps
+    // sharing one Redis with colliding event names would otherwise leak payloads.
+    if (!channelPrefix && !process.env.SPFN_SSE_CHANNEL_PREFIX)
+    {
+        transportLogger.warn(
+            'Event fan-out is on the default channel prefix (spfn:sse:). Apps sharing one '
+            + 'Redis must set channelPrefix or SPFN_SSE_CHANNEL_PREFIX to avoid cross-app leakage.',
+        );
+    }
+
+    state.pubSubCache = createRedisPubSubCache(
+        client,
+        resolveChannelPrefix(channelPrefix),
+        (connection) =>
+        {
+            state.subscriber = connection;
+        },
+    );
+
+    return state.pubSubCache;
+}
+
+/**
+ * Close the shared pub/sub subscriber connection and reset transport state.
+ *
+ * Called during graceful shutdown — the subscriber is a `duplicate()` of the
+ * cache write connection and is not tracked by the cache manager, so it must be
+ * quit explicitly (before `closeCache`). No-op when no subscriber was opened.
+ *
+ * Also resets each wired EventDef's cache binding. EventDefs are module
+ * singletons that outlive a server instance; without this, a second server start
+ * in the same process (tests, hot-reload) hits the `cacheSubscribed` latch, never
+ * rebinds, and silently runs with cross-pod fan-out dead.
+ */
+export async function closeEventTransport(): Promise<void>
+{
+    const subscriber = state.subscriber;
+
+    for (const event of state.wired.values())
+    {
+        event._resetCache?.();
+    }
+
+    state.subscriber = undefined;
+    state.pubSubCache = undefined;
+    state.wired.clear();
+
+    if (!subscriber?.quit)
+    {
+        return;
+    }
+
+    // Bound the quit: a wedged connection (broken socket, no FIN) must not stall
+    // shutdown past this timeout — the process exits and the OS reclaims the socket.
+    await Promise.race([
+        subscriber.quit().catch(() => undefined),
+        new Promise<void>((resolve) =>
+        {
+            const timer = setTimeout(resolve, SUBSCRIBER_QUIT_TIMEOUT_MS);
+            timer.unref?.();
+        }),
+    ]);
+}

--- a/packages/core/src/event/event.ts
+++ b/packages/core/src/event/event.ts
@@ -179,18 +179,33 @@ function createEventImpl<TPayload>(
             return self;
         }
 
-        cache = newCache;
-        cacheSubscribed = true;
-
+        // Subscribe FIRST, then flip to cache mode. If subscribe rejects, the
+        // event stays in-process (cache undefined) and cacheSubscribed stays
+        // false — so emit keeps delivering locally and a later useCache can retry.
+        // Setting these before the await would latch a half-broken state: emit
+        // would publish to a channel this instance never subscribed to.
         await newCache.subscribe(name, async (message: unknown) =>
         {
             eventLogger.debug(`Received event from cache: ${name}`);
             await handlerManager.trigger(message as TPayload);
         });
 
+        cache = newCache;
+        cacheSubscribed = true;
+
         eventLogger.debug(`Cache subscription ready for event: ${name}`);
 
         return self;
+    };
+
+    // Drop the cache binding so a later useCache can rebind a fresh transport.
+    // Without this, the cacheSubscribed latch would make a second server start in
+    // the same process (tests, hot-reload) a no-op while the event still points at
+    // a torn-down cache — cross-pod fan-out would silently stay dead.
+    const resetCache = (): void =>
+    {
+        cache = undefined;
+        cacheSubscribed = false;
     };
 
     const self: EventDef<TPayload> = {
@@ -201,6 +216,7 @@ function createEventImpl<TPayload>(
         emit: emit as EventDef<TPayload>['emit'],
         useCache,
         _registerJobQueue: jobQueueManager.register,
+        _resetCache: resetCache,
         _payload: undefined as unknown as TPayload,
     };
 

--- a/packages/core/src/event/sse/handler.ts
+++ b/packages/core/src/event/sse/handler.ts
@@ -55,7 +55,10 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
 )
 {
     const {
-        pingInterval = 30000,
+        // 10s — keep-alive가 중간 프록시(GCP LB/nginx)의 idle 타임아웃(흔히 ~15-30s)보다 자주 와야
+        // 첫 ping 전 침묵 구간에 연결이 끊기지 않는다. 30s 기본은 idle 타임아웃보다 길어 SSE가
+        // 데이터 없는 동안 끊기던 문제가 있었다.
+        pingInterval = 10000,
         auth: authConfig,
     } = config;
 

--- a/packages/core/src/event/sse/types.ts
+++ b/packages/core/src/event/sse/types.ts
@@ -150,7 +150,7 @@ export interface SSEHandlerConfig
 {
     /**
      * Keep-alive ping interval in milliseconds
-     * @default 30000
+     * @default 10000
      */
     pingInterval?: number;
 
@@ -158,6 +158,26 @@ export interface SSEHandlerConfig
      * Custom headers for SSE response
      */
     headers?: Record<string, string>;
+
+    /**
+     * Cross-pod event broadcast via the cache (Redis/Valkey) pub/sub.
+     *
+     * When `true` (default) and a cache is configured (`CACHE_URL`), each event
+     * is auto-wired so an `emit` on one pod reaches subscribers on every pod.
+     * Without a cache this is a no-op (events stay in-process). Set `false` to
+     * force in-process even when a cache is present.
+     *
+     * @default true
+     */
+    multiInstance?: boolean;
+
+    /**
+     * Pub/sub channel prefix for cross-pod broadcast.
+     *
+     * Defaults to env `SPFN_SSE_CHANNEL_PREFIX`, else `spfn:sse:`. Use distinct
+     * prefixes to isolate apps/tenants that share one Redis instance.
+     */
+    channelPrefix?: string;
 
     /**
      * Authentication and authorization configuration

--- a/packages/core/src/event/types.ts
+++ b/packages/core/src/event/types.ts
@@ -75,6 +75,13 @@ export interface EventDef<TPayload = void>
     _registerJobQueue: (queueName: string, sender: JobQueueSender) => void;
 
     /**
+     * Internal: Drop the cache binding (cache + subscribed flag).
+     * Called by the event cache transport on shutdown so a later useCache can
+     * rebind a fresh cache in the same process.
+     */
+    _resetCache: () => void;
+
+    /**
      * Type inference helper
      */
     _payload: TPayload;

--- a/packages/core/src/event/ws/types.ts
+++ b/packages/core/src/event/ws/types.ts
@@ -129,6 +129,26 @@ export interface WSHandlerConfig
     pingInterval?: number;
 
     /**
+     * Cross-pod event broadcast via the cache (Redis/Valkey) pub/sub.
+     *
+     * When `true` (default) and a cache is configured (`CACHE_URL`), each event
+     * is auto-wired so an `emit` on one pod reaches subscribers on every pod.
+     * Without a cache this is a no-op (events stay in-process). Set `false` to
+     * force in-process even when a cache is present.
+     *
+     * @default true
+     */
+    multiInstance?: boolean;
+
+    /**
+     * Pub/sub channel prefix for cross-pod broadcast.
+     *
+     * Defaults to env `SPFN_SSE_CHANNEL_PREFIX`, else `spfn:sse:`. Use distinct
+     * prefixes to isolate apps/tenants that share one Redis instance.
+     */
+    channelPrefix?: string;
+
+    /**
      * Authentication and authorization configuration
      */
     auth?: WSHandlerAuthConfig;

--- a/packages/core/src/server/README.md
+++ b/packages/core/src/server/README.md
@@ -116,8 +116,8 @@ There is **no validation in the builder** — validation runs inside `startServe
 | `.middleware({...})` | `middleware` | Toggle built-ins: `{ logger?, cors?, errorHandler?, onError? }` |
 | `.cors(opts \| false)` | `cors` | hono/cors options, or `false` to disable |
 | `.jobs(router, cfg?)` | `jobs` / `jobsConfig` | pg-boss job router (`@spfn/core/job`); `cfg` is `Omit<BossOptions, 'connectionString'>` |
-| `.events(router, cfg?)` | `events` / `eventsConfig` | SSE router (`@spfn/core/event`); `cfg.path` default `/events/stream`, `cfg.auth` for token-gated streams |
-| `.websockets(router, cfg?)` | `websockets` / `websocketsConfig` | WS router; `cfg.path` default `/ws`, `cfg.auth` for token auth |
+| `.events(router, cfg?)` | `events` / `eventsConfig` | SSE router (`@spfn/core/event`); `cfg.path` default `/events/stream`, `cfg.auth` for token-gated streams; cross-pod fan-out auto-wires when a cache is set (`cfg.multiInstance`/`cfg.channelPrefix`) |
+| `.websockets(router, cfg?)` | `websockets` / `websocketsConfig` | WS router; `cfg.path` default `/ws`, `cfg.auth` for token auth; same `multiInstance`/`channelPrefix` cross-pod knobs as `.events()` |
 | `.workflows(router, cfg?)` | `workflows` / `workflowsConfig` | `@spfn/workflow` router; inits engine after DB |
 | `.database({...})` | `database` | Pool / healthCheck / monitoring overrides |
 | `.timeout({...})` | `timeout` | `{ request?, keepAlive?, headers? }` (ms) |

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -13,6 +13,7 @@ import { registerRoutes, type RegisteredRoute } from '@spfn/core/route';
 import { ErrorHandler, RequestLogger } from '@spfn/core/middleware';
 import { createSSEHandler } from '../event/sse/handler';
 import { SSETokenManager, CacheTokenStore } from '../event/sse/token-manager';
+import { wireEventRouterCache } from '../event/cache-transport';
 import { createHealthCheckHandler } from './helpers';
 import { serverLogger } from './logger';
 
@@ -310,6 +311,14 @@ async function registerSSEEndpoint(app: Hono, config?: ServerConfig): Promise<vo
         }
     }
 
+    // Auto-wire cross-pod event broadcast (Redis pub/sub) when a cache is present.
+    // Without a cache this is a no-op and events stay in-process.
+    const transport = await wireEventRouterCache(config.events, {
+        multiInstance: eventsConfig.multiInstance,
+        channelPrefix: eventsConfig.channelPrefix,
+        debug,
+    });
+
     // Register SSE stream handler
     app.get(streamPath, createSSEHandler(config.events, eventsConfig, tokenManager));
 
@@ -319,6 +328,7 @@ async function registerSSEEndpoint(app: Hono, config?: ServerConfig): Promise<vo
         serverLogger.info(`✓ SSE endpoint registered at ${streamPath}`, {
             events: eventNames,
             auth: !!authConfig?.enabled,
+            transport,
         });
     }
 }

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -316,7 +316,6 @@ async function registerSSEEndpoint(app: Hono, config?: ServerConfig): Promise<vo
     const transport = await wireEventRouterCache(config.events, {
         multiInstance: eventsConfig.multiInstance,
         channelPrefix: eventsConfig.channelPrefix,
-        debug,
     });
 
     // Register SSE stream handler

--- a/packages/core/src/server/start-server.ts
+++ b/packages/core/src/server/start-server.ts
@@ -15,6 +15,7 @@ import { closeDatabase, initDatabase, getDatabase } from '@spfn/core/db';
 import { initBoss, stopBoss, registerJobs } from '../job';
 import { attachWSHandler } from '../event/ws/handler';
 import { SSETokenManager, CacheTokenStore } from '../event/sse/token-manager';
+import { wireEventRouterCache, closeEventTransport } from '../event/cache-transport';
 import { serverLogger } from './logger';
 import { printBanner } from './banner';
 import { createServer } from './create-server';
@@ -419,6 +420,14 @@ async function initializeWebSocket(
         if (debug) serverLogger.info(`✓ WS token endpoint registered at POST ${tokenPath}`);
     }
 
+    // Auto-wire cross-pod event broadcast (Redis pub/sub) for WS events.
+    // Events shared with the SSE router are wired once; no-op without a cache.
+    await wireEventRouterCache(wsRouter, {
+        multiInstance: wsConfig.multiInstance,
+        channelPrefix: wsConfig.channelPrefix,
+        debug,
+    });
+
     return await attachWSHandler(server, wsRouter, wsConfig, tokenManager);
 }
 
@@ -556,6 +565,9 @@ function createShutdownHandler(
 
         if (infraConfig.redis)
         {
+            // Quit the event pub/sub subscriber (a duplicate connection) before
+            // the cache write/read connections it was duplicated from.
+            await closeEventTransport();
             await closeInfrastructure(closeCache, 'Redis', TIMEOUTS.REDIS_CLOSE);
         }
 
@@ -823,6 +835,7 @@ async function cleanupOnFailure(config: ServerConfig): Promise<void>
 
         if (infraConfig.redis)
         {
+            await closeEventTransport();
             await closeInfrastructure(closeCache, 'Redis', TIMEOUTS.REDIS_CLOSE);
         }
 

--- a/packages/core/src/server/start-server.ts
+++ b/packages/core/src/server/start-server.ts
@@ -425,7 +425,6 @@ async function initializeWebSocket(
     await wireEventRouterCache(wsRouter, {
         multiInstance: wsConfig.multiInstance,
         channelPrefix: wsConfig.channelPrefix,
-        debug,
     });
 
     return await attachWSHandler(server, wsRouter, wsConfig, tokenManager);


### PR DESCRIPTION
## 배경

멀티파드(HPA)에서 챗 `emit`이 일어난 파드와 SSE 스트림이 붙은 파드가 달라, 이벤트가 미전달되어 챗이 "생각중"에서 멈추던 문제를 해결한다. monospace는 1파드 고정으로 우회 중이었고, 이 변경으로 그 제약을 풀 수 있다.

## 변경 요지

이미 존재하던 `EventDef.useCache(PubSubCache)` 프리미티브를 **서버 시작 시 자동 연결**한다(토큰 store가 cache를 자동 감지하던 패턴과 동일). 핵심은 새 transport를 만든 게 아니라 죽어있던 fan-out을 라이프사이클에 wiring한 것.

- `.events()` / `.websockets()` 시작 시 cache(`CACHE_URL`) 감지 → 라우터의 각 이벤트에 `useCache` 자동 연결. cache 없으면 in-process no-op(기존 동작 유지).
- `multiInstance` / `channelPrefix` 옵션, SSE `pingInterval` 기본 30s→10s(프록시 idle 타임아웃 대응).
- auth `filter`는 수신 파드에서 구독자별로 그대로 실행 — transport는 이벤트명 fan-out만.

## 견고성 (멀티에이전트 적대 감사로 하드닝)

설계→리뷰 후 다단계 적대 감사(finder + refute-by-majority 검증)를 반복해 확정 결함이 0이 될 때까지 수정했다(13→6→2→1→0).

- **무한 hang 방지**: publish/subscribe에 5s 타임아웃(ioredis 기본 command timeout 없음 → half-open 소켓에서 emit·부팅 hang).
- **circuit-breaker**: 지속 장애 시 청크당 타임아웃 누적(50청크=~250s) 제거. healthy/open/half-open 게이트로 동시성에서도 "장애 비용=cooldown당 1회".
- **결정론적 중복배달 차단**: `client.status!=='ready'`면 publish skip(ioredis offline-queue가 재연결 시 발송 → echo 중복).
- **subscriber 비대칭 장애**: write는 살아있고 subscriber 소켓만 죽으면 같은 파드가 echo를 못 받던 무음을, publish 성공+subscriber 미연결 시 로컬 폴백으로 커버.
- **degrade**: publish/직렬화 실패·부분 wiring 실패 시 in-process 폴백(emit·스트림 안 죽음), 경고 throttle, transport 결정 항상 INFO 로깅.
- **복구**: subscribe-first + `_resetCache`로 같은 프로세스 재기동 시 재바인딩, 시작 SUBSCRIBE 실패는 per-event degrade.

## 문서화된 한계
mid-stream publish 실패 시 순서 역전 가능(시퀀스 번호 없음), 수신측 payload 스키마 미검증(redis=신뢰 경계), SSE slow-client writeSSE 버퍼링은 **별도 후속 PR**.

## 테스트
`packages/core/src/event/__tests__/cache-transport.test.ts` 27개(이벤트 영역 총 46개) — cross-pod fan-out, void 이벤트, prefix 격리, 로컬 폴백, breaker(동시 프로브 포함), 타임아웃, subscriber-down, 재시작 복구, honesty-branch 등. type-check·build·lint 클린.

> 참고: `apps/`·스크래치 파일은 제외했고, `packages/cli` build.ts 변경은 무관 건이라 별도 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)