### PR TITLE
fix(core/event): SSE writeSSE backpressure (bounded outbound queue)

### DIFF
--- a/packages/core/src/event/README.md
+++ b/packages/core/src/event/README.md
@@ -182,9 +182,16 @@ export default defineServerConfig()
 SSEAuthConfig<TRouter> }`. The `auth` field is the **generic** `SSEAuthConfig<TRouter>` so
 `authorize`/`filter` get full event-name and payload inference from your router.
 
+> **Backpressure (`maxQueue`, default 1000).** Each connection's outbound frames go through a
+> single drain loop that `await`s every write, so a slow client applies real backpressure
+> instead of letting frames buffer unboundedly in memory. If the per-connection queue exceeds
+> `maxQueue`, the connection is **closed** (the client reconnects) rather than dropping frames —
+> dropping a chunk would corrupt an ordered token stream. Raise `maxQueue` for very bursty
+> producers; lower it to cap memory more aggressively.
+
 > `SSEHandlerConfig` also declares a `headers` field, but the current handler only reads
-> `pingInterval` and `auth`. Setting custom `headers` here is a no-op — set response headers
-> in middleware instead.
+> `pingInterval`, `auth`, and `maxQueue`. Setting custom `headers` here is a no-op — set
+> response headers in middleware instead.
 
 ---
 
@@ -514,7 +521,11 @@ fully decoupled.
   `emit` that runs before any `subscribe` simply has no handlers. Register handlers / jobs at
   startup, not lazily after the first emit.
 - **`auth.headers`/`SSEHandlerConfig.headers` does nothing.** The handler reads only
-  `pingInterval` and `auth`. Don't expect custom response headers from config.
+  `pingInterval`, `auth`, and `maxQueue`. Don't expect custom response headers from config.
+- **A slow client is dropped, not buffered forever.** Writes are bounded (`maxQueue`, default
+  1000): if a client can't keep up with a fast producer, its connection is closed instead of
+  growing memory without limit. Expect occasional reconnects under heavy streaming to slow
+  clients; that's the backpressure working, not a bug.
 - **Don't `new EventSource(...)` by hand.** You lose type inference, the `connected`/`ping`
   control-event handling, one-time-token reconnect, and StrictMode-safe teardown that the
   client implements. Use `createSSEClient` / `createAuthSSEClient`.

--- a/packages/core/src/event/sse/__tests__/bounded-writer.test.ts
+++ b/packages/core/src/event/sse/__tests__/bounded-writer.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Bounded SSE writer tests
+ *
+ * Asserts serialized (one-at-a-time) delivery with backpressure, and that a slow
+ * consumer is closed on queue overflow rather than buffering unboundedly.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createBoundedWriter, type SSEFrame } from '../bounded-writer';
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+/** A stream whose writeSSE hangs until manually resolved/rejected — models a slow socket. */
+class FakeStream
+{
+    writes: SSEFrame[] = [];
+    inFlight = 0;
+    maxInFlight = 0;
+    private settlers: Array<{ resolve: () => void; reject: (e: Error) => void }> = [];
+
+    async writeSSE(frame: SSEFrame): Promise<void>
+    {
+        this.writes.push(frame);
+        this.inFlight++;
+        this.maxInFlight = Math.max(this.maxInFlight, this.inFlight);
+
+        try
+        {
+            await new Promise<void>((resolve, reject) =>
+            {
+                this.settlers.push({ resolve, reject });
+            });
+        }
+        finally
+        {
+            this.inFlight--;
+        }
+    }
+
+    resolveNext(): void
+    {
+        this.settlers.shift()?.resolve();
+    }
+
+    rejectNext(err: Error): void
+    {
+        this.settlers.shift()?.reject(err);
+    }
+}
+
+describe('createBoundedWriter', () =>
+{
+    it('writes frames one at a time, in order (no concurrent writeSSE)', async () =>
+    {
+        const stream = new FakeStream();
+        const writer = createBoundedWriter(stream, 100, () => undefined);
+
+        writer.enqueue({ data: '1' });
+        writer.enqueue({ data: '2' });
+        writer.enqueue({ data: '3' });
+
+        // Only the first write has started; the rest wait in the queue.
+        expect(stream.writes.map(w => w.data)).toEqual(['1']);
+        expect(stream.inFlight).toBe(1);
+        expect(writer.queued).toBe(2);
+
+        stream.resolveNext();
+        await tick();
+        stream.resolveNext();
+        await tick();
+        stream.resolveNext();
+        await tick();
+
+        expect(stream.writes.map(w => w.data)).toEqual(['1', '2', '3']);
+        expect(stream.maxInFlight).toBe(1); // never two writes at once → backpressure held
+        expect(writer.queued).toBe(0);
+    });
+
+    it('closes the connection on queue overflow (slow consumer)', () =>
+    {
+        const stream = new FakeStream(); // writes never resolve
+        const onClose = vi.fn();
+        const writer = createBoundedWriter(stream, 3, onClose);
+
+        writer.enqueue({ data: '1' }); // → in-flight (hangs), queue 0
+        writer.enqueue({ data: '2' }); // queue 1
+        writer.enqueue({ data: '3' }); // queue 2
+        writer.enqueue({ data: '4' }); // queue 3 (== max, ok)
+        expect(onClose).not.toHaveBeenCalled();
+
+        writer.enqueue({ data: '5' }); // queue 4 > 3 → overflow
+        expect(onClose).toHaveBeenCalledOnce();
+        expect(onClose.mock.calls[0][0]).toMatch(/overflow/);
+    });
+
+    it('close() stops draining and drops queued frames', async () =>
+    {
+        const stream = new FakeStream();
+        const writer = createBoundedWriter(stream, 100, () => undefined);
+
+        writer.enqueue({ data: '1' }); // in-flight
+        writer.enqueue({ data: '2' }); // queued
+        writer.close();
+
+        expect(writer.queued).toBe(0);
+
+        stream.resolveNext(); // finish the in-flight write
+        await tick();
+
+        expect(stream.writes.map(w => w.data)).toEqual(['1']); // '2' never written
+    });
+
+    it('closes on a write error', async () =>
+    {
+        const stream = new FakeStream();
+        const onClose = vi.fn();
+        const writer = createBoundedWriter(stream, 100, onClose);
+
+        writer.enqueue({ data: '1' });
+        stream.rejectNext(new Error('socket gone'));
+        await tick();
+
+        expect(onClose).toHaveBeenCalledOnce();
+        expect(onClose.mock.calls[0][0]).toMatch(/socket gone/);
+    });
+
+    it('ignores enqueue after close', () =>
+    {
+        const stream = new FakeStream();
+        const writer = createBoundedWriter(stream, 100, () => undefined);
+
+        writer.close();
+        writer.enqueue({ data: '1' });
+
+        expect(stream.writes).toHaveLength(0);
+        expect(writer.queued).toBe(0);
+    });
+});

--- a/packages/core/src/event/sse/bounded-writer.ts
+++ b/packages/core/src/event/sse/bounded-writer.ts
@@ -1,0 +1,120 @@
+/**
+ * Bounded SSE outbound writer
+ *
+ * Serializes writes to one SSE stream through a single drain loop that `await`s
+ * each `writeSSE` — so a slow client applies real backpressure instead of letting
+ * frames pile up unbounded in memory (OOM under a fast producer + slow consumer).
+ *
+ * The queue is per-connection, so a slow stream never blocks other connections.
+ * When the queue exceeds `maxQueue`, the connection is closed (via `onClose`)
+ * rather than silently dropping frames — dropping a chunk would corrupt an
+ * ordered token/chat stream; the client reconnects and re-fetches instead.
+ */
+
+/** A frame to write to the SSE stream (subset of Hono's SSEMessage). */
+export interface SSEFrame
+{
+    data: string;
+    event?: string;
+    id?: string;
+}
+
+/** Minimal stream surface this writer needs (Hono's SSEStreamingApi satisfies it). */
+export interface SSEWritable
+{
+    writeSSE(message: SSEFrame): Promise<void>;
+}
+
+export interface BoundedWriter
+{
+    /** Queue a frame for delivery; closes the connection if the queue overflows. */
+    enqueue(frame: SSEFrame): void;
+
+    /** Stop draining and drop any queued frames (called on connection cleanup). */
+    close(): void;
+
+    /** Current queue depth (for tests/diagnostics). */
+    readonly queued: number;
+}
+
+/**
+ * Create a bounded, backpressure-aware writer for one SSE stream.
+ *
+ * @param stream   the SSE stream (`writeSSE` returns a promise that resolves when
+ *                 the socket has drained — that is what gives us backpressure)
+ * @param maxQueue max frames buffered before the connection is closed
+ * @param onClose  called once when the writer closes the connection (overflow or
+ *                 a write error); the caller cleans up and logs
+ */
+export function createBoundedWriter(
+    stream: SSEWritable,
+    maxQueue: number,
+    onClose: (reason: string) => void,
+): BoundedWriter
+{
+    const pending: SSEFrame[] = [];
+    let flushing = false;
+    let closed = false;
+
+    const flush = async (): Promise<void> =>
+    {
+        if (flushing || closed)
+        {
+            return;
+        }
+
+        flushing = true;
+
+        while (pending.length > 0 && !closed)
+        {
+            const frame = pending.shift() as SSEFrame;
+            try
+            {
+                await stream.writeSSE(frame);
+            }
+            catch (err)
+            {
+                flushing = false;
+                onClose(err instanceof Error ? err.message : String(err));
+
+                return;
+            }
+        }
+
+        flushing = false;
+    };
+
+    return {
+        enqueue(frame: SSEFrame): void
+        {
+            if (closed)
+            {
+                return;
+            }
+
+            pending.push(frame);
+
+            // Slow consumer: the drain loop can't keep up, so the queue grew past
+            // the bound. Close rather than buffer unboundedly or drop silently.
+            if (pending.length > maxQueue)
+            {
+                onClose('outbound queue overflow (slow consumer)');
+
+                return;
+            }
+
+            void flush();
+        },
+
+        close(): void
+        {
+            closed = true;
+            pending.length = 0;
+        },
+
+        get queued(): number
+        {
+            return pending.length;
+        },
+    };
+}

--- a/packages/core/src/event/sse/handler.ts
+++ b/packages/core/src/event/sse/handler.ts
@@ -22,8 +22,12 @@ import { logger } from '@spfn/core/logger';
 import type { EventRouterDef, InferEventNames } from '../router';
 import type { SSEHandlerConfig, SSEHandlerAuthConfig } from './types';
 import type { SSETokenManager } from './token-manager';
+import { createBoundedWriter } from './bounded-writer';
 
 const sseLogger = logger.child('@spfn/core:sse');
+
+/** Default outbound queue cap per connection before a slow consumer is dropped. */
+const DEFAULT_MAX_QUEUE = 1000;
 
 // Extend Hono context with SSE subject
 declare module 'hono'
@@ -57,6 +61,7 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
     const {
         pingInterval = 30000,
         auth: authConfig,
+        maxQueue = DEFAULT_MAX_QUEUE,
     } = config;
 
     return async (c: Context) =>
@@ -118,17 +123,37 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
             let messageId = 0;
             let connectionDead = false;
             let pingTimer: ReturnType<typeof setInterval>;
+            let writer: ReturnType<typeof createBoundedWriter>;
 
-            const cleanup = () =>
+            const cleanup = (reason?: string) =>
             {
                 if (connectionDead) return;
                 connectionDead = true;
                 clearInterval(pingTimer);
                 unsubscribes.forEach(fn => fn());
+                writer?.close();
                 sseLogger.info('SSE dead connection cleaned up', {
                     events: allowedEvents,
+                    reason,
                 });
             };
+
+            // All writes go through one bounded, backpressure-aware drain loop so a
+            // slow client can't pile frames up in memory (it's closed on overflow).
+            writer = createBoundedWriter(stream, maxQueue, (reason) =>
+            {
+                sseLogger.warn('SSE connection closed', { events: allowedEvents, reason });
+                cleanup(reason);
+            });
+
+            // Send initial connection message (first frame in the queue).
+            writer.enqueue({
+                event: 'connected',
+                data: JSON.stringify({
+                    subscribedEvents: allowedEvents,
+                    timestamp: Date.now(),
+                }),
+            });
 
             for (const eventName of allowedEvents as InferEventNames<TRouter>[])
             {
@@ -164,18 +189,10 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
                         messageId,
                     });
 
-                    stream.writeSSE({
+                    writer.enqueue({
                         id: String(messageId),
                         event: eventName as string,
                         data: JSON.stringify(message),
-                    }).catch((err) =>
-                    {
-                        sseLogger.warn('SSE write failed', {
-                            event: eventName,
-                            messageId,
-                            error: err.message,
-                        });
-                        cleanup();
                     });
                 });
 
@@ -187,29 +204,14 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
                 subscriptionCount: unsubscribes.length,
             });
 
-            // Send initial connection message
-            await stream.writeSSE({
-                event: 'connected',
-                data: JSON.stringify({
-                    subscribedEvents: allowedEvents,
-                    timestamp: Date.now(),
-                }),
-            });
-
             // Keep-alive ping
             pingTimer = setInterval(() =>
             {
                 if (connectionDead) return;
 
-                stream.writeSSE({
+                writer.enqueue({
                     event: 'ping',
                     data: JSON.stringify({ timestamp: Date.now() }),
-                }).catch((err) =>
-                {
-                    sseLogger.warn('SSE ping failed', {
-                        error: err.message,
-                    });
-                    cleanup();
                 });
             }, pingInterval);
 

--- a/packages/core/src/event/sse/types.ts
+++ b/packages/core/src/event/sse/types.ts
@@ -160,6 +160,14 @@ export interface SSEHandlerConfig
     headers?: Record<string, string>;
 
     /**
+     * Max outbound frames buffered per connection before a slow consumer is
+     * dropped (connection closed). Bounds memory under a fast producer + slow
+     * client; the client reconnects rather than receiving corrupted/partial data.
+     * @default 1000
+     */
+    maxQueue?: number;
+
+    /**
      * Authentication and authorization configuration
      */
     auth?: SSEHandlerAuthConfig;


### PR DESCRIPTION
## 배경

SSE 핸들러가 이벤트 도착 시 `stream.writeSSE`를 **await 없이** fire-and-forget로 호출했다(`handler.ts`의 이벤트 콜백·ping). 느린 클라이언트(모바일·백그라운드 탭·느린 망)면 TCP 송신 버퍼가 차고 write가 Node 메모리에 무한정 쌓여 OOM 위험 — 빠른 LLM 토큰 스트림 + 느린 소비자가 정확히 이 시나리오다.

> redis fan-out PR(#16)의 멀티에이전트 E2E 리뷰에서 발견돼 별도 후속작업으로 기록했던 건. fan-out과 독립이라 별도 PR로 분리.

## 변경

- **connection별 bounded 큐 + 단일 drain 루프.** drain이 `await stream.writeSSE()`로 한 프레임씩 직렬 전송 → 소켓 버퍼가 빠질 때까지 기다리는 **진짜 backpressure**, 메모리 bounded. 큐가 연결별이라 느린 연결이 다른 연결을 막지 않음(HOL 없음).
- 이벤트 콜백·ping의 fire-and-forget writeSSE → `writer.enqueue`로 교체.
- 큐 상한 `maxQueue`(기본 1000) 초과 시 **연결 종료** + WARN. 토큰 스트림은 청크를 하나라도 버리면 텍스트가 깨지므로, 조용한 손실 대신 끊고 클라이언트가 재연결·재요청으로 복구.
- 큐/drain 로직을 `createBoundedWriter`로 분리 — 단위 테스트 5개(직렬 전송·동시 write 없음, 오버플로 close, close 시 drain 중단, write 에러 close).

## API
`SSEHandlerConfig.maxQueue?: number`(기본 1000) 추가. 기존 동작 호환(설정 안 하면 1000).

## 테스트
`bounded-writer.test.ts` 5개 + 기존 SSE 통합 테스트(token-auth) 통과. type-check·build·lint 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)