### PR TITLE
feat(core): proxy→backend HMAC signing + proxy-guard

### DIFF
--- a/PROXY-BACKEND-AUTH-SPEC.md
+++ b/PROXY-BACKEND-AUTH-SPEC.md
@@ -1,0 +1,131 @@
+# @spfn/core 프록시↔백엔드 신뢰 검증 + Origin 검증 (클라이언트 출처 강화)
+
+> 출처: 보안 설계 논의(2026-06-24). 백엔드가 모바일 때문에 공개망에 노출돼야 하는 전제 위에서,
+> 코드/아키텍처 레벨로 클라이언트 출처를 검증하는 1차 작업.
+> 모바일 client attestation은 이 작업의 후속(메모리: mobile-attestation-followup).
+
+## 배경 (왜)
+
+백엔드(`SPFN_API_URL`, 기본 `http://localhost:8790`)는 모바일 앱 때문에 공개망에 떠야 한다.
+지금은 client-signed JWT 인증만으로 막고 있다. 위협을 둘로 가른다.
+
+- **위협 A — 미인증 외부인.** 남의 데이터 접근, login/register 무차별, 프록시를 건너뛴 백엔드 직접 타격.
+  → 막을 수 있고, 막아야 한다. 이 작업의 대상.
+- **위협 B — 인증된 본인의 비공식 클라이언트 자동화.** 자기 계정으로 직접 짠 스크립트 호출.
+  → 근본적으로 원천 차단 불가. "충분히 비싸게"의 게임. 웹은 한계가 명확(아래), 모바일은 후속 attestation.
+
+현재 구조에서 정상 Next.js 앱은 `/api/rpc/[routeName]` 프록시(`packages/core/src/nextjs/proxy/rpc.ts`)를
+거쳐 백엔드로 간다. 프록시가 routeName→{method,path}를 resolve해 forward하므로 클라는 실제 백엔드 path를 모른다.
+하지만 백엔드는 "이 요청이 우리 프록시를 거쳐 왔는가"를 검증하지 않는다 → JWT만 있으면 백엔드 직접 호출 가능.
+
+## 범위
+
+### A. 프록시→백엔드 HMAC 서명 (핵심)
+
+프록시가 백엔드로 forward할 때 요청에 서명을 실어, 백엔드가 "정상 프록시 경유"를 검증한다.
+
+- **서명 대상**: `method + resolvedPath + timestamp + nonce + bodyHash`. path를 포함해야
+  캡처한 서명을 다른 라우트에 재사용하는 걸 막는다.
+- **bodyHash**: JSON body일 때만 SHA-256 포함. 대용량 formData는 서명 범위에서 제외
+  (method+path+timestamp+nonce만) — 업로드 성능 보호. SSE는 응답 스트리밍이라 무관.
+- **헤더**: `X-SPFN-Proxy-Signature`, `X-SPFN-Proxy-Timestamp`, `X-SPFN-Proxy-Nonce`, `X-SPFN-Proxy-Key-Id`.
+- **알고리즘**: HMAC-SHA256. 요청당 마이크로초 단위 — 프록시↔백엔드 왕복 대비 무시 가능.
+- **공유 시크릿**: `SPFN_PROXY_SECRET`을 프록시·백엔드 양쪽에 주입(아래 E·F 참고).
+  값은 로그/출력 노출 금지(키 이름만). k8s secret으로 양쪽 deployment 주입 권장.
+
+**프록시 측 끼우는 자리**: `rpc.ts` `handleRpc`의 fetch 직전(현재 ~371행).
+모든 인터셉터가 헤더·body를 만진 *후* fetchOptions가 최종 확정된 시점이어야
+서명한 body와 실제 전송 body가 일치한다(인터셉터가 body 변경 가능, ~365행).
+`RpcProxyConfig`에 시크릿/on-off 옵션 추가.
+
+**백엔드 측 검증**: 라우트 등록 전 전역 미들웨어(파이프라인 4단계 `config.use[]` 자리).
+서명 재계산 일치 확인 + timestamp 윈도우(예 30s) 검사로 캡처-재전송 차단.
+통과 시 컨텍스트에 `clientType: 'web'` 주입 → 라우트가 출처를 알 수 있고,
+이 자리가 후속 attestation 레벨 체크가 들어올 지점.
+
+### B. Origin allowlist 검증
+
+- 브라우저 안 JS는 `Origin`/`Referer`를 위조 못 함(forbidden headers). 위조 가능한 건 브라우저 밖(curl/서버)인데
+  거기선 세션 쿠키(HttpOnly + SameSite=strict, 이미 적용됨)가 안 실려 인증 실패.
+- 미인증 cross-origin 요청을 입구에서 떨구는 저비용 미들웨어. 허용 origin 목록을 config/env로.
+- HMAC 미들웨어와 같은 전역 단계에 함께 등록.
+
+### C. nonce replay 차단 (옵셔널, Redis)
+
+- timestamp 윈도우만으로는 같은 윈도우 내 재전송이 남는다. 완전 차단은 nonce를 Redis에 짧은 TTL로 캐싱,
+  한 번 쓴 nonce 거부.
+- **옵셔널**: 모두가 Redis를 쓰진 않음. `CACHE_URL`(SSE/토큰 store와 동일 컨벤션) 있을 때만 활성,
+  없으면 timestamp 윈도우로만 동작. 옵션 플래그로 민감 라우트에만 켤 수도.
+
+### D. enforcement 모드 (config 옵션)
+
+프레임워크라 기본값이 기존 앱을 깨면 안 된다.
+
+- `off` (기본): 검증 안 함. 기존 호환.
+- `tag`: 서명/origin 검증해 `clientType` 등 컨텍스트만 태깅, 실패해도 통과(관측 우선).
+- `strict`: 검증 실패 시 거부.
+- 운영 권장: 프로덕션 트래픽 받는 중이면 `tag`로 관측 후 `strict` 승격, 신규면 바로 `strict`.
+
+### E. 키 로테이션 (무중단)
+
+두 독립 프로세스(Next 프록시·SPFN 백엔드)가 같은 키를 공유하므로, 단일 시크릿을 한 번에
+교체하면 롤링 배포 중 파드가 섞여 검증이 깨진다. 그래서 **키 ID + grace 키셋**으로 푼다.
+
+- **표현**: 시크릿은 `<keyId>:<secret>` (콜론 없으면 keyId=`default`, 하위호환).
+- **프록시**: active 키(`SPFN_PROXY_SECRET`)로만 서명, `X-SPFN-Proxy-Key-Id` 헤더로 keyId 전달.
+- **백엔드**: keyId로 키셋에서 검증 키 선택. 키셋 = active(`SPFN_PROXY_SECRET`) +
+  grace(`SPFN_PROXY_SECRET_PREVIOUS`, 콤마로 여럿). keyId collision은 active 우선.
+- **무중단 절차**: ① 백엔드 `active=v2, previous=v1` 배포(둘 다 검증) → ② 프록시 `active=v2`
+  배포 → ③ grace 지나면 백엔드 `previous`에서 v1 제거. 어느 시점에도 깨지는 요청 없음.
+- **자동화 확장**: 이 키셋이 토대. GCP Secret Manager가 env를 주기적으로 굴리고 양쪽이 짧은
+  TTL로 재로드하면 완전 자동 로테이션. (시간 기반 파생은 master 유출 시 무력이라 비채택.)
+
+### F. .env 배치 (react2shell 맥락)
+
+react2shell(CVE-2025-55182, RSC RCE/env 유출) 때문에 SPFN은 Next가 읽을 필요 없는 시크릿을
+`.env.server`로 격리한다(Next process.env에 안 올림 → RCE로도 안 샘). 이 분리에 맞춰:
+
+- **`SPFN_PROXY_SECRET`(active)** → `.env.local`. 프록시가 *서명을 만들려면* Next가 알아야 해서
+  `.env.server` 격리 불가(거기 두면 프록시가 못 읽어 서명 자체를 안 붙임). `nextjs: true` +
+  `sensitive: true`라 CLI가 `.env.local`로 분류(서버 런타임만, 브라우저 미노출). 백엔드는 loadEnv가
+  `.env.local`도 읽으므로 양쪽이 본다.
+- **`SPFN_PROXY_SECRET_PREVIOUS`(grace)** → `.env.server`. 백엔드 검증 전용(프록시는 previous로
+  서명 안 함)이라 Next에 노출할 이유가 없음. `nextjs: false`.
+- **한계(정직)**: active는 Next가 들 수밖에 없어 react2shell류 노출을 못 피한다. 다만 (1) 이 시크릿이
+  새도 무력화되는 건 "프록시 우회 차단"뿐 — JWT 인증은 독립이라 데이터 접근은 막힘. (2) Next가 RCE로
+  뚫리면 시크릿 유출과 무관하게 공격자가 Next 안에서 백엔드를 직접 호출 가능 → 격리해도 이득 적음.
+  실질 방어는 **Next 패치 유지 + 정기 로테이션**(E).
+- 배포(k8s)에선 파일 무관 — 양쪽 deployment env로 주입. previous는 백엔드 pod에만.
+
+## 웹의 한계 (정직하게 — 문서에 박아둘 것)
+
+- 브라우저 안 + 우리 도메인(정상 앱 OR DevTools 콘솔 붙여넣기)은 Origin·쿠키·모든 헤더가 동일 →
+  네트워크 레벨에서 **구분 불가능.** 콘솔 붙여넣기는 막을 수 없고 비용만 올린다(CSRF double-submit,
+  커스텀 헤더, self-XSS 콘솔 경고문 등). 단 콘솔 코드는 *본인 계정*에만 닿음(남의 쿠키 없음) → 위협 B.
+- 브라우저 안 + 다른 도메인(악성 사이트 cross-origin)은 Origin이 그 도메인으로 박히고(위조 불가)
+  쿠키도 SameSite=strict로 안 실려 막힘 → B로 차단.
+- 브라우저 밖(curl/서버)은 Origin 위조 가능하나 쿠키 없어 본인 계정 외 불가.
+- 결론: "외부 흉내 / cross-origin"은 A+B로 잡힘. "콘솔 붙여넣기"는 못 잡음 → 모바일 attestation이 필요한 이유.
+
+## 모바일 attestation (후속, 별도 작업)
+
+App Attest(iOS) / Play Integrity(Android). B 미들웨어에 "또는 유효한 attestation" OR 조건 추가 형태로 자람.
+상세: 메모리 `mobile-attestation-followup`.
+
+## 수용 기준
+
+- 프록시 경유 정상 요청: 백엔드가 서명 검증 통과, `clientType=web` 태깅.
+- 프록시 우회 백엔드 직접 호출(서명 없음): `strict`에서 거부.
+- Origin 미허용 cross-origin: 거부.
+- Redis 미설정: nonce 없이 timestamp 윈도우로 정상 동작.
+- `off`/기존 앱: 동작 변화 없음(호환).
+- formData 업로드 성능: bodyHash 제외로 회귀 없음.
+
+## 관련 파일
+
+- `packages/core/src/nextjs/proxy/rpc.ts` (프록시 forward, fetch 직전 서명 자리 ~371행)
+- `packages/core/src/nextjs/proxy/types.ts` (`RpcProxyConfig`)
+- `packages/core/src/nextjs/proxy/helpers.ts` (`buildProxyHeaders` 등)
+- 백엔드 미들웨어 등록부 (server config `config.use[]`, 파이프라인 4단계)
+- 쿠키 설정 참고: `packages/auth` session-helpers (SameSite=strict, HttpOnly 이미 적용)
+- nonce store 참고: `CacheTokenStore`(Redis transport 패턴)

--- a/PROXY-BACKEND-AUTH-SPEC.md
+++ b/PROXY-BACKEND-AUTH-SPEC.md
@@ -50,10 +50,13 @@
 - **자동 skip**: health·SSE 스트림(`/events/stream`)·WS 경로는 서명 없이 통과(EventSource는 커스텀 헤더 불가).
   단 SSE **토큰(POST)** 은 프록시를 거치고 자격증명을 발급하므로 skip하지 않고 검증한다.
   OPTIONS preflight는 서명 면제(비-mutating)하되 strict면 origin은 검사.
-- **모드별 차이**: origin allowlist는 **strict 게이트**(거부). `tag`는 origin을 무시하고 `clientType`을
-  *서명만으로* 결정해 관측 지표가 왜곡되지 않게 한다. nonce·body-cap도 strict에서만 동작.
-- **body-cap**: `maxBodyBytes` 설정 시 Content-Length 초과 요청을 해시 전에 413으로 거부(가드가 버퍼링하는
-  메모리 상한). multipart는 비대상. 미설정이면 무제한(기존 동작).
+- **모드별 차이**: origin·서명·nonce·body-cap 게이트는 *양 모드에서 평가*하고 enforcement만 다르다 —
+  strict는 거부(403/413), tag는 `clientType='untrusted'`로 태깅하고 통과. 그래서 tag는 strict가 무엇을
+  거부할지 정확히 관측한다(지표 왜곡 없음). OPTIONS도 origin 검사 후 `clientType`을 태깅한다.
+- **body-cap**: `maxBodyBytes` 설정 시 body를 *스트리밍으로 측정*하다 초과하면 중단·413. Content-Length는
+  신뢰하지 않으므로 누락·chunked·과소보고로 우회할 수 없다. multipart는 비대상. 미설정이면 무제한.
+- **base path**: 프록시는 라우트 상대 경로를 서명하므로 `SPFN_API_URL`에 백엔드가 유지하는 base path가 있으면
+  서명이 어긋난다. 프록시 부팅 시 경고를 남기며, ingress가 prefix를 strip하는 구성을 전제로 한다.
 
 ### B. Origin allowlist 검증
 

--- a/PROXY-BACKEND-AUTH-SPEC.md
+++ b/PROXY-BACKEND-AUTH-SPEC.md
@@ -24,10 +24,12 @@
 
 프록시가 백엔드로 forward할 때 요청에 서명을 실어, 백엔드가 "정상 프록시 경유"를 검증한다.
 
-- **서명 대상**: `method + resolvedPath + timestamp + nonce + bodyHash`. path를 포함해야
-  캡처한 서명을 다른 라우트에 재사용하는 걸 막는다.
-- **bodyHash**: JSON body일 때만 SHA-256 포함. 대용량 formData는 서명 범위에서 제외
-  (method+path+timestamp+nonce만) — 업로드 성능 보호. SSE는 응답 스트리밍이라 무관.
+- **서명 대상**: `method + path + query + timestamp + nonce + bodyHash`. path·query는
+  **wire 표현**(프록시가 보내는 raw request-target). 백엔드는 디코드된 `c.req.path`가 아니라
+  `new URL(c.req.url).pathname`·`.search`로 재구성해 바이트를 일치시킨다(인코딩 드리프트 방지).
+  query를 서명에 넣어야 캡처한 서명을 쿼리만 바꿔 재전송하는 걸 막는다.
+- **bodyHash**: multipart(formData)만 제외(대용량·업로드 성능). 그 외 *모든* content-type의 body는
+  항상 SHA-256으로 바인딩 — content-type을 비-JSON으로 바꿔 body를 서명에서 푸는 우회를 차단. SSE는 응답 스트리밍이라 무관.
 - **헤더**: `X-SPFN-Proxy-Signature`, `X-SPFN-Proxy-Timestamp`, `X-SPFN-Proxy-Nonce`, `X-SPFN-Proxy-Key-Id`.
 - **알고리즘**: HMAC-SHA256. 요청당 마이크로초 단위 — 프록시↔백엔드 왕복 대비 무시 가능.
 - **공유 시크릿**: `SPFN_PROXY_SECRET`을 프록시·백엔드 양쪽에 주입(아래 E·F 참고).
@@ -38,10 +40,15 @@
 서명한 body와 실제 전송 body가 일치한다(인터셉터가 body 변경 가능, ~365행).
 `RpcProxyConfig`에 시크릿/on-off 옵션 추가.
 
-**백엔드 측 검증**: 라우트 등록 전 전역 미들웨어(파이프라인 4단계 `config.use[]` 자리).
-서명 재계산 일치 확인 + timestamp 윈도우(예 30s) 검사로 캡처-재전송 차단.
+**백엔드 측 검증**: 라우트 등록 전 전역 미들웨어(파이프라인 4단계, CORS 다음).
+서명 재계산 일치 + timestamp 윈도우(기본 30s) 검사로 캡처-재전송 차단.
 통과 시 컨텍스트에 `clientType: 'web'` 주입 → 라우트가 출처를 알 수 있고,
 이 자리가 후속 attestation 레벨 체크가 들어올 지점.
+
+- **fail-closed**: `strict`인데 키가 미설정이면 미들웨어 생성 시 throw(서버 시작 실패) — 검증 불가 상태로
+  문이 열린 채 뜨지 않게. `tag`는 관측 모드라 키 없으면 전부 `untrusted` 태깅하고 통과(경고).
+- **자동 skip**: health·SSE(`/events/stream`, `/token`)·WS 경로와 OPTIONS preflight는 서명 없이 통과.
+  프록시를 거치지 않는 정상 트래픽(EventSource는 커스텀 헤더 불가, preflight는 비-mutating)이라 막으면 안 됨.
 
 ### B. Origin allowlist 검증
 

--- a/PROXY-BACKEND-AUTH-SPEC.md
+++ b/PROXY-BACKEND-AUTH-SPEC.md
@@ -47,8 +47,13 @@
 
 - **fail-closed**: `strict`인데 키가 미설정이면 미들웨어 생성 시 throw(서버 시작 실패) — 검증 불가 상태로
   문이 열린 채 뜨지 않게. `tag`는 관측 모드라 키 없으면 전부 `untrusted` 태깅하고 통과(경고).
-- **자동 skip**: health·SSE(`/events/stream`, `/token`)·WS 경로와 OPTIONS preflight는 서명 없이 통과.
-  프록시를 거치지 않는 정상 트래픽(EventSource는 커스텀 헤더 불가, preflight는 비-mutating)이라 막으면 안 됨.
+- **자동 skip**: health·SSE 스트림(`/events/stream`)·WS 경로는 서명 없이 통과(EventSource는 커스텀 헤더 불가).
+  단 SSE **토큰(POST)** 은 프록시를 거치고 자격증명을 발급하므로 skip하지 않고 검증한다.
+  OPTIONS preflight는 서명 면제(비-mutating)하되 strict면 origin은 검사.
+- **모드별 차이**: origin allowlist는 **strict 게이트**(거부). `tag`는 origin을 무시하고 `clientType`을
+  *서명만으로* 결정해 관측 지표가 왜곡되지 않게 한다. nonce·body-cap도 strict에서만 동작.
+- **body-cap**: `maxBodyBytes` 설정 시 Content-Length 초과 요청을 해시 전에 413으로 거부(가드가 버퍼링하는
+  메모리 상한). multipart는 비대상. 미설정이면 무제한(기존 동작).
 
 ### B. Origin allowlist 검증
 
@@ -63,6 +68,8 @@
   한 번 쓴 nonce 거부.
 - **옵셔널**: 모두가 Redis를 쓰진 않음. `CACHE_URL`(SSE/토큰 store와 동일 컨벤션) 있을 때만 활성,
   없으면 timestamp 윈도우로만 동작. 옵션 플래그로 민감 라우트에만 켤 수도.
+- **degrade**: store가 잠깐 불통이면 timestamp 윈도우로 폴백(통과 + 경고). Redis blip이 정상 트래픽을
+  500으로 만들지 않게 — replay 하드닝이 가용성을 떨어뜨리면 안 됨.
 
 ### D. enforcement 모드 (config 옵션)
 

--- a/PROXY-BACKEND-AUTH-SPEC.md
+++ b/PROXY-BACKEND-AUTH-SPEC.md
@@ -49,7 +49,8 @@
   문이 열린 채 뜨지 않게. `tag`는 관측 모드라 키 없으면 전부 `untrusted` 태깅하고 통과(경고).
 - **자동 skip**: health·SSE 스트림(`/events/stream`)·WS 경로는 서명 없이 통과(EventSource는 커스텀 헤더 불가).
   단 SSE **토큰(POST)** 은 프록시를 거치고 자격증명을 발급하므로 skip하지 않고 검증한다.
-  OPTIONS preflight는 CORS 레이어(`cors()`)의 영역이라 guard가 *가장 먼저* 면제한다(origin 검사도 안 함).
+  진짜 CORS preflight(`Access-Control-Request-Method` 동반)만 CORS 레이어(`cors()`) 영역으로 *가장 먼저*
+  면제한다(origin 검사도 안 함). 그 외 OPTIONS(드문 OPTIONS-as-API)는 정상 검증을 거치므로 우회가 아니다.
   허용되지 않은 origin은 preflight를 통과해도 뒤따르는 실제 요청에서 origin+서명으로 차단되므로 데이터 노출이 없다.
 - **모드별 차이**: origin·서명·nonce·body-cap 게이트는 *양 모드에서 평가*하고 enforcement만 다르다 —
   strict는 거부(403/413), tag는 `clientType='untrusted'`로 태깅하고 통과. 그래서 tag는 strict가 무엇을

--- a/PROXY-BACKEND-AUTH-SPEC.md
+++ b/PROXY-BACKEND-AUTH-SPEC.md
@@ -49,10 +49,11 @@
   문이 열린 채 뜨지 않게. `tag`는 관측 모드라 키 없으면 전부 `untrusted` 태깅하고 통과(경고).
 - **자동 skip**: health·SSE 스트림(`/events/stream`)·WS 경로는 서명 없이 통과(EventSource는 커스텀 헤더 불가).
   단 SSE **토큰(POST)** 은 프록시를 거치고 자격증명을 발급하므로 skip하지 않고 검증한다.
-  OPTIONS preflight는 서명 면제(비-mutating)하되 strict면 origin은 검사.
+  OPTIONS preflight는 CORS 레이어(`cors()`)의 영역이라 guard가 *가장 먼저* 면제한다(origin 검사도 안 함).
+  허용되지 않은 origin은 preflight를 통과해도 뒤따르는 실제 요청에서 origin+서명으로 차단되므로 데이터 노출이 없다.
 - **모드별 차이**: origin·서명·nonce·body-cap 게이트는 *양 모드에서 평가*하고 enforcement만 다르다 —
   strict는 거부(403/413), tag는 `clientType='untrusted'`로 태깅하고 통과. 그래서 tag는 strict가 무엇을
-  거부할지 정확히 관측한다(지표 왜곡 없음). OPTIONS도 origin 검사 후 `clientType`을 태깅한다.
+  거부할지 정확히 관측한다(지표 왜곡 없음). OPTIONS는 origin 검사 없이 `clientType='untrusted'`로만 태깅한다.
 - **body-cap**: `maxBodyBytes` 설정 시 body를 *스트리밍으로 측정*하다 초과하면 중단·413. Content-Length는
   신뢰하지 않으므로 누락·chunked·과소보고로 우회할 수 없다. multipart는 비대상. 미설정이면 무제한.
 - **base path**: 프록시는 라우트 상대 경로를 서명하므로 `SPFN_API_URL`에 백엔드가 유지하는 base path가 있으면

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -379,4 +379,24 @@ export const coreEnvSchema = defineEnvSchema({
         nextjs: true,
         examples: [60000, 120000, 280000],
     }),
+
+    // ========================================================================
+    // Proxy → Backend trust (HMAC signing)
+    // ========================================================================
+
+    SPFN_PROXY_SECRET: envString({
+        description: 'Shared secret for signing proxy→backend requests (HMAC-SHA256). Read by BOTH processes — the Next.js proxy (to sign) and the SPFN backend (to verify) — so it belongs in .env.local (loaded by both; the backend reads it via loadEnv, Next.js reads it server-side without exposing it to the browser). Set the SAME value on both. Leave unset to disable proxy-guard signing.',
+        required: false,
+        sensitive: true,
+        nextjs: true,
+        examples: ['<32+ byte random hex>', 'v2:<32+ byte random hex>'],
+    }),
+
+    SPFN_PROXY_SECRET_PREVIOUS: envString({
+        description: 'Previous (grace) proxy keys still accepted for verification during rotation — comma-separated <keyId>:<secret>. The proxy never signs with these; they only keep requests signed with the prior key verifying until a rollout settles. Backend-only (verification), so it belongs in .env.server, NOT exposed to the Next.js process.',
+        required: false,
+        sensitive: true,
+        nextjs: false,
+        examples: ['v1:<old secret>', 'v1:<old>,v0:<older>'],
+    }),
 });

--- a/packages/core/src/middleware/README.md
+++ b/packages/core/src/middleware/README.md
@@ -48,9 +48,12 @@ From `@spfn/core/middleware`:
   — register with `app.use(...)`.
 - `maskSensitiveData(obj, sensitiveFields, seen?)` → deep-masked copy of `obj`.
 - `createProxyGuard(config?: ProxyGuardConfig)` → Hono middleware. Verifies the proxy→backend
-  HMAC signature (rotating key set, keyed by `keyId`) + optional origin allowlist, then sets
-  `c.get('clientType')` (`'web'` | `'untrusted'`). Modes: `off` (default) / `tag` / `strict`.
-  Usually enabled via `defineServerConfig().proxyGuard({...})`, not `app.use` directly.
+  HMAC signature (rotating key set, keyed by `keyId`) over `method+path+query+body`, plus an
+  optional origin allowlist, then sets `c.get('clientType')` (`'web'` | `'untrusted'`). Modes:
+  `off` (default) / `tag` / `strict` — every gate is evaluated in BOTH modes, only enforcement
+  differs (strict rejects 403/413, tag tags `untrusted` and continues). `maxBodyBytes` caps the
+  hashed body (stream-measured). Usually enabled via `defineServerConfig().proxyGuard({...})`,
+  not `app.use` directly.
 - `createCacheNonceStore(cache, prefix?)` → `NonceStore` for hard replay rejection (Redis
   `SET … PX NX`). Pass to `proxyGuard.nonceStore` (auto-wired from a cache when `nonce: true`).
 

--- a/packages/core/src/middleware/README.md
+++ b/packages/core/src/middleware/README.md
@@ -1,10 +1,11 @@
-# @spfn/core/middleware — Built-in HTTP middleware (error handling + request logging)
+# @spfn/core/middleware — Built-in HTTP middleware (error handling + request logging + proxy-guard)
 
-Two production Hono middleware factories and a masking helper: `ErrorHandler` (serializes
-thrown errors into HTTP responses) and `RequestLogger` (structured request/response logging
-with request IDs, slow-request detection, and sensitive-data masking).
+Production Hono middleware factories and a masking helper: `ErrorHandler` (serializes
+thrown errors into HTTP responses), `RequestLogger` (structured request/response logging
+with request IDs, slow-request detection, and sensitive-data masking), and `createProxyGuard`
+(verifies a trusted-proxy HMAC signature + origin allowlist and tags `clientType`).
 
-> **These are the only exports of this module.** `defineMiddleware` (custom named
+> **These are the exports of this module.** `defineMiddleware` (custom named
 > middleware), `.use()` / `.skip()` (route-level wiring), and `Transactional` (DB
 > transaction middleware) are **not** here — they live in `@spfn/core/route` and
 > `@spfn/core/db`. See [Related](#related).
@@ -16,6 +17,8 @@ import {
     ErrorHandler,
     RequestLogger,
     maskSensitiveData,
+    createProxyGuard,
+    createCacheNonceStore,
 } from '@spfn/core/middleware';
 
 import type {
@@ -23,6 +26,10 @@ import type {
     OnErrorContext,
     RequestLoggerOptions,
     RequestLoggerConfig, // deprecated alias of RequestLoggerOptions
+    ProxyGuardConfig,
+    ProxyGuardMode,
+    ClientType,
+    NonceStore,
 } from '@spfn/core/middleware';
 ```
 
@@ -40,8 +47,18 @@ From `@spfn/core/middleware`:
 - `RequestLogger(options?: RequestLoggerOptions)` → Hono middleware `(c, next) => Promise<void>`
   — register with `app.use(...)`.
 - `maskSensitiveData(obj, sensitiveFields, seen?)` → deep-masked copy of `obj`.
+- `createProxyGuard(config?: ProxyGuardConfig)` → Hono middleware. Verifies the proxy→backend
+  HMAC signature (rotating key set, keyed by `keyId`) + optional origin allowlist, then sets
+  `c.get('clientType')` (`'web'` | `'untrusted'`). Modes: `off` (default) / `tag` / `strict`.
+  Usually enabled via `defineServerConfig().proxyGuard({...})`, not `app.use` directly.
+- `createCacheNonceStore(cache, prefix?)` → `NonceStore` for hard replay rejection (Redis
+  `SET … PX NX`). Pass to `proxyGuard.nonceStore` (auto-wired from a cache when `nonce: true`).
 
-Types: `ErrorHandlerOptions`, `OnErrorContext`, `RequestLoggerOptions`, `RequestLoggerConfig`.
+Types: `ErrorHandlerOptions`, `OnErrorContext`, `RequestLoggerOptions`, `RequestLoggerConfig`,
+`ProxyGuardConfig`, `ProxyGuardMode`, `ClientType`, `NonceStore`.
+
+See the root `PROXY-BACKEND-AUTH-SPEC.md` for the threat model, key rotation, and `.env`
+placement (`SPFN_PROXY_SECRET` in `.env.local`; grace `SPFN_PROXY_SECRET_PREVIOUS` in `.env.server`).
 
 > **`RequestLoggerConfig` is deprecated** — it is a type alias of `RequestLoggerOptions`.
 > Use `RequestLoggerOptions` in new code.

--- a/packages/core/src/middleware/__tests__/proxy-guard.test.ts
+++ b/packages/core/src/middleware/__tests__/proxy-guard.test.ts
@@ -391,7 +391,7 @@ describe('createProxyGuard', () =>
 
     describe('bypass-path handling', () =>
     {
-        it('skips OPTIONS preflight without a signature and tags clientType', async () =>
+        it('exempts OPTIONS from signature but tags it untrusted (unsigned, not trusted)', async () =>
         {
             const app = new Hono();
             app.use('*', createProxyGuard({ mode: 'strict', secret: SECRET }));
@@ -400,8 +400,8 @@ describe('createProxyGuard', () =>
             const res = await app.request('/users', { method: 'OPTIONS' });
 
             expect(res.status).toBe(200);
-            // clientType must be set so downstream never sees it undefined
-            expect((await res.json()).clientType).toBe('web');
+            // Set (never undefined) but NOT 'web' — a bare preflight isn't trusted.
+            expect((await res.json()).clientType).toBe('untrusted');
         });
 
         it('skips configured skipPaths without a signature', async () =>

--- a/packages/core/src/middleware/__tests__/proxy-guard.test.ts
+++ b/packages/core/src/middleware/__tests__/proxy-guard.test.ts
@@ -139,6 +139,71 @@ describe('createProxyGuard', () =>
             const json = await res.json();
             expect(json.clientType).toBe('web');
         });
+
+        it('tags by signature only, ignoring the origin allowlist (no metric skew)', async () =>
+        {
+            const taggingGuard = createProxyGuard({
+                mode: 'tag',
+                secret: SECRET,
+                allowedOrigins: ['https://app.example.com'],
+            });
+            const app = buildApp(taggingGuard);
+            const body = JSON.stringify({ name: 'Ray' });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    origin: 'https://evil.example.com',
+                    ...signedHeaders('POST', '/users', body),
+                },
+                body,
+            });
+
+            // Valid signature from a non-allowlisted origin is still 'web' in tag mode.
+            expect((await res.json()).clientType).toBe('web');
+        });
+    });
+
+    describe('availability & limits', () =>
+    {
+        it('degrades to allow (not 500) when the nonce store throws', async () =>
+        {
+            const flakyStore: NonceStore = {
+                async checkAndSet()
+                {
+                    throw new Error('redis unreachable');
+                },
+            };
+            const guard = createProxyGuard({ mode: 'strict', secret: SECRET, nonceStore: flakyStore });
+            const app = buildApp(guard);
+
+            const res = await app.request('/users/9', {
+                method: 'GET',
+                headers: { ...signedHeaders('GET', '/users/9') },
+            });
+
+            expect(res.status).toBe(200);
+        });
+
+        it('rejects an oversized body with 413 before hashing (strict)', async () =>
+        {
+            const guard = createProxyGuard({ mode: 'strict', secret: SECRET, maxBodyBytes: 16 });
+            const app = buildApp(guard);
+            const body = JSON.stringify({ data: 'x'.repeat(200) });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    'content-length': String(body.length),
+                    ...signedHeaders('POST', '/users', body),
+                },
+                body,
+            });
+
+            expect(res.status).toBe(413);
+        });
     });
 
     describe('mode: off', () =>

--- a/packages/core/src/middleware/__tests__/proxy-guard.test.ts
+++ b/packages/core/src/middleware/__tests__/proxy-guard.test.ts
@@ -25,13 +25,15 @@ function buildApp(guard: ReturnType<typeof createProxyGuard>)
         return c.json({ clientType: c.get('clientType'), echo: body });
     });
     app.get('/users/:id', (c) => c.json({ clientType: c.get('clientType'), id: c.req.param('id') }));
+    app.get('/files/:name', (c) => c.json({ clientType: c.get('clientType'), name: c.req.param('name') }));
+    app.get('/search', (c) => c.json({ clientType: c.get('clientType') }));
 
     return app;
 }
 
-function signedHeaders(method: string, path: string, body?: string, secret = SECRET)
+function signedHeaders(method: string, path: string, body?: string, secret = SECRET, query?: string)
 {
-    return signProxyRequest({ key: parseProxyKey(secret), method, path, body });
+    return signProxyRequest({ key: parseProxyKey(secret), method, path, query, body });
 }
 
 describe('createProxyGuard', () =>
@@ -231,6 +233,94 @@ describe('createProxyGuard', () =>
             // Same signed headers (same nonce) replayed → rejected
             const second = await app.request('/users/7', { method: 'GET', headers });
             expect(second.status).toBe(403);
+        });
+    });
+
+    describe('fail-closed on misconfiguration', () =>
+    {
+        it('throws at construction when strict mode has no key', () =>
+        {
+            expect(() => createProxyGuard({ mode: 'strict', secret: '' })).toThrow(/strict/);
+        });
+
+        it('does not throw in tag mode with no key (observe-only)', () =>
+        {
+            expect(() => createProxyGuard({ mode: 'tag', secret: '' })).not.toThrow();
+        });
+    });
+
+    describe('wire request-target binding', () =>
+    {
+        const guard = createProxyGuard({ mode: 'strict', secret: SECRET });
+
+        it('verifies a percent-encoded path without decode drift', async () =>
+        {
+            const app = buildApp(guard);
+            const res = await app.request('/files/a%2Fb', {
+                method: 'GET',
+                headers: { ...signedHeaders('GET', '/files/a%2Fb') },
+            });
+
+            expect(res.status).toBe(200);
+        });
+
+        it('verifies a matching query string', async () =>
+        {
+            const app = buildApp(guard);
+            const res = await app.request('/search?q=hi&limit=10', {
+                method: 'GET',
+                headers: { ...signedHeaders('GET', '/search', undefined, SECRET, '?q=hi&limit=10') },
+            });
+
+            expect(res.status).toBe(200);
+        });
+
+        it('rejects a tampered query param', async () =>
+        {
+            const app = buildApp(guard);
+            const res = await app.request('/search?limit=99999', {
+                method: 'GET',
+                headers: { ...signedHeaders('GET', '/search', undefined, SECRET, '?limit=10') },
+            });
+
+            expect(res.status).toBe(403);
+        });
+
+        it('binds the body even for a non-json content-type', async () =>
+        {
+            const app = buildApp(guard);
+            const signedBody = JSON.stringify({ amount: 100 });
+            const tampered = JSON.stringify({ amount: 999999 });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: { 'content-type': 'text/plain', ...signedHeaders('POST', '/users', signedBody) },
+                body: tampered,
+            });
+
+            expect(res.status).toBe(403);
+        });
+    });
+
+    describe('bypass-path handling', () =>
+    {
+        it('skips OPTIONS preflight without a signature', async () =>
+        {
+            const app = buildApp(createProxyGuard({ mode: 'strict', secret: SECRET }));
+            const res = await app.request('/users', { method: 'OPTIONS' });
+
+            expect(res.status).not.toBe(403);
+        });
+
+        it('skips configured skipPaths without a signature', async () =>
+        {
+            const guard = createProxyGuard({ mode: 'strict', secret: SECRET, skipPaths: ['/events/stream'] });
+            const app = new Hono();
+            app.use('*', guard);
+            app.get('/events/stream', (c) => c.json({ ok: true }));
+
+            const res = await app.request('/events/stream', { method: 'GET' });
+            expect(res.status).toBe(200);
         });
     });
 

--- a/packages/core/src/middleware/__tests__/proxy-guard.test.ts
+++ b/packages/core/src/middleware/__tests__/proxy-guard.test.ts
@@ -321,7 +321,7 @@ describe('createProxyGuard', () =>
             // Preflight from a disallowed origin is NOT 403'd by the guard (CORS owns it)
             const preflight = await app.request('/users', {
                 method: 'OPTIONS',
-                headers: { origin: 'https://evil.example.com' },
+                headers: { origin: 'https://evil.example.com', 'access-control-request-method': 'POST' },
             });
             expect(preflight.status).not.toBe(403);
 
@@ -439,17 +439,32 @@ describe('createProxyGuard', () =>
 
     describe('bypass-path handling', () =>
     {
-        it('exempts OPTIONS from signature but tags it untrusted (unsigned, not trusted)', async () =>
+        it('exempts a genuine CORS preflight but tags it untrusted (unsigned, not trusted)', async () =>
         {
             const app = new Hono();
             app.use('*', createProxyGuard({ mode: 'strict', secret: SECRET }));
             app.options('/users', (c) => c.json({ clientType: c.get('clientType') }));
 
-            const res = await app.request('/users', { method: 'OPTIONS' });
+            const res = await app.request('/users', {
+                method: 'OPTIONS',
+                headers: { 'access-control-request-method': 'POST' },
+            });
 
             expect(res.status).toBe(200);
             // Set (never undefined) but NOT 'web' — a bare preflight isn't trusted.
             expect((await res.json()).clientType).toBe('untrusted');
+        });
+
+        it('verifies a NON-preflight OPTIONS — OPTIONS-as-API is not an unguarded bypass', async () =>
+        {
+            const app = new Hono();
+            app.use('*', createProxyGuard({ mode: 'strict', secret: SECRET }));
+            app.options('/data', (c) => c.json({ ok: true }));
+
+            // No Access-Control-Request-Method → not a preflight → must be verified.
+            const res = await app.request('/data', { method: 'OPTIONS' });
+
+            expect(res.status).toBe(403);
         });
 
         it('skips configured skipPaths without a signature', async () =>

--- a/packages/core/src/middleware/__tests__/proxy-guard.test.ts
+++ b/packages/core/src/middleware/__tests__/proxy-guard.test.ts
@@ -203,6 +203,29 @@ describe('createProxyGuard', () =>
             expect(res.status).toBe(413);
         });
 
+        it('rejects with a clean 403 (not 500) when the body stream errors mid-read', async () =>
+        {
+            const guard = createProxyGuard({ mode: 'strict', secret: SECRET });
+            const app = buildApp(guard);
+            const stream = new ReadableStream({
+                start(controller)
+                {
+                    controller.error(new Error('client abort'));
+                },
+            });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', ...signedHeaders('POST', '/users', '{}') },
+                body: stream,
+                // @ts-expect-error duplex is required for a stream request body
+                duplex: 'half',
+            });
+
+            // A read failure is a clean reject, never a 500 / on-call page.
+            expect(res.status).toBe(403);
+        });
+
         it('caps oversized body via stream measurement (no truthful Content-Length)', async () =>
         {
             const guard = createProxyGuard({ mode: 'strict', secret: SECRET, maxBodyBytes: 16 });

--- a/packages/core/src/middleware/__tests__/proxy-guard.test.ts
+++ b/packages/core/src/middleware/__tests__/proxy-guard.test.ts
@@ -140,7 +140,7 @@ describe('createProxyGuard', () =>
             expect(json.clientType).toBe('web');
         });
 
-        it('tags by signature only, ignoring the origin allowlist (no metric skew)', async () =>
+        it('tags a cross-origin request untrusted (observes what strict would reject)', async () =>
         {
             const taggingGuard = createProxyGuard({
                 mode: 'tag',
@@ -160,8 +160,10 @@ describe('createProxyGuard', () =>
                 body,
             });
 
-            // Valid signature from a non-allowlisted origin is still 'web' in tag mode.
-            expect((await res.json()).clientType).toBe('web');
+            // tag mode evaluates the same gates strict would — a disallowed origin is
+            // observable as 'untrusted', not silently 'web'.
+            expect(res.status).toBe(200);
+            expect((await res.json()).clientType).toBe('untrusted');
         });
     });
 
@@ -186,7 +188,7 @@ describe('createProxyGuard', () =>
             expect(res.status).toBe(200);
         });
 
-        it('rejects an oversized body with 413 before hashing (strict)', async () =>
+        it('rejects an oversized body with 413 (strict)', async () =>
         {
             const guard = createProxyGuard({ mode: 'strict', secret: SECRET, maxBodyBytes: 16 });
             const app = buildApp(guard);
@@ -194,12 +196,32 @@ describe('createProxyGuard', () =>
 
             const res = await app.request('/users', {
                 method: 'POST',
-                headers: {
-                    'content-type': 'application/json',
-                    'content-length': String(body.length),
-                    ...signedHeaders('POST', '/users', body),
-                },
+                headers: { 'content-type': 'application/json', ...signedHeaders('POST', '/users', body) },
                 body,
+            });
+
+            expect(res.status).toBe(413);
+        });
+
+        it('caps oversized body via stream measurement (no truthful Content-Length)', async () =>
+        {
+            const guard = createProxyGuard({ mode: 'strict', secret: SECRET, maxBodyBytes: 16 });
+            const app = buildApp(guard);
+            const big = 'x'.repeat(500);
+            const stream = new ReadableStream({
+                start(controller)
+                {
+                    controller.enqueue(new TextEncoder().encode(big));
+                    controller.close();
+                },
+            });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', ...signedHeaders('POST', '/users', big) },
+                body: stream,
+                // @ts-expect-error duplex is required for a stream request body
+                duplex: 'half',
             });
 
             expect(res.status).toBe(413);
@@ -369,12 +391,17 @@ describe('createProxyGuard', () =>
 
     describe('bypass-path handling', () =>
     {
-        it('skips OPTIONS preflight without a signature', async () =>
+        it('skips OPTIONS preflight without a signature and tags clientType', async () =>
         {
-            const app = buildApp(createProxyGuard({ mode: 'strict', secret: SECRET }));
+            const app = new Hono();
+            app.use('*', createProxyGuard({ mode: 'strict', secret: SECRET }));
+            app.options('/users', (c) => c.json({ clientType: c.get('clientType') }));
+
             const res = await app.request('/users', { method: 'OPTIONS' });
 
-            expect(res.status).not.toBe(403);
+            expect(res.status).toBe(200);
+            // clientType must be set so downstream never sees it undefined
+            expect((await res.json()).clientType).toBe('web');
         });
 
         it('skips configured skipPaths without a signature', async () =>

--- a/packages/core/src/middleware/__tests__/proxy-guard.test.ts
+++ b/packages/core/src/middleware/__tests__/proxy-guard.test.ts
@@ -313,6 +313,31 @@ describe('createProxyGuard', () =>
 
             expect(res.status).toBe(200);
         });
+
+        it('exempts OPTIONS from the origin gate but still blocks the real cross-origin request', async () =>
+        {
+            const app = buildApp(guard);
+
+            // Preflight from a disallowed origin is NOT 403'd by the guard (CORS owns it)
+            const preflight = await app.request('/users', {
+                method: 'OPTIONS',
+                headers: { origin: 'https://evil.example.com' },
+            });
+            expect(preflight.status).not.toBe(403);
+
+            // ...but the actual cross-origin request is rejected — no data exposure.
+            const body = JSON.stringify({ name: 'Ray' });
+            const real = await app.request('/users', {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    origin: 'https://evil.example.com',
+                    ...signedHeaders('POST', '/users', body),
+                },
+                body,
+            });
+            expect(real.status).toBe(403);
+        });
     });
 
     describe('nonce replay rejection', () =>

--- a/packages/core/src/middleware/__tests__/proxy-guard.test.ts
+++ b/packages/core/src/middleware/__tests__/proxy-guard.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Proxy-guard middleware 테스트
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+
+import { createProxyGuard, type NonceStore } from '../proxy-guard';
+import { signProxyRequest, parseProxyKey } from '../../security/proxy-signature';
+
+const SECRET = 'test-shared-secret';
+
+/**
+ * Build a Hono app whose handler echoes back the parsed body and clientType,
+ * so we can assert both verification outcome AND that body-reading still works.
+ */
+function buildApp(guard: ReturnType<typeof createProxyGuard>)
+{
+    const app = new Hono();
+    app.use('*', guard);
+    app.post('/users', async (c) =>
+    {
+        const body = await c.req.json();
+
+        return c.json({ clientType: c.get('clientType'), echo: body });
+    });
+    app.get('/users/:id', (c) => c.json({ clientType: c.get('clientType'), id: c.req.param('id') }));
+
+    return app;
+}
+
+function signedHeaders(method: string, path: string, body?: string, secret = SECRET)
+{
+    return signProxyRequest({ key: parseProxyKey(secret), method, path, body });
+}
+
+describe('createProxyGuard', () =>
+{
+    describe('mode: strict', () =>
+    {
+        const guard = createProxyGuard({ mode: 'strict', secret: SECRET });
+
+        it('accepts a properly signed request and tags clientType=web', async () =>
+        {
+            const app = buildApp(guard);
+            const body = JSON.stringify({ name: 'Ray' });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', ...signedHeaders('POST', '/users', body) },
+                body,
+            });
+
+            expect(res.status).toBe(200);
+            const json = await res.json();
+            expect(json.clientType).toBe('web');
+            // body must still be readable by the handler after the guard cloned it
+            expect(json.echo).toEqual({ name: 'Ray' });
+        });
+
+        it('rejects an unsigned request with 403', async () =>
+        {
+            const app = buildApp(guard);
+            const body = JSON.stringify({ name: 'Ray' });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body,
+            });
+
+            expect(res.status).toBe(403);
+        });
+
+        it('rejects a request whose body was tampered after signing', async () =>
+        {
+            const app = buildApp(guard);
+            const signedBody = JSON.stringify({ amount: 100 });
+            const tamperedBody = JSON.stringify({ amount: 999999 });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', ...signedHeaders('POST', '/users', signedBody) },
+                body: tamperedBody,
+            });
+
+            expect(res.status).toBe(403);
+        });
+
+        it('verifies a signed GET request', async () =>
+        {
+            const app = buildApp(guard);
+
+            const res = await app.request('/users/42', {
+                method: 'GET',
+                headers: { ...signedHeaders('GET', '/users/42') },
+            });
+
+            expect(res.status).toBe(200);
+            const json = await res.json();
+            expect(json.clientType).toBe('web');
+        });
+    });
+
+    describe('mode: tag', () =>
+    {
+        const guard = createProxyGuard({ mode: 'tag', secret: SECRET });
+
+        it('lets an unsigned request through but tags it untrusted', async () =>
+        {
+            const app = buildApp(guard);
+            const body = JSON.stringify({ name: 'Ray' });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body,
+            });
+
+            expect(res.status).toBe(200);
+            const json = await res.json();
+            expect(json.clientType).toBe('untrusted');
+            expect(json.echo).toEqual({ name: 'Ray' });
+        });
+
+        it('tags a properly signed request as web', async () =>
+        {
+            const app = buildApp(guard);
+            const body = JSON.stringify({ name: 'Ray' });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', ...signedHeaders('POST', '/users', body) },
+                body,
+            });
+
+            const json = await res.json();
+            expect(json.clientType).toBe('web');
+        });
+    });
+
+    describe('mode: off', () =>
+    {
+        it('is a no-op (no clientType, no rejection)', async () =>
+        {
+            const app = buildApp(createProxyGuard({ mode: 'off', secret: SECRET }));
+            const body = JSON.stringify({ name: 'Ray' });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body,
+            });
+
+            expect(res.status).toBe(200);
+            const json = await res.json();
+            expect(json.clientType).toBeUndefined();
+        });
+    });
+
+    describe('origin allowlist', () =>
+    {
+        const guard = createProxyGuard({
+            mode: 'strict',
+            secret: SECRET,
+            allowedOrigins: ['https://app.example.com'],
+        });
+
+        it('rejects a disallowed Origin', async () =>
+        {
+            const app = buildApp(guard);
+            const body = JSON.stringify({ name: 'Ray' });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    origin: 'https://evil.example.com',
+                    ...signedHeaders('POST', '/users', body),
+                },
+                body,
+            });
+
+            expect(res.status).toBe(403);
+        });
+
+        it('accepts an allowed Origin with a valid signature', async () =>
+        {
+            const app = buildApp(guard);
+            const body = JSON.stringify({ name: 'Ray' });
+
+            const res = await app.request('/users', {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    origin: 'https://app.example.com',
+                    ...signedHeaders('POST', '/users', body),
+                },
+                body,
+            });
+
+            expect(res.status).toBe(200);
+        });
+    });
+
+    describe('nonce replay rejection', () =>
+    {
+        it('rejects a replayed nonce when a nonce store is provided', async () =>
+        {
+            const seen = new Set<string>();
+            const nonceStore: NonceStore = {
+                async checkAndSet(nonce)
+                {
+                    if (seen.has(nonce))
+                    {
+                        return false;
+                    }
+                    seen.add(nonce);
+
+                    return true;
+                },
+            };
+
+            const guard = createProxyGuard({ mode: 'strict', secret: SECRET, nonceStore });
+            const app = buildApp(guard);
+            const headers = { ...signedHeaders('GET', '/users/7') };
+
+            const first = await app.request('/users/7', { method: 'GET', headers });
+            expect(first.status).toBe(200);
+
+            // Same signed headers (same nonce) replayed → rejected
+            const second = await app.request('/users/7', { method: 'GET', headers });
+            expect(second.status).toBe(403);
+        });
+    });
+
+    describe('key rotation (grace window)', () =>
+    {
+        // Backend mid-rotation: active v2, still accepting v1
+        const guard = createProxyGuard({
+            mode: 'strict',
+            secret: 'v2:new-secret',
+            previousSecrets: 'v1:old-secret',
+        });
+
+        it('accepts the new active key', async () =>
+        {
+            const app = buildApp(guard);
+            const res = await app.request('/users/1', {
+                method: 'GET',
+                headers: { ...signedHeaders('GET', '/users/1', undefined, 'v2:new-secret') },
+            });
+
+            expect(res.status).toBe(200);
+        });
+
+        it('still accepts the previous (grace) key', async () =>
+        {
+            const app = buildApp(guard);
+            const res = await app.request('/users/1', {
+                method: 'GET',
+                headers: { ...signedHeaders('GET', '/users/1', undefined, 'v1:old-secret') },
+            });
+
+            expect(res.status).toBe(200);
+        });
+
+        it('rejects a retired key no longer in the set', async () =>
+        {
+            const app = buildApp(guard);
+            const res = await app.request('/users/1', {
+                method: 'GET',
+                headers: { ...signedHeaders('GET', '/users/1', undefined, 'v0:retired-secret') },
+            });
+
+            expect(res.status).toBe(403);
+        });
+    });
+});

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -6,3 +6,5 @@ export { ErrorHandler } from './error-handler';
 export type { ErrorHandlerOptions, OnErrorContext } from './error-handler';
 export { RequestLogger, maskSensitiveData } from './request-logger';
 export type { RequestLoggerOptions, RequestLoggerConfig } from './request-logger';
+export { createProxyGuard, createCacheNonceStore } from './proxy-guard';
+export type { ProxyGuardConfig, ProxyGuardMode, ClientType, NonceStore } from './proxy-guard';

--- a/packages/core/src/middleware/proxy-guard.ts
+++ b/packages/core/src/middleware/proxy-guard.ts
@@ -1,0 +1,301 @@
+/**
+ * Proxy-guard middleware
+ *
+ * Verifies that an inbound request came through a trusted Next.js RPC proxy
+ * (HMAC signature) and/or from an allowed browser origin, then tags the request
+ * with a `clientType`. Lets the backend reject direct-to-backend calls that
+ * bypass the proxy.
+ *
+ * This does NOT replace user authentication (JWT) — it answers "what kind of
+ * client is this?", not "who is the user?". It also cannot stop a client from
+ * calling the proxy itself; that is the web's inherent limit (see
+ * PROXY-BACKEND-AUTH-SPEC.md). Mobile clients call the backend directly and are
+ * handled by a future attestation path, OR'd into this same check.
+ *
+ * @module middleware/proxy-guard
+ */
+import type { Context, MiddlewareHandler, Next } from 'hono';
+
+import { env } from '@spfn/core/config';
+import { logger } from '@spfn/core/logger';
+
+import {
+    verifyProxyRequest,
+    parseProxyKeySet,
+    PROXY_SIGNATURE_HEADER,
+    PROXY_TIMESTAMP_HEADER,
+    PROXY_NONCE_HEADER,
+    PROXY_KEY_ID_HEADER,
+    type VerifyFailureReason,
+} from '../security/proxy-signature';
+
+const guardLogger = logger.child('@spfn/core:proxy-guard');
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * How the request reached the backend.
+ * - `web`: verified via a trusted proxy signature
+ * - `untrusted`: could not be verified (only reached handlers in `tag` mode)
+ * - future: `ios` | `android` once attestation lands
+ */
+export type ClientType = 'web' | 'untrusted' | (string & {});
+
+/**
+ * Enforcement mode.
+ * - `off`: middleware is a no-op (default — keeps existing apps working).
+ * - `tag`: verify and set `clientType`, but never reject (observe first).
+ * - `strict`: reject requests that fail verification.
+ */
+export type ProxyGuardMode = 'off' | 'tag' | 'strict';
+
+/**
+ * Optional replay store. Returns `true` when the nonce is fresh (and records it),
+ * `false` when it has been seen before. Backed by Redis in multi-instance setups.
+ */
+export interface NonceStore
+{
+    checkAndSet(nonce: string, ttlMs: number): Promise<boolean>;
+}
+
+export interface ProxyGuardConfig
+{
+    /**
+     * Active shared HMAC secret, as `<keyId>:<secret>` (or a bare secret).
+     * Defaults to `env.SPFN_PROXY_SECRET`. Without it (and no previous keys),
+     * signatures cannot be verified and every request is tagged `untrusted`.
+     */
+    secret?: string;
+
+    /**
+     * Previous (grace) keys still accepted for verification during rotation, as a
+     * comma-separated list of `<keyId>:<secret>`. The proxy never signs with
+     * these — they exist only so in-flight requests signed with the prior key
+     * keep verifying until the rollout settles. Defaults to
+     * `env.SPFN_PROXY_SECRET_PREVIOUS`. Backend-only, so it can live in
+     * `.env.server` (never exposed to the Next.js process).
+     */
+    previousSecrets?: string;
+
+    /** Enforcement mode. @default 'off' */
+    mode?: ProxyGuardMode;
+
+    /** Allowed clock skew / replay window in ms. @default 30000 */
+    windowMs?: number;
+
+    /**
+     * Browser origin allowlist. When set, a request carrying an `Origin` header
+     * not in this list is rejected (strict) / tagged (tag). Requests without an
+     * `Origin` (server-to-server, mobile) skip this check and fall back to the
+     * signature.
+     */
+    allowedOrigins?: string[];
+
+    /** Optional Redis-backed nonce store for hard replay rejection. */
+    nonceStore?: NonceStore;
+
+    /** Paths to skip entirely (e.g. health checks). */
+    skipPaths?: string[];
+}
+
+// ============================================================================
+// Hono context augmentation
+// ============================================================================
+
+declare module 'hono'
+{
+    interface ContextVariableMap
+    {
+        clientType?: ClientType;
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Read the raw JSON body without consuming it for downstream handlers.
+ * Returns undefined for non-JSON (GET, multipart uploads) — matching the proxy,
+ * which excludes those from the signature.
+ */
+async function readJsonBody(c: Context): Promise<string | undefined>
+{
+    const method = c.req.method;
+    if (method === 'GET' || method === 'HEAD')
+    {
+        return undefined;
+    }
+
+    const contentType = c.req.header('content-type') || '';
+    if (!contentType.includes('application/json'))
+    {
+        return undefined;
+    }
+
+    try
+    {
+        return await c.req.raw.clone().text();
+    }
+    catch
+    {
+        return undefined;
+    }
+}
+
+function isOriginAllowed(c: Context, allowedOrigins: string[] | undefined): boolean
+{
+    if (!allowedOrigins || allowedOrigins.length === 0)
+    {
+        return true;
+    }
+
+    const origin = c.req.header('origin');
+    if (!origin)
+    {
+        // No browser Origin (server-to-server / mobile) — defer to signature.
+        return true;
+    }
+
+    return allowedOrigins.includes(origin);
+}
+
+// ============================================================================
+// Middleware
+// ============================================================================
+
+/**
+ * Create the proxy-guard middleware.
+ *
+ * @example
+ * ```typescript
+ * export default defineServerConfig()
+ *     .proxyGuard({ mode: 'strict', allowedOrigins: ['https://app.example.com'] })
+ *     .routes(appRouter)
+ *     .build();
+ * ```
+ */
+export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandler
+{
+    const mode = config.mode ?? 'off';
+    const windowMs = config.windowMs ?? 30_000;
+    const allowedOrigins = config.allowedOrigins;
+    const nonceStore = config.nonceStore;
+    const skipPaths = new Set(config.skipPaths ?? []);
+
+    // Accepted key set: active secret first (wins on keyId collision), then grace keys.
+    const keys = parseProxyKeySet([
+        config.secret ?? env.SPFN_PROXY_SECRET,
+        config.previousSecrets ?? env.SPFN_PROXY_SECRET_PREVIOUS,
+    ]);
+
+    return async (c: Context, next: Next) =>
+    {
+        if (mode === 'off' || skipPaths.has(c.req.path))
+        {
+            return next();
+        }
+
+        // 1. Origin allowlist (browser cross-origin guard)
+        if (!isOriginAllowed(c, allowedOrigins))
+        {
+            return reject(c, mode, next, 'origin-not-allowed');
+        }
+
+        // 2. Without any accepted key we cannot verify a signature — tag and move on.
+        if (keys.length === 0)
+        {
+            c.set('clientType', 'untrusted');
+
+            return next();
+        }
+
+        // 3. HMAC signature
+        const body = await readJsonBody(c);
+        const result = verifyProxyRequest({
+            keys,
+            method: c.req.method,
+            path: c.req.path,
+            body,
+            signature: c.req.header(PROXY_SIGNATURE_HEADER),
+            timestamp: c.req.header(PROXY_TIMESTAMP_HEADER),
+            nonce: c.req.header(PROXY_NONCE_HEADER),
+            keyId: c.req.header(PROXY_KEY_ID_HEADER),
+            windowMs,
+        });
+
+        if (!result.valid)
+        {
+            return reject(c, mode, next, result.reason);
+        }
+
+        // 4. Optional hard replay rejection via nonce store
+        if (nonceStore && result.nonce)
+        {
+            const fresh = await nonceStore.checkAndSet(result.nonce, windowMs * 2);
+            if (!fresh)
+            {
+                return reject(c, mode, next, 'nonce-replay');
+            }
+        }
+
+        c.set('clientType', 'web');
+
+        return next();
+    };
+}
+
+// ============================================================================
+// Redis-backed nonce store (optional)
+// ============================================================================
+
+/** Minimal cache client (compatible with ioredis Redis | Cluster). */
+type CacheClient = {
+    set(key: string, value: string, ...args: any[]): Promise<any>;
+};
+
+/**
+ * Build a Redis-backed nonce store for hard replay rejection.
+ *
+ * Uses `SET key 1 PX ttl NX` — an atomic "set if absent". A fresh nonce returns
+ * 'OK'; a replayed one returns null. TTL keeps the key set bounded (only nonces
+ * within the replay window matter).
+ */
+export function createCacheNonceStore(cache: CacheClient, prefix = 'spfn:proxy-nonce:'): NonceStore
+{
+    return {
+        async checkAndSet(nonce: string, ttlMs: number): Promise<boolean>
+        {
+            const res = await cache.set(`${prefix}${nonce}`, '1', 'PX', Math.ceil(ttlMs), 'NX');
+
+            return res === 'OK';
+        },
+    };
+}
+
+/**
+ * Reject (strict) or tag-and-continue (tag). Keeps the rejection response generic
+ * so it leaks no detail about why verification failed.
+ */
+function reject(
+    c: Context,
+    mode: ProxyGuardMode,
+    next: Next,
+    reason: VerifyFailureReason | 'origin-not-allowed' | 'nonce-replay' | undefined,
+)
+{
+    if (mode === 'strict')
+    {
+        guardLogger.warn('Rejected unverified request', { reason, path: c.req.path, method: c.req.method });
+
+        return c.json({ error: 'Forbidden', message: 'Request origin could not be verified' }, 403);
+    }
+
+    // tag mode — observe only, never block
+    guardLogger.debug('Unverified request (would reject in strict mode)', { reason, path: c.req.path });
+    c.set('clientType', 'untrusted');
+
+    return next();
+}

--- a/packages/core/src/middleware/proxy-guard.ts
+++ b/packages/core/src/middleware/proxy-guard.ts
@@ -128,6 +128,9 @@ declare module 'hono'
 /** Sentinel: body exceeded maxBodyBytes while streaming (never fully buffered). */
 export const BODY_OVERSIZE = Symbol('proxy-guard:body-oversize');
 
+/** Sentinel: the body stream errored mid-read (e.g. client abort). */
+export const BODY_READ_ERROR = Symbol('proxy-guard:body-read-error');
+
 /**
  * Read the raw request body without consuming it for downstream handlers.
  * Bound for ANY non-multipart content-type (not just application/json) so the
@@ -139,7 +142,10 @@ export const BODY_OVERSIZE = Symbol('proxy-guard:body-oversize');
  * limit — so a missing/chunked/under-reported Content-Length can't bypass the cap
  * (the header is never trusted). Returns BODY_OVERSIZE in that case.
  */
-async function readRawBody(c: Context, maxBytes?: number): Promise<string | undefined | typeof BODY_OVERSIZE>
+async function readRawBody(
+    c: Context,
+    maxBytes?: number,
+): Promise<Buffer | undefined | typeof BODY_OVERSIZE | typeof BODY_READ_ERROR>
 {
     const method = c.req.method;
     if (method === 'GET' || method === 'HEAD')
@@ -186,18 +192,17 @@ async function readRawBody(c: Context, maxBytes?: number): Promise<string | unde
             chunks.push(value);
         }
     }
-    catch (err)
+    catch
     {
-        // Don't swallow a mid-stream read error as an empty body — that would hash
-        // '' and 403 a validly-signed request as a phantom signature mismatch.
-        guardLogger.warn('Failed to read request body for signature verification', {
-            error: (err as Error).message,
-        });
+        // A mid-stream error (client abort, network blip) RETURNS a sentinel — not an
+        // empty body (would 403 valid traffic) and not a re-throw (would 500 + page
+        // on-call and break tag mode's never-reject contract).
+        guardLogger.debug('Request body read failed (client abort?)');
 
-        throw err;
+        return BODY_READ_ERROR;
     }
 
-    return Buffer.concat(chunks).toString('utf8');
+    return Buffer.concat(chunks);
 }
 
 function isOriginAllowed(c: Context, allowedOrigins: string[] | undefined): boolean
@@ -281,6 +286,17 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return next();
         }
 
+        // OPTIONS preflight belongs to the CORS layer, not the signature guard. Exempt
+        // it FIRST (before the origin gate) so a cross-origin preflight isn't 403'd here
+        // without CORS headers. Tagged 'untrusted' (unsigned) so downstream that reads
+        // clientType never sees it unset nor treats a bare preflight as trusted.
+        if (c.req.method === 'OPTIONS')
+        {
+            c.set('clientType', 'untrusted');
+
+            return next();
+        }
+
         // Every gate below is EVALUATED in both modes; only enforcement differs
         // (reject() = 403 in strict, tag clientType='untrusted' + continue in tag).
         // So tag mode observes exactly what strict would reject — no metric skew.
@@ -291,17 +307,7 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return reject(c, mode, next, 'origin-not-allowed');
         }
 
-        // 2. OPTIONS preflight carries no signature and is non-mutating — exempt from
-        //    the signature check (origin already checked). Tag 'untrusted' (it is
-        //    unsigned) so downstream never sees it unset NOR treats it as trusted.
-        if (c.req.method === 'OPTIONS')
-        {
-            c.set('clientType', 'untrusted');
-
-            return next();
-        }
-
-        // 3. No accepted key — only reachable in tag mode (strict throws at construction).
+        // 2. No accepted key — only reachable in tag mode (strict throws at construction).
         if (keys.length === 0)
         {
             c.set('clientType', 'untrusted');
@@ -309,7 +315,7 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return next();
         }
 
-        // 4. Cheap header-presence check BEFORE buffering the body, so unsigned requests
+        // 3. Cheap header-presence check BEFORE buffering the body, so unsigned requests
         //    (direct-to-backend attacks, tag-mode rollout traffic) reject/tag without
         //    paying the body read.
         const signature = c.req.header(PROXY_SIGNATURE_HEADER);
@@ -321,7 +327,7 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return reject(c, mode, next, 'missing-headers');
         }
 
-        // 5. Read body with a streaming size cap (Content-Length is never trusted, so a
+        // 4. Read body with a streaming size cap (Content-Length is never trusted, so a
         //    missing/chunked/under-reported length can't bypass the bound).
         const body = await readRawBody(c, maxBodyBytes);
         if (body === BODY_OVERSIZE)
@@ -335,8 +341,14 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
 
             return next();
         }
+        if (body === BODY_READ_ERROR)
+        {
+            // Body stream failed (client abort) — can't verify, so don't hash an empty
+            // body. Reject in strict / tag untrusted, never a 500.
+            return reject(c, mode, next, 'body-read-error');
+        }
 
-        // 6. HMAC over the wire request-target (raw path + query) and body. Use the raw
+        // 5. HMAC over the wire request-target (raw path + query) and body. Use the raw
         //    URL, NOT the decoded c.req.path, so it matches the bytes the proxy signed.
         const url = new URL(c.req.url);
         const result = verifyProxyRequest({
@@ -420,7 +432,7 @@ function reject(
     c: Context,
     mode: ProxyGuardMode,
     next: Next,
-    reason: VerifyFailureReason | 'origin-not-allowed' | 'nonce-replay' | undefined,
+    reason: VerifyFailureReason | 'origin-not-allowed' | 'nonce-replay' | 'body-read-error' | undefined,
 )
 {
     if (mode === 'strict')

--- a/packages/core/src/middleware/proxy-guard.ts
+++ b/packages/core/src/middleware/proxy-guard.ts
@@ -94,11 +94,18 @@ export interface ProxyGuardConfig
      */
     allowedOrigins?: string[];
 
-    /** Optional Redis-backed nonce store for hard replay rejection. */
+    /** Optional Redis-backed nonce store for hard replay rejection (strict mode only). */
     nonceStore?: NonceStore;
 
     /** Paths to skip entirely (e.g. health checks). */
     skipPaths?: string[];
+
+    /**
+     * Reject (413) requests whose Content-Length exceeds this many bytes BEFORE
+     * buffering the body for hashing — bounds the per-request memory the guard
+     * adds. Undefined = no cap (default). Does not apply to multipart (unsigned).
+     */
+    maxBodyBytes?: number;
 }
 
 // ============================================================================
@@ -148,6 +155,30 @@ async function readRawBody(c: Context): Promise<string | undefined>
     }
 }
 
+/**
+ * Whether the request's declared Content-Length exceeds the cap. Checked before
+ * the body is read so the guard never buffers an oversized payload. Multipart is
+ * exempt (the guard doesn't hash it).
+ */
+function isBodyOverLimit(c: Context, maxBytes: number): boolean
+{
+    const method = c.req.method;
+    if (method === 'GET' || method === 'HEAD')
+    {
+        return false;
+    }
+
+    const contentType = c.req.header('content-type') || '';
+    if (contentType.includes('multipart/form-data'))
+    {
+        return false;
+    }
+
+    const len = Number(c.req.header('content-length'));
+
+    return Number.isFinite(len) && len > maxBytes;
+}
+
 function isOriginAllowed(c: Context, allowedOrigins: string[] | undefined): boolean
 {
     if (!allowedOrigins || allowedOrigins.length === 0)
@@ -187,6 +218,7 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
     const allowedOrigins = config.allowedOrigins;
     const nonceStore = config.nonceStore;
     const skipPaths = new Set(config.skipPaths ?? []);
+    const maxBodyBytes = config.maxBodyBytes;
 
     // Accepted key set: active secret first (wins on keyId collision), then grace keys.
     const activeRaw = config.secret ?? env.SPFN_PROXY_SECRET;
@@ -223,19 +255,27 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
 
     return async (c: Context, next: Next) =>
     {
-        // OPTIONS (CORS preflight) carries no signature and is non-mutating — never block it.
-        if (mode === 'off' || c.req.method === 'OPTIONS' || skipPaths.has(c.req.path))
+        if (mode === 'off' || skipPaths.has(c.req.path))
         {
             return next();
         }
 
-        // 1. Origin allowlist (browser cross-origin guard)
-        if (!isOriginAllowed(c, allowedOrigins))
+        // 1. Origin allowlist is a STRICT-mode gate. In tag mode we don't gate on it —
+        //    clientType is decided purely by the signature, so observe-only metrics
+        //    aren't skewed by a valid-but-cross-origin request.
+        if (mode === 'strict' && !isOriginAllowed(c, allowedOrigins))
         {
             return reject(c, mode, next, 'origin-not-allowed');
         }
 
-        // 2. No accepted key — only reachable in tag mode (strict throws at construction).
+        // 2. OPTIONS preflight carries no signature and is non-mutating — exempt from
+        //    the signature check (the origin gate above still applied in strict).
+        if (c.req.method === 'OPTIONS')
+        {
+            return next();
+        }
+
+        // 3. No accepted key — only reachable in tag mode (strict throws at construction).
         if (keys.length === 0)
         {
             c.set('clientType', 'untrusted');
@@ -243,7 +283,21 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return next();
         }
 
-        // 3. HMAC over the wire request-target (raw path + query) and body. Use the raw
+        // 4. Bound the memory the guard buffers for hashing: reject oversized bodies
+        //    BEFORE reading them (multipart is unsigned and exempt).
+        if (maxBodyBytes && isBodyOverLimit(c, maxBodyBytes))
+        {
+            if (mode === 'strict')
+            {
+                return c.json({ error: 'Payload Too Large' }, 413);
+            }
+
+            c.set('clientType', 'untrusted');
+
+            return next();
+        }
+
+        // 5. HMAC over the wire request-target (raw path + query) and body. Use the raw
         //    URL, NOT the decoded c.req.path, so it matches the bytes the proxy signed.
         const url = new URL(c.req.url);
         const body = await readRawBody(c);
@@ -265,13 +319,24 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return reject(c, mode, next, result.reason);
         }
 
-        // 4. Optional hard replay rejection via nonce store
-        if (nonceStore && result.nonce)
+        // 6. Hard replay rejection via nonce store — STRICT only (tag never blocks, so
+        //    the round-trip would be wasted). Degrade to the timestamp window if the
+        //    store is briefly unavailable rather than 500-ing valid traffic.
+        if (mode === 'strict' && nonceStore && result.nonce)
         {
-            const fresh = await nonceStore.checkAndSet(result.nonce, windowMs * 2);
-            if (!fresh)
+            try
             {
-                return reject(c, mode, next, 'nonce-replay');
+                const fresh = await nonceStore.checkAndSet(result.nonce, windowMs * 2);
+                if (!fresh)
+                {
+                    return reject(c, mode, next, 'nonce-replay');
+                }
+            }
+            catch (err)
+            {
+                guardLogger.warn('Nonce store unavailable — falling back to timestamp window', {
+                    error: (err as Error).message,
+                });
             }
         }
 

--- a/packages/core/src/middleware/proxy-guard.ts
+++ b/packages/core/src/middleware/proxy-guard.ts
@@ -126,10 +126,10 @@ declare module 'hono'
 // ============================================================================
 
 /** Sentinel: body exceeded maxBodyBytes while streaming (never fully buffered). */
-export const BODY_OVERSIZE = Symbol('proxy-guard:body-oversize');
+const BODY_OVERSIZE = Symbol('proxy-guard:body-oversize');
 
 /** Sentinel: the body stream errored mid-read (e.g. client abort). */
-export const BODY_READ_ERROR = Symbol('proxy-guard:body-read-error');
+const BODY_READ_ERROR = Symbol('proxy-guard:body-read-error');
 
 /**
  * Read the raw request body without consuming it for downstream handlers.

--- a/packages/core/src/middleware/proxy-guard.ts
+++ b/packages/core/src/middleware/proxy-guard.ts
@@ -286,11 +286,12 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return next();
         }
 
-        // OPTIONS preflight belongs to the CORS layer, not the signature guard. Exempt
-        // it FIRST (before the origin gate) so a cross-origin preflight isn't 403'd here
-        // without CORS headers. Tagged 'untrusted' (unsigned) so downstream that reads
-        // clientType never sees it unset nor treats a bare preflight as trusted.
-        if (c.req.method === 'OPTIONS')
+        // A genuine CORS preflight (OPTIONS + Access-Control-Request-Method) belongs to
+        // the CORS layer, not the signature guard — exempt it FIRST so it isn't 403'd
+        // here without CORS headers. A NON-preflight OPTIONS (rare OPTIONS-as-API) falls
+        // through to normal verification, so exempting preflight is never an unguarded
+        // bypass. Tagged 'untrusted' (unsigned) so downstream never sees it unset.
+        if (c.req.method === 'OPTIONS' && c.req.header('access-control-request-method'))
         {
             c.set('clientType', 'untrusted');
 

--- a/packages/core/src/middleware/proxy-guard.ts
+++ b/packages/core/src/middleware/proxy-guard.ts
@@ -101,9 +101,10 @@ export interface ProxyGuardConfig
     skipPaths?: string[];
 
     /**
-     * Reject (413) requests whose Content-Length exceeds this many bytes BEFORE
-     * buffering the body for hashing — bounds the per-request memory the guard
-     * adds. Undefined = no cap (default). Does not apply to multipart (unsigned).
+     * Reject (413) once the streamed body exceeds this many bytes. Measured AS IT
+     * STREAMS — Content-Length is NOT trusted, so a missing/chunked/under-reported
+     * length can't bypass it. Bounds the per-request memory the guard buffers.
+     * Undefined = no cap (default). Multipart is exempt (unsigned).
      */
     maxBodyBytes?: number;
 }
@@ -185,9 +186,15 @@ async function readRawBody(c: Context, maxBytes?: number): Promise<string | unde
             chunks.push(value);
         }
     }
-    catch
+    catch (err)
     {
-        return undefined;
+        // Don't swallow a mid-stream read error as an empty body — that would hash
+        // '' and 403 a validly-signed request as a phantom signature mismatch.
+        guardLogger.warn('Failed to read request body for signature verification', {
+            error: (err as Error).message,
+        });
+
+        throw err;
     }
 
     return Buffer.concat(chunks).toString('utf8');
@@ -285,11 +292,11 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
         }
 
         // 2. OPTIONS preflight carries no signature and is non-mutating — exempt from
-        //    the signature check (origin already checked). Tag it so downstream that
-        //    reads clientType never sees it unset.
+        //    the signature check (origin already checked). Tag 'untrusted' (it is
+        //    unsigned) so downstream never sees it unset NOR treats it as trusted.
         if (c.req.method === 'OPTIONS')
         {
-            c.set('clientType', 'web');
+            c.set('clientType', 'untrusted');
 
             return next();
         }
@@ -302,7 +309,19 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return next();
         }
 
-        // 4. Read body with a streaming size cap (Content-Length is never trusted, so a
+        // 4. Cheap header-presence check BEFORE buffering the body, so unsigned requests
+        //    (direct-to-backend attacks, tag-mode rollout traffic) reject/tag without
+        //    paying the body read.
+        const signature = c.req.header(PROXY_SIGNATURE_HEADER);
+        const timestamp = c.req.header(PROXY_TIMESTAMP_HEADER);
+        const nonce = c.req.header(PROXY_NONCE_HEADER);
+        const keyId = c.req.header(PROXY_KEY_ID_HEADER);
+        if (!signature || !timestamp || !nonce || !keyId)
+        {
+            return reject(c, mode, next, 'missing-headers');
+        }
+
+        // 5. Read body with a streaming size cap (Content-Length is never trusted, so a
         //    missing/chunked/under-reported length can't bypass the bound).
         const body = await readRawBody(c, maxBodyBytes);
         if (body === BODY_OVERSIZE)
@@ -317,7 +336,7 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return next();
         }
 
-        // 5. HMAC over the wire request-target (raw path + query) and body. Use the raw
+        // 6. HMAC over the wire request-target (raw path + query) and body. Use the raw
         //    URL, NOT the decoded c.req.path, so it matches the bytes the proxy signed.
         const url = new URL(c.req.url);
         const result = verifyProxyRequest({
@@ -326,10 +345,10 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             path: url.pathname,
             query: url.search,
             body,
-            signature: c.req.header(PROXY_SIGNATURE_HEADER),
-            timestamp: c.req.header(PROXY_TIMESTAMP_HEADER),
-            nonce: c.req.header(PROXY_NONCE_HEADER),
-            keyId: c.req.header(PROXY_KEY_ID_HEADER),
+            signature,
+            timestamp,
+            nonce,
+            keyId,
             windowMs,
         });
 

--- a/packages/core/src/middleware/proxy-guard.ts
+++ b/packages/core/src/middleware/proxy-guard.ts
@@ -21,6 +21,7 @@ import { logger } from '@spfn/core/logger';
 
 import {
     verifyProxyRequest,
+    parseProxyKey,
     parseProxyKeySet,
     PROXY_SIGNATURE_HEADER,
     PROXY_TIMESTAMP_HEADER,
@@ -117,11 +118,13 @@ declare module 'hono'
 // ============================================================================
 
 /**
- * Read the raw JSON body without consuming it for downstream handlers.
- * Returns undefined for non-JSON (GET, multipart uploads) — matching the proxy,
- * which excludes those from the signature.
+ * Read the raw request body without consuming it for downstream handlers.
+ * Bound for ANY non-multipart content-type (not just application/json) so the
+ * backend hashes exactly what the proxy signed — otherwise the body could be
+ * tampered by flipping content-type. Multipart uploads are excluded on both
+ * sides (their large bodies are never hashed).
  */
-async function readJsonBody(c: Context): Promise<string | undefined>
+async function readRawBody(c: Context): Promise<string | undefined>
 {
     const method = c.req.method;
     if (method === 'GET' || method === 'HEAD')
@@ -130,7 +133,7 @@ async function readJsonBody(c: Context): Promise<string | undefined>
     }
 
     const contentType = c.req.header('content-type') || '';
-    if (!contentType.includes('application/json'))
+    if (contentType.includes('multipart/form-data'))
     {
         return undefined;
     }
@@ -186,14 +189,42 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
     const skipPaths = new Set(config.skipPaths ?? []);
 
     // Accepted key set: active secret first (wins on keyId collision), then grace keys.
-    const keys = parseProxyKeySet([
-        config.secret ?? env.SPFN_PROXY_SECRET,
-        config.previousSecrets ?? env.SPFN_PROXY_SECRET_PREVIOUS,
-    ]);
+    const activeRaw = config.secret ?? env.SPFN_PROXY_SECRET;
+    const previousRaw = config.previousSecrets ?? env.SPFN_PROXY_SECRET_PREVIOUS;
+    const keys = parseProxyKeySet([activeRaw, previousRaw]);
+
+    // Fail CLOSED on misconfiguration: strict with no key would otherwise let every
+    // request (including direct-to-backend) through. Refuse to start instead.
+    if (mode === 'strict' && keys.length === 0)
+    {
+        throw new Error(
+            '[proxy-guard] mode "strict" requires a proxy key but none is configured '
+            + '(SPFN_PROXY_SECRET is empty/unset). Refusing to start with the guard open — '
+            + 'set the secret, or use mode "tag" / "off".',
+        );
+    }
+
+    // Warn when rotation can't work: bare secrets (no "keyId:" prefix) on both active
+    // and previous collapse to the same keyId, so the grace key is silently dropped.
+    if (activeRaw && previousRaw)
+    {
+        const activeId = parseProxyKey(activeRaw).keyId;
+        const collides = previousRaw.split(',').some(p => p.trim() && parseProxyKey(p.trim()).keyId === activeId);
+        if (collides)
+        {
+            guardLogger.warn(
+                'Previous proxy key shares keyId with the active key (likely bare secrets without a '
+                + '"keyId:" prefix) — grace key ignored, rotation will drop in-flight requests. '
+                + 'Use "<keyId>:<secret>" on both keys.',
+                { keyId: activeId },
+            );
+        }
+    }
 
     return async (c: Context, next: Next) =>
     {
-        if (mode === 'off' || skipPaths.has(c.req.path))
+        // OPTIONS (CORS preflight) carries no signature and is non-mutating — never block it.
+        if (mode === 'off' || c.req.method === 'OPTIONS' || skipPaths.has(c.req.path))
         {
             return next();
         }
@@ -204,7 +235,7 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return reject(c, mode, next, 'origin-not-allowed');
         }
 
-        // 2. Without any accepted key we cannot verify a signature — tag and move on.
+        // 2. No accepted key — only reachable in tag mode (strict throws at construction).
         if (keys.length === 0)
         {
             c.set('clientType', 'untrusted');
@@ -212,12 +243,15 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return next();
         }
 
-        // 3. HMAC signature
-        const body = await readJsonBody(c);
+        // 3. HMAC over the wire request-target (raw path + query) and body. Use the raw
+        //    URL, NOT the decoded c.req.path, so it matches the bytes the proxy signed.
+        const url = new URL(c.req.url);
+        const body = await readRawBody(c);
         const result = verifyProxyRequest({
             keys,
             method: c.req.method,
-            path: c.req.path,
+            path: url.pathname,
+            query: url.search,
             body,
             signature: c.req.header(PROXY_SIGNATURE_HEADER),
             timestamp: c.req.header(PROXY_TIMESTAMP_HEADER),

--- a/packages/core/src/middleware/proxy-guard.ts
+++ b/packages/core/src/middleware/proxy-guard.ts
@@ -124,14 +124,21 @@ declare module 'hono'
 // Helpers
 // ============================================================================
 
+/** Sentinel: body exceeded maxBodyBytes while streaming (never fully buffered). */
+export const BODY_OVERSIZE = Symbol('proxy-guard:body-oversize');
+
 /**
  * Read the raw request body without consuming it for downstream handlers.
  * Bound for ANY non-multipart content-type (not just application/json) so the
  * backend hashes exactly what the proxy signed — otherwise the body could be
  * tampered by flipping content-type. Multipart uploads are excluded on both
  * sides (their large bodies are never hashed).
+ *
+ * When maxBytes is set the body is measured AS IT STREAMS and aborted past the
+ * limit — so a missing/chunked/under-reported Content-Length can't bypass the cap
+ * (the header is never trusted). Returns BODY_OVERSIZE in that case.
  */
-async function readRawBody(c: Context): Promise<string | undefined>
+async function readRawBody(c: Context, maxBytes?: number): Promise<string | undefined | typeof BODY_OVERSIZE>
 {
     const method = c.req.method;
     if (method === 'GET' || method === 'HEAD')
@@ -145,38 +152,45 @@ async function readRawBody(c: Context): Promise<string | undefined>
         return undefined;
     }
 
+    const stream = c.req.raw.clone().body;
+    if (!stream)
+    {
+        return undefined;
+    }
+
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+
     try
     {
-        return await c.req.raw.clone().text();
+        for (;;)
+        {
+            const { done, value } = await reader.read();
+            if (done)
+            {
+                break;
+            }
+
+            total += value.byteLength;
+            if (maxBytes !== undefined && total > maxBytes)
+            {
+                // Fire-and-forget: awaiting cancel() can hang under some stream
+                // implementations, and this is a clone so the original is untouched.
+                void reader.cancel().catch(() => undefined);
+
+                return BODY_OVERSIZE;
+            }
+
+            chunks.push(value);
+        }
     }
     catch
     {
         return undefined;
     }
-}
 
-/**
- * Whether the request's declared Content-Length exceeds the cap. Checked before
- * the body is read so the guard never buffers an oversized payload. Multipart is
- * exempt (the guard doesn't hash it).
- */
-function isBodyOverLimit(c: Context, maxBytes: number): boolean
-{
-    const method = c.req.method;
-    if (method === 'GET' || method === 'HEAD')
-    {
-        return false;
-    }
-
-    const contentType = c.req.header('content-type') || '';
-    if (contentType.includes('multipart/form-data'))
-    {
-        return false;
-    }
-
-    const len = Number(c.req.header('content-length'));
-
-    return Number.isFinite(len) && len > maxBytes;
+    return Buffer.concat(chunks).toString('utf8');
 }
 
 function isOriginAllowed(c: Context, allowedOrigins: string[] | undefined): boolean
@@ -260,18 +274,23 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return next();
         }
 
-        // 1. Origin allowlist is a STRICT-mode gate. In tag mode we don't gate on it —
-        //    clientType is decided purely by the signature, so observe-only metrics
-        //    aren't skewed by a valid-but-cross-origin request.
-        if (mode === 'strict' && !isOriginAllowed(c, allowedOrigins))
+        // Every gate below is EVALUATED in both modes; only enforcement differs
+        // (reject() = 403 in strict, tag clientType='untrusted' + continue in tag).
+        // So tag mode observes exactly what strict would reject — no metric skew.
+
+        // 1. Origin allowlist (browser cross-origin guard)
+        if (!isOriginAllowed(c, allowedOrigins))
         {
             return reject(c, mode, next, 'origin-not-allowed');
         }
 
         // 2. OPTIONS preflight carries no signature and is non-mutating — exempt from
-        //    the signature check (the origin gate above still applied in strict).
+        //    the signature check (origin already checked). Tag it so downstream that
+        //    reads clientType never sees it unset.
         if (c.req.method === 'OPTIONS')
         {
+            c.set('clientType', 'web');
+
             return next();
         }
 
@@ -283,9 +302,10 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return next();
         }
 
-        // 4. Bound the memory the guard buffers for hashing: reject oversized bodies
-        //    BEFORE reading them (multipart is unsigned and exempt).
-        if (maxBodyBytes && isBodyOverLimit(c, maxBodyBytes))
+        // 4. Read body with a streaming size cap (Content-Length is never trusted, so a
+        //    missing/chunked/under-reported length can't bypass the bound).
+        const body = await readRawBody(c, maxBodyBytes);
+        if (body === BODY_OVERSIZE)
         {
             if (mode === 'strict')
             {
@@ -300,7 +320,6 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
         // 5. HMAC over the wire request-target (raw path + query) and body. Use the raw
         //    URL, NOT the decoded c.req.path, so it matches the bytes the proxy signed.
         const url = new URL(c.req.url);
-        const body = await readRawBody(c);
         const result = verifyProxyRequest({
             keys,
             method: c.req.method,
@@ -319,10 +338,10 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             return reject(c, mode, next, result.reason);
         }
 
-        // 6. Hard replay rejection via nonce store — STRICT only (tag never blocks, so
-        //    the round-trip would be wasted). Degrade to the timestamp window if the
-        //    store is briefly unavailable rather than 500-ing valid traffic.
-        if (mode === 'strict' && nonceStore && result.nonce)
+        // 6. Hard replay rejection via nonce store (both modes — tag observes replays).
+        //    Degrade to the timestamp window if the store is briefly unavailable rather
+        //    than 500-ing valid traffic.
+        if (nonceStore && result.nonce)
         {
             try
             {

--- a/packages/core/src/nextjs/proxy/helpers.ts
+++ b/packages/core/src/nextjs/proxy/helpers.ts
@@ -32,6 +32,9 @@ export function buildProxyHeaders(
         'user-agent',
         'accept',
         'accept-language',
+        // Forwarded so the backend proxy-guard can enforce its origin allowlist on
+        // the real browser Origin; without this allowedOrigins would be a no-op.
+        'origin',
     ];
 
     for (const header of headersToForward)

--- a/packages/core/src/nextjs/proxy/rpc.ts
+++ b/packages/core/src/nextjs/proxy/rpc.ts
@@ -23,7 +23,7 @@ import { env } from '@spfn/core/config';
 import { logger } from '@spfn/core/logger';
 import type { HttpMethod } from '@spfn/core/route';
 
-import { signProxyRequest, parseProxyKey } from '../../security/proxy-signature';
+import { signProxyRequest, parseProxyKeySet } from '../../security/proxy-signature';
 import { buildUrlWithParams, buildQueryString } from '../shared';
 import { interceptorRegistry } from './interceptors';
 import { executeRequestInterceptors, executeResponseInterceptors, filterMatchingInterceptors } from './interceptors';
@@ -124,7 +124,9 @@ export function createRpcProxy(config: RpcProxyConfig)
     } = config;
 
     // Parse the active signing key once — it's fixed for the proxy's lifetime.
-    const proxyKey = proxySecret ? parseProxyKey(proxySecret) : null;
+    // Use the SAME parser the backend uses (comma key set) and take the active key,
+    // so a `v2:new,v1:old` secret is interpreted identically on both sides.
+    const proxyKey = proxySecret ? (parseProxyKeySet([proxySecret])[0] ?? null) : null;
 
     /**
      * Resolve route info from routeMap
@@ -393,15 +395,15 @@ export function createRpcProxy(config: RpcProxyConfig)
             if (proxyKey)
             {
                 const signedBody = typeof fetchOptions.body === 'string' ? fetchOptions.body : undefined;
-                // Sign the FINAL target URL (parsed), so any base-path prefix in
-                // SPFN_API_URL is included exactly as the backend sees it via
-                // new URL(c.req.url).pathname/.search.
-                const signedUrl = new URL(targetUrl);
+                // Sign the route-relative path (no SPFN_API_URL base prefix) so it
+                // matches the backend's `new URL(c.req.url).pathname` whether the
+                // prefix is absent or stripped by an ingress. resolvedPath is already
+                // the percent-encoded wire form; queryString is the raw search.
                 const signatureHeaders = signProxyRequest({
                     key: proxyKey,
                     method: targetMethod,
-                    path: signedUrl.pathname,
-                    query: signedUrl.search,
+                    path: resolvedPath,
+                    query: queryString,
                     body: signedBody,
                 });
 

--- a/packages/core/src/nextjs/proxy/rpc.ts
+++ b/packages/core/src/nextjs/proxy/rpc.ts
@@ -23,6 +23,7 @@ import { env } from '@spfn/core/config';
 import { logger } from '@spfn/core/logger';
 import type { HttpMethod } from '@spfn/core/route';
 
+import { signProxyRequest, parseProxyKey } from '../../security/proxy-signature';
 import { buildUrlWithParams, buildQueryString } from '../shared';
 import { interceptorRegistry } from './interceptors';
 import { executeRequestInterceptors, executeResponseInterceptors, filterMatchingInterceptors } from './interceptors';
@@ -81,6 +82,17 @@ export interface RpcProxyConfig extends Omit<TypedProxyConfig, 'onRequest' | 'on
      * ```
      */
     routeMap: RouteMap;
+
+    /**
+     * Shared secret for signing proxy→backend requests (HMAC-SHA256).
+     *
+     * When set, every forwarded request carries an HMAC signature the backend's
+     * proxy-guard middleware verifies, letting it reject direct-to-backend calls
+     * that bypass this proxy. Set the SAME value here and on the backend.
+     *
+     * @default process.env.SPFN_PROXY_SECRET (undefined → signing disabled)
+     */
+    proxySecret?: string;
 }
 
 // ============================================================================
@@ -107,6 +119,7 @@ export function createRpcProxy(config: RpcProxyConfig)
         interceptors,
         autoDiscoverInterceptors = true,
         disableAutoInterceptors,
+        proxySecret = env.SPFN_PROXY_SECRET,
         routeMap,
     } = config;
 
@@ -365,6 +378,28 @@ export function createRpcProxy(config: RpcProxyConfig)
                 if (requestCtx.body)
                 {
                     fetchOptions.body = JSON.stringify(requestCtx.body);
+                }
+            }
+
+            // ============================================================
+            // Proxy → Backend signature (proxy-guard)
+            // ============================================================
+            // Sign the FINAL request (after interceptors settled body/headers) so
+            // the backend can prove it came through this trusted proxy. JSON body
+            // is hashed into the signature; large multipart uploads are excluded.
+            if (proxySecret)
+            {
+                const signedBody = typeof fetchOptions.body === 'string' ? fetchOptions.body : undefined;
+                const signatureHeaders = signProxyRequest({
+                    key: parseProxyKey(proxySecret),
+                    method: targetMethod,
+                    path: resolvedPath,
+                    body: signedBody,
+                });
+
+                for (const [headerName, value] of Object.entries(signatureHeaders))
+                {
+                    headers.set(headerName, value);
                 }
             }
 

--- a/packages/core/src/nextjs/proxy/rpc.ts
+++ b/packages/core/src/nextjs/proxy/rpc.ts
@@ -123,6 +123,9 @@ export function createRpcProxy(config: RpcProxyConfig)
         routeMap,
     } = config;
 
+    // Parse the active signing key once — it's fixed for the proxy's lifetime.
+    const proxyKey = proxySecret ? parseProxyKey(proxySecret) : null;
+
     /**
      * Resolve route info from routeMap
      */
@@ -387,13 +390,18 @@ export function createRpcProxy(config: RpcProxyConfig)
             // Sign the FINAL request (after interceptors settled body/headers) so
             // the backend can prove it came through this trusted proxy. JSON body
             // is hashed into the signature; large multipart uploads are excluded.
-            if (proxySecret)
+            if (proxyKey)
             {
                 const signedBody = typeof fetchOptions.body === 'string' ? fetchOptions.body : undefined;
+                // Sign the FINAL target URL (parsed), so any base-path prefix in
+                // SPFN_API_URL is included exactly as the backend sees it via
+                // new URL(c.req.url).pathname/.search.
+                const signedUrl = new URL(targetUrl);
                 const signatureHeaders = signProxyRequest({
-                    key: parseProxyKey(proxySecret),
+                    key: proxyKey,
                     method: targetMethod,
-                    path: resolvedPath,
+                    path: signedUrl.pathname,
+                    query: signedUrl.search,
                     body: signedBody,
                 });
 

--- a/packages/core/src/nextjs/proxy/rpc.ts
+++ b/packages/core/src/nextjs/proxy/rpc.ts
@@ -128,6 +128,29 @@ export function createRpcProxy(config: RpcProxyConfig)
     // so a `v2:new,v1:old` secret is interpreted identically on both sides.
     const proxyKey = proxySecret ? (parseProxyKeySet([proxySecret])[0] ?? null) : null;
 
+    // proxy-guard signs route-relative paths; if SPFN_API_URL carries a base path the
+    // backend keeps (no ingress strip), the signed path won't match c.req.url and
+    // strict mode 403s everything. Warn loudly so it's diagnosable.
+    if (proxyKey)
+    {
+        try
+        {
+            const basePath = new URL(apiUrl).pathname;
+            if (basePath !== '/' && basePath !== '')
+            {
+                rpcLogger.warn(
+                    `SPFN_API_URL has a base path ("${basePath}"). proxy-guard signs route-relative paths, `
+                    + 'so the backend must receive paths WITHOUT this prefix (e.g. ingress strip) or strict '
+                    + 'mode will reject all signed requests with 403.',
+                );
+            }
+        }
+        catch
+        {
+            // invalid apiUrl is surfaced elsewhere
+        }
+    }
+
     /**
      * Resolve route info from routeMap
      */

--- a/packages/core/src/security/__tests__/proxy-signature.test.ts
+++ b/packages/core/src/security/__tests__/proxy-signature.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Proxy signature (HMAC) + key rotation 테스트
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+    signProxyRequest,
+    verifyProxyRequest,
+    parseProxyKey,
+    parseProxyKeySet,
+    DEFAULT_KEY_ID,
+    PROXY_SIGNATURE_HEADER,
+    PROXY_TIMESTAMP_HEADER,
+    PROXY_NONCE_HEADER,
+    PROXY_KEY_ID_HEADER,
+    type ProxyKey,
+} from '../proxy-signature';
+
+const KEY: ProxyKey = { keyId: 'v1', secret: 'test-shared-secret-please-rotate' };
+
+function sign(opts: { key?: ProxyKey; method: string; path: string; body?: string; timestamp?: string })
+{
+    return signProxyRequest({ key: opts.key ?? KEY, ...opts });
+}
+
+describe('proxy-signature', () =>
+{
+    describe('key parsing', () =>
+    {
+        it('parses <keyId>:<secret>', () =>
+        {
+            expect(parseProxyKey('v2:abc123')).toEqual({ keyId: 'v2', secret: 'abc123' });
+        });
+
+        it('keeps colons inside the secret', () =>
+        {
+            expect(parseProxyKey('v2:ab:cd')).toEqual({ keyId: 'v2', secret: 'ab:cd' });
+        });
+
+        it('falls back to DEFAULT_KEY_ID for a bare secret', () =>
+        {
+            expect(parseProxyKey('abc123')).toEqual({ keyId: DEFAULT_KEY_ID, secret: 'abc123' });
+        });
+
+        it('builds a key set, active wins on keyId collision, skips blanks', () =>
+        {
+            const keys = parseProxyKeySet(['v2:new', 'v1:old, v0:older', undefined, '', 'v2:dupe']);
+            expect(keys).toEqual([
+                { keyId: 'v2', secret: 'new' },
+                { keyId: 'v1', secret: 'old' },
+                { keyId: 'v0', secret: 'older' },
+            ]);
+        });
+    });
+
+    describe('sign → verify round-trip', () =>
+    {
+        it('verifies a signed POST with JSON body', () =>
+        {
+            const body = JSON.stringify({ name: 'Ray' });
+            const headers = sign({ method: 'POST', path: '/users', body });
+
+            const result = verifyProxyRequest({
+                keys: [KEY],
+                method: 'POST',
+                path: '/users',
+                body,
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: headers[PROXY_TIMESTAMP_HEADER],
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+            });
+
+            expect(result.valid).toBe(true);
+            expect(result.nonce).toBe(headers[PROXY_NONCE_HEADER]);
+            expect(result.keyId).toBe('v1');
+        });
+
+        it('verifies a signed GET with no body', () =>
+        {
+            const headers = sign({ method: 'GET', path: '/users/123' });
+
+            const result = verifyProxyRequest({
+                keys: [KEY],
+                method: 'GET',
+                path: '/users/123',
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: headers[PROXY_TIMESTAMP_HEADER],
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+            });
+
+            expect(result.valid).toBe(true);
+        });
+    });
+
+    describe('key rotation', () =>
+    {
+        const oldKey: ProxyKey = { keyId: 'v1', secret: 'old-secret' };
+        const newKey: ProxyKey = { keyId: 'v2', secret: 'new-secret' };
+        // Backend accepts both during the grace window
+        const keySet = [newKey, oldKey];
+
+        it('accepts a request signed with the new active key', () =>
+        {
+            const headers = sign({ key: newKey, method: 'GET', path: '/ping' });
+            const result = verifyProxyRequest({
+                keys: keySet,
+                method: 'GET',
+                path: '/ping',
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: headers[PROXY_TIMESTAMP_HEADER],
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+            });
+
+            expect(result.valid).toBe(true);
+            expect(result.keyId).toBe('v2');
+        });
+
+        it('still accepts a request signed with the previous (grace) key', () =>
+        {
+            const headers = sign({ key: oldKey, method: 'GET', path: '/ping' });
+            const result = verifyProxyRequest({
+                keys: keySet,
+                method: 'GET',
+                path: '/ping',
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: headers[PROXY_TIMESTAMP_HEADER],
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+            });
+
+            expect(result.valid).toBe(true);
+            expect(result.keyId).toBe('v1');
+        });
+
+        it('rejects a key that has been retired from the set', () =>
+        {
+            const retired: ProxyKey = { keyId: 'v0', secret: 'retired-secret' };
+            const headers = sign({ key: retired, method: 'GET', path: '/ping' });
+            const result = verifyProxyRequest({
+                keys: keySet,
+                method: 'GET',
+                path: '/ping',
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: headers[PROXY_TIMESTAMP_HEADER],
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+            });
+
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('unknown-key');
+        });
+
+        it('rejects a matching keyId whose secret was rotated underneath it', () =>
+        {
+            // Attacker replays v2 keyId but signed with a stale/guessed secret
+            const headers = sign({ key: { keyId: 'v2', secret: 'wrong-secret' }, method: 'GET', path: '/ping' });
+            const result = verifyProxyRequest({
+                keys: keySet,
+                method: 'GET',
+                path: '/ping',
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: headers[PROXY_TIMESTAMP_HEADER],
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+            });
+
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('signature-mismatch');
+        });
+    });
+
+    describe('tamper detection', () =>
+    {
+        const body = JSON.stringify({ amount: 100 });
+        const headers = sign({ method: 'POST', path: '/transfer', body });
+
+        const base = {
+            keys: [KEY],
+            signature: headers[PROXY_SIGNATURE_HEADER],
+            timestamp: headers[PROXY_TIMESTAMP_HEADER],
+            nonce: headers[PROXY_NONCE_HEADER],
+            keyId: headers[PROXY_KEY_ID_HEADER],
+        };
+
+        it('rejects a tampered body', () =>
+        {
+            const result = verifyProxyRequest({
+                ...base,
+                method: 'POST',
+                path: '/transfer',
+                body: JSON.stringify({ amount: 999999 }),
+            });
+
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('signature-mismatch');
+        });
+
+        it('rejects a swapped path', () =>
+        {
+            const result = verifyProxyRequest({ ...base, method: 'POST', path: '/admin/transfer', body });
+
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('signature-mismatch');
+        });
+
+        it('rejects a swapped method', () =>
+        {
+            const result = verifyProxyRequest({ ...base, method: 'DELETE', path: '/transfer', body });
+
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('signature-mismatch');
+        });
+    });
+
+    describe('timestamp window', () =>
+    {
+        it('rejects a stale timestamp (replay outside window)', () =>
+        {
+            const oldTs = String(1_000_000);
+            const headers = sign({ method: 'GET', path: '/ping', timestamp: oldTs });
+
+            const result = verifyProxyRequest({
+                keys: [KEY],
+                method: 'GET',
+                path: '/ping',
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: oldTs,
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+                now: 1_000_000 + 60_000,
+                windowMs: 30_000,
+            });
+
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('stale-timestamp');
+        });
+    });
+
+    describe('missing headers', () =>
+    {
+        it('rejects when signature/timestamp/nonce/keyId are absent', () =>
+        {
+            const result = verifyProxyRequest({
+                keys: [KEY],
+                method: 'GET',
+                path: '/ping',
+                signature: undefined,
+                timestamp: undefined,
+                nonce: undefined,
+                keyId: undefined,
+            });
+
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('missing-headers');
+        });
+    });
+});

--- a/packages/core/src/security/__tests__/proxy-signature.test.ts
+++ b/packages/core/src/security/__tests__/proxy-signature.test.ts
@@ -19,7 +19,7 @@ import {
 
 const KEY: ProxyKey = { keyId: 'v1', secret: 'test-shared-secret-please-rotate' };
 
-function sign(opts: { key?: ProxyKey; method: string; path: string; body?: string; timestamp?: string })
+function sign(opts: { key?: ProxyKey; method: string; path: string; query?: string; body?: string; timestamp?: string })
 {
     return signProxyRequest({ key: opts.key ?? KEY, ...opts });
 }
@@ -213,6 +213,60 @@ describe('proxy-signature', () =>
 
             expect(result.valid).toBe(false);
             expect(result.reason).toBe('signature-mismatch');
+        });
+    });
+
+    describe('query + encoded path binding', () =>
+    {
+        it('verifies a matching query string', () =>
+        {
+            const headers = sign({ method: 'GET', path: '/users', query: '?limit=10&page=2' });
+            const result = verifyProxyRequest({
+                keys: [KEY],
+                method: 'GET',
+                path: '/users',
+                query: '?limit=10&page=2',
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: headers[PROXY_TIMESTAMP_HEADER],
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+            });
+
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects an altered query param', () =>
+        {
+            const headers = sign({ method: 'GET', path: '/users', query: '?limit=10' });
+            const result = verifyProxyRequest({
+                keys: [KEY],
+                method: 'GET',
+                path: '/users',
+                query: '?limit=99999',
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: headers[PROXY_TIMESTAMP_HEADER],
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+            });
+
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('signature-mismatch');
+        });
+
+        it('verifies a percent-encoded path verbatim (no decode drift)', () =>
+        {
+            const headers = sign({ method: 'GET', path: '/files/a%2Fb' });
+            const result = verifyProxyRequest({
+                keys: [KEY],
+                method: 'GET',
+                path: '/files/a%2Fb',
+                signature: headers[PROXY_SIGNATURE_HEADER],
+                timestamp: headers[PROXY_TIMESTAMP_HEADER],
+                nonce: headers[PROXY_NONCE_HEADER],
+                keyId: headers[PROXY_KEY_ID_HEADER],
+            });
+
+            expect(result.valid).toBe(true);
         });
     });
 

--- a/packages/core/src/security/__tests__/proxy-signature.test.ts
+++ b/packages/core/src/security/__tests__/proxy-signature.test.ts
@@ -52,6 +52,13 @@ describe('proxy-signature', () =>
                 { keyId: 'v0', secret: 'older' },
             ]);
         });
+
+        it('exposes the active key as [0] for a comma key set (proxy parity)', () =>
+        {
+            // The proxy signs with parseProxyKeySet([secret])[0]; it MUST match the
+            // active key the backend selects from the same env var.
+            expect(parseProxyKeySet(['v2:new,v1:old'])[0]).toEqual({ keyId: 'v2', secret: 'new' });
+        });
     });
 
     describe('sign → verify round-trip', () =>

--- a/packages/core/src/security/__tests__/proxy-signature.test.ts
+++ b/packages/core/src/security/__tests__/proxy-signature.test.ts
@@ -43,6 +43,11 @@ describe('proxy-signature', () =>
             expect(parseProxyKey('abc123')).toEqual({ keyId: DEFAULT_KEY_ID, secret: 'abc123' });
         });
 
+        it('normalizes a leading-colon secret to DEFAULT_KEY_ID (empty keyId footgun)', () =>
+        {
+            expect(parseProxyKey(':mysecret')).toEqual({ keyId: DEFAULT_KEY_ID, secret: 'mysecret' });
+        });
+
         it('builds a key set, active wins on keyId collision, skips blanks', () =>
         {
             const keys = parseProxyKeySet(['v2:new', 'v1:old, v0:older', undefined, '', 'v2:dupe']);

--- a/packages/core/src/security/proxy-signature.ts
+++ b/packages/core/src/security/proxy-signature.ts
@@ -167,16 +167,21 @@ export function buildCanonicalString(parts: SignatureParts): string
 }
 
 /**
- * Hash a JSON body string. Returns '' for undefined/empty (no-body requests).
+ * Hash a request body. Accepts a string (proxy side, from JSON.stringify) or a
+ * Buffer (backend side, straight from the stream — avoids a bytes→string→bytes
+ * round-trip). Returns '' for empty/no body. A utf8 string and its Buffer hash
+ * identically, so both sides agree.
  */
-export function hashBody(body: string | undefined | null): string
+export function hashBody(body: string | Buffer | undefined | null): string
 {
-    if (!body)
+    if (!body || body.length === 0)
     {
         return '';
     }
 
-    return createHash('sha256').update(body, 'utf8').digest('hex');
+    return typeof body === 'string'
+        ? createHash('sha256').update(body, 'utf8').digest('hex')
+        : createHash('sha256').update(body).digest('hex');
 }
 
 /**
@@ -252,6 +257,9 @@ export type VerifyFailureReason =
     | 'unknown-key'
     | 'signature-mismatch';
 
+// ('body-read-error' / 'origin-not-allowed' / 'nonce-replay' are guard-level
+//  reasons carried separately by the middleware, not produced by verify itself.)
+
 export interface VerifyResult
 {
     valid: boolean;
@@ -271,8 +279,8 @@ export interface VerifyInput
     path: string;
     /** Raw (wire) query string from `new URL(c.req.url).search`, or '' for none. */
     query?: string;
-    /** Raw request body string as received, if any. */
-    body?: string | null;
+    /** Raw request body (string or Buffer) as received, if any. */
+    body?: string | Buffer | null;
     signature: string | null | undefined;
     timestamp: string | null | undefined;
     nonce: string | null | undefined;

--- a/packages/core/src/security/proxy-signature.ts
+++ b/packages/core/src/security/proxy-signature.ts
@@ -1,0 +1,341 @@
+/**
+ * Proxy → Backend request signing (HMAC-SHA256) with key rotation
+ *
+ * Shared between the Next.js RPC proxy (which signs outbound requests) and the
+ * backend proxy-guard middleware (which verifies them). Keeping the canonical
+ * string and HMAC logic in one pure module guarantees both sides agree.
+ *
+ * The signature proves a request passed through a trusted proxy that holds the
+ * shared secret. It does NOT authenticate the end user — that is the JWT layer's
+ * job — and it cannot stop a client from calling the proxy itself. Its role is to
+ * stop direct-to-backend calls that bypass the proxy.
+ *
+ * Keys are identified by a short keyId so secrets can be rotated without downtime:
+ * the proxy signs with the active key and stamps its keyId in a header; the
+ * backend keeps a set of accepted keys (current + previous) and selects by keyId.
+ * Roll a new key in, let both sides pick it up, switch the proxy to it, then drop
+ * the old one after a grace period — no request is ever rejected mid-rotation.
+ *
+ * @module security/proxy-signature
+ */
+import { createHmac, randomBytes, timingSafeEqual, createHash } from 'node:crypto';
+
+// ============================================================================
+// Header names
+// ============================================================================
+
+export const PROXY_SIGNATURE_HEADER = 'x-spfn-proxy-signature';
+export const PROXY_TIMESTAMP_HEADER = 'x-spfn-proxy-timestamp';
+export const PROXY_NONCE_HEADER = 'x-spfn-proxy-nonce';
+export const PROXY_KEY_ID_HEADER = 'x-spfn-proxy-key-id';
+
+/** keyId used when a raw secret carries no `keyId:` prefix (back-compat). */
+export const DEFAULT_KEY_ID = 'default';
+
+// ============================================================================
+// Keys
+// ============================================================================
+
+/**
+ * A signing key: a short identifier plus its secret. Encoded in env as
+ * `<keyId>:<secret>` (e.g. `v2:9f3c...`); a bare secret gets `DEFAULT_KEY_ID`.
+ */
+export interface ProxyKey
+{
+    keyId: string;
+    secret: string;
+}
+
+/**
+ * Parse one `<keyId>:<secret>` (or bare `<secret>`) string into a ProxyKey.
+ * keyId is everything before the FIRST colon; the secret keeps any later colons.
+ */
+export function parseProxyKey(raw: string): ProxyKey
+{
+    const idx = raw.indexOf(':');
+    if (idx === -1)
+    {
+        return { keyId: DEFAULT_KEY_ID, secret: raw };
+    }
+
+    return { keyId: raw.slice(0, idx), secret: raw.slice(idx + 1) };
+}
+
+/**
+ * Build the backend's accepted key set from raw env values. Each input may be a
+ * single key or a comma-separated list (for multiple grace keys). Earlier inputs
+ * win on keyId collision, so pass the active secret first.
+ */
+export function parseProxyKeySet(raws: Array<string | undefined | null>): ProxyKey[]
+{
+    const keys: ProxyKey[] = [];
+    const seen = new Set<string>();
+
+    for (const raw of raws)
+    {
+        if (!raw)
+        {
+            continue;
+        }
+
+        for (const part of raw.split(','))
+        {
+            const trimmed = part.trim();
+            if (!trimmed)
+            {
+                continue;
+            }
+
+            const key = parseProxyKey(trimmed);
+            if (!key.secret || seen.has(key.keyId))
+            {
+                continue;
+            }
+
+            seen.add(key.keyId);
+            keys.push(key);
+        }
+    }
+
+    return keys;
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * The parts of a request that are bound into the signature.
+ */
+export interface SignatureParts
+{
+    /** Resolved backend HTTP method (GET/POST/PUT/...) */
+    method: string;
+
+    /** Resolved backend path including leading slash, WITHOUT query string */
+    path: string;
+
+    /** Unix epoch milliseconds, as a string */
+    timestamp: string;
+
+    /** Random per-request nonce */
+    nonce: string;
+
+    /**
+     * SHA-256 hex of the raw JSON body, or empty string when there is no JSON
+     * body (GET requests, or large multipart uploads which are excluded by design).
+     */
+    bodyHash: string;
+}
+
+/**
+ * Headers produced by signing — ready to set on the outbound fetch.
+ */
+export interface SignatureHeaders
+{
+    [PROXY_SIGNATURE_HEADER]: string;
+    [PROXY_TIMESTAMP_HEADER]: string;
+    [PROXY_NONCE_HEADER]: string;
+    [PROXY_KEY_ID_HEADER]: string;
+}
+
+// ============================================================================
+// Canonical string + HMAC
+// ============================================================================
+
+/**
+ * Build the canonical string that gets signed. Field order is fixed and each
+ * field is newline-separated, so a captured signature cannot be replayed against
+ * a different method, path, or body.
+ */
+export function buildCanonicalString(parts: SignatureParts): string
+{
+    return [parts.method.toUpperCase(), parts.path, parts.timestamp, parts.nonce, parts.bodyHash].join('\n');
+}
+
+/**
+ * Hash a JSON body string. Returns '' for undefined/empty (no-body requests).
+ */
+export function hashBody(body: string | undefined | null): string
+{
+    if (!body)
+    {
+        return '';
+    }
+
+    return createHash('sha256').update(body, 'utf8').digest('hex');
+}
+
+/**
+ * Compute the HMAC-SHA256 signature (hex) for the given parts.
+ */
+export function computeSignature(secret: string, parts: SignatureParts): string
+{
+    return createHmac('sha256', secret).update(buildCanonicalString(parts)).digest('hex');
+}
+
+/**
+ * Generate a fresh random nonce (hex).
+ */
+export function generateNonce(): string
+{
+    return randomBytes(16).toString('hex');
+}
+
+// ============================================================================
+// Sign (proxy side)
+// ============================================================================
+
+export interface SignInput
+{
+    /** The active signing key. */
+    key: ProxyKey;
+    method: string;
+    path: string;
+    /** Raw JSON body string, if any. Omit for GET / large uploads. */
+    body?: string | null;
+    /** Override the timestamp (testing). Defaults to Date.now(). */
+    timestamp?: string;
+    /** Override the nonce (testing). Defaults to a random nonce. */
+    nonce?: string;
+}
+
+/**
+ * Sign an outbound proxy request and return the headers to attach (including the
+ * keyId so the backend knows which key to verify against).
+ */
+export function signProxyRequest(input: SignInput): SignatureHeaders
+{
+    const timestamp = input.timestamp ?? String(Date.now());
+    const nonce = input.nonce ?? generateNonce();
+    const signature = computeSignature(input.key.secret, {
+        method: input.method,
+        path: input.path,
+        timestamp,
+        nonce,
+        bodyHash: hashBody(input.body),
+    });
+
+    return {
+        [PROXY_SIGNATURE_HEADER]: signature,
+        [PROXY_TIMESTAMP_HEADER]: timestamp,
+        [PROXY_NONCE_HEADER]: nonce,
+        [PROXY_KEY_ID_HEADER]: input.key.keyId,
+    };
+}
+
+// ============================================================================
+// Verify (backend side)
+// ============================================================================
+
+export type VerifyFailureReason =
+    | 'missing-headers'
+    | 'stale-timestamp'
+    | 'bad-timestamp'
+    | 'unknown-key'
+    | 'signature-mismatch';
+
+export interface VerifyResult
+{
+    valid: boolean;
+    reason?: VerifyFailureReason;
+    /** The verified nonce, for optional replay tracking by the caller. */
+    nonce?: string;
+    /** The keyId the request was verified against (for logging/metrics). */
+    keyId?: string;
+}
+
+export interface VerifyInput
+{
+    /** Accepted keys (active + grace). Selected by the request's keyId header. */
+    keys: ProxyKey[];
+    method: string;
+    path: string;
+    /** Raw JSON body string as received, if any. */
+    body?: string | null;
+    signature: string | null | undefined;
+    timestamp: string | null | undefined;
+    nonce: string | null | undefined;
+    keyId: string | null | undefined;
+    /** Allowed clock skew / replay window in ms. Default 30s. */
+    windowMs?: number;
+    /** Current time (testing). Defaults to Date.now(). */
+    now?: number;
+}
+
+/**
+ * Constant-time hex string comparison. Returns false on any length/format diff.
+ */
+function safeEqualHex(a: string, b: string): boolean
+{
+    let bufA: Buffer;
+    let bufB: Buffer;
+
+    try
+    {
+        bufA = Buffer.from(a, 'hex');
+        bufB = Buffer.from(b, 'hex');
+    }
+    catch
+    {
+        return false;
+    }
+
+    if (bufA.length === 0 || bufA.length !== bufB.length)
+    {
+        return false;
+    }
+
+    return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Verify an inbound request's proxy signature against the accepted key set.
+ *
+ * Checks, in order: headers present, timestamp within window (replay guard),
+ * keyId known, and HMAC match. Nonce-level replay rejection is left to the caller
+ * (optional, Redis-backed) since not every deployment has a shared store.
+ */
+export function verifyProxyRequest(input: VerifyInput): VerifyResult
+{
+    const { signature, timestamp, nonce, keyId } = input;
+
+    if (!signature || !timestamp || !nonce || !keyId)
+    {
+        return { valid: false, reason: 'missing-headers' };
+    }
+
+    const ts = Number(timestamp);
+    if (!Number.isFinite(ts))
+    {
+        return { valid: false, reason: 'bad-timestamp' };
+    }
+
+    const now = input.now ?? Date.now();
+    const windowMs = input.windowMs ?? 30_000;
+    if (Math.abs(now - ts) > windowMs)
+    {
+        return { valid: false, reason: 'stale-timestamp' };
+    }
+
+    const key = input.keys.find(k => k.keyId === keyId);
+    if (!key)
+    {
+        return { valid: false, reason: 'unknown-key' };
+    }
+
+    const expected = computeSignature(key.secret, {
+        method: input.method,
+        path: input.path,
+        timestamp,
+        nonce,
+        bodyHash: hashBody(input.body),
+    });
+
+    if (!safeEqualHex(signature, expected))
+    {
+        return { valid: false, reason: 'signature-mismatch' };
+    }
+
+    return { valid: true, nonce, keyId };
+}

--- a/packages/core/src/security/proxy-signature.ts
+++ b/packages/core/src/security/proxy-signature.ts
@@ -58,7 +58,9 @@ export function parseProxyKey(raw: string): ProxyKey
         return { keyId: DEFAULT_KEY_ID, secret: raw };
     }
 
-    return { keyId: raw.slice(0, idx), secret: raw.slice(idx + 1) };
+    // A leading colon (':secret') yields an empty keyId; the backend treats an empty
+    // keyId header as "missing" and rejects, so normalize it to DEFAULT_KEY_ID.
+    return { keyId: raw.slice(0, idx) || DEFAULT_KEY_ID, secret: raw.slice(idx + 1) };
 }
 
 /**

--- a/packages/core/src/security/proxy-signature.ts
+++ b/packages/core/src/security/proxy-signature.ts
@@ -282,22 +282,16 @@ export interface VerifyInput
 }
 
 /**
- * Constant-time hex string comparison. Returns false on any length/format diff.
+ * Constant-time hex string comparison. Returns false on any length diff.
+ *
+ * Buffer.from(_, 'hex') does NOT throw on invalid hex — it silently truncates at
+ * the first bad char — so a malformed signature yields a shorter buffer that the
+ * length check rejects. No try/catch needed.
  */
 function safeEqualHex(a: string, b: string): boolean
 {
-    let bufA: Buffer;
-    let bufB: Buffer;
-
-    try
-    {
-        bufA = Buffer.from(a, 'hex');
-        bufB = Buffer.from(b, 'hex');
-    }
-    catch
-    {
-        return false;
-    }
+    const bufA = Buffer.from(a, 'hex');
+    const bufB = Buffer.from(b, 'hex');
 
     if (bufA.length === 0 || bufA.length !== bufB.length)
     {

--- a/packages/core/src/security/proxy-signature.ts
+++ b/packages/core/src/security/proxy-signature.ts
@@ -112,8 +112,18 @@ export interface SignatureParts
     /** Resolved backend HTTP method (GET/POST/PUT/...) */
     method: string;
 
-    /** Resolved backend path including leading slash, WITHOUT query string */
+    /**
+     * Raw (wire) backend path, percent-encoding preserved, leading slash, NO query.
+     * Proxy signs its outbound request-target path; the backend reconstructs the
+     * SAME bytes from `new URL(c.req.url).pathname` (NOT the decoded `c.req.path`).
+     */
     path: string;
+
+    /**
+     * Raw (wire) query string including leading `?`, or '' when there is none.
+     * Both sides use the verbatim search string so query params are authenticated.
+     */
+    query: string;
 
     /** Unix epoch milliseconds, as a string */
     timestamp: string;
@@ -122,8 +132,9 @@ export interface SignatureParts
     nonce: string;
 
     /**
-     * SHA-256 hex of the raw JSON body, or empty string when there is no JSON
-     * body (GET requests, or large multipart uploads which are excluded by design).
+     * SHA-256 hex of the raw request body, or empty string when there is no body
+     * (GET/HEAD, or multipart uploads which are excluded by design). Bound for ANY
+     * non-multipart content-type, not just application/json.
      */
     bodyHash: string;
 }
@@ -150,7 +161,7 @@ export interface SignatureHeaders
  */
 export function buildCanonicalString(parts: SignatureParts): string
 {
-    return [parts.method.toUpperCase(), parts.path, parts.timestamp, parts.nonce, parts.bodyHash].join('\n');
+    return [parts.method.toUpperCase(), parts.path, parts.query, parts.timestamp, parts.nonce, parts.bodyHash].join('\n');
 }
 
 /**
@@ -191,8 +202,11 @@ export interface SignInput
     /** The active signing key. */
     key: ProxyKey;
     method: string;
+    /** Raw (wire) path, leading slash, percent-encoding preserved, NO query. */
     path: string;
-    /** Raw JSON body string, if any. Omit for GET / large uploads. */
+    /** Raw (wire) query string including leading `?`, or '' / omitted for none. */
+    query?: string;
+    /** Raw request body string, if any. Omit for GET / multipart uploads. */
     body?: string | null;
     /** Override the timestamp (testing). Defaults to Date.now(). */
     timestamp?: string;
@@ -211,6 +225,7 @@ export function signProxyRequest(input: SignInput): SignatureHeaders
     const signature = computeSignature(input.key.secret, {
         method: input.method,
         path: input.path,
+        query: input.query ?? '',
         timestamp,
         nonce,
         bodyHash: hashBody(input.body),
@@ -250,8 +265,11 @@ export interface VerifyInput
     /** Accepted keys (active + grace). Selected by the request's keyId header. */
     keys: ProxyKey[];
     method: string;
+    /** Raw (wire) path from `new URL(c.req.url).pathname` — NOT decoded `c.req.path`. */
     path: string;
-    /** Raw JSON body string as received, if any. */
+    /** Raw (wire) query string from `new URL(c.req.url).search`, or '' for none. */
+    query?: string;
+    /** Raw request body string as received, if any. */
     body?: string | null;
     signature: string | null | undefined;
     timestamp: string | null | undefined;
@@ -327,6 +345,7 @@ export function verifyProxyRequest(input: VerifyInput): VerifyResult
     const expected = computeSignature(key.secret, {
         method: input.method,
         path: input.path,
+        query: input.query ?? '',
         timestamp,
         nonce,
         bodyHash: hashBody(input.body),

--- a/packages/core/src/server/README.md
+++ b/packages/core/src/server/README.md
@@ -262,9 +262,11 @@ When there is no `app.ts`, `createServer` builds the app in this **fixed order**
 
 - Each built-in is opt-out via `.middleware({ logger: false, cors: false, errorHandler: false })`.
 - **`proxyGuard`** is opt-in (`mode: 'off'` by default). When enabled via `.proxyGuard({...})`
-  it verifies the trusted-proxy HMAC signature + origin allowlist and tags `c.get('clientType')`.
-  The health-check path is skipped automatically so k8s probes are never blocked. See
-  `@spfn/core/middleware` and the root `PROXY-BACKEND-AUTH-SPEC.md`.
+  it verifies the trusted-proxy HMAC signature (`method+path+query+body`) + origin allowlist and
+  tags `c.get('clientType')`. `tag` and `strict` evaluate every gate; only enforcement differs.
+  Health, SSE stream, and WS paths plus genuine CORS preflights are skipped automatically so
+  probes/EventSource/preflight are never blocked. See `@spfn/core/middleware` and the root
+  `PROXY-BACKEND-AUTH-SPEC.md`.
 - `.middleware({ onError })` forwards an error callback into `ErrorHandler` (e.g. Slack
   notifier) — it runs async and does not block the response.
 - Named `middlewares` (from `.middlewares()` / `.routes()`) are applied **per route** inside

--- a/packages/core/src/server/README.md
+++ b/packages/core/src/server/README.md
@@ -250,16 +250,21 @@ When there is no `app.ts`, `createServer` builds the app in this **fixed order**
 1. errorHandlerEnabled flag        (if middleware.errorHandler !== false)
 2. RequestLogger()                 (if middleware.logger !== false)
 3. cors(config.cors)               (if middleware.cors !== false && cors !== false)
-4. config.use[*]                   (raw custom middleware, in array order)
-5. health-check route              (GET config.healthCheck.path, default /health)
-6. lifecycle.beforeRoutes(app)
-7. registerRoutes(app, routes, middlewares)
-8. SSE endpoint                    (if .events(): GET /events/stream [+ POST token])
-9. lifecycle.afterRoutes(app)
-10. app.onError(ErrorHandler(...)) (if middleware.errorHandler !== false)
+4. proxyGuard                      (if proxyGuard.mode !== 'off')
+5. config.use[*]                   (raw custom middleware, in array order)
+6. health-check route              (GET config.healthCheck.path, default /health)
+7. lifecycle.beforeRoutes(app)
+8. registerRoutes(app, routes, middlewares)
+9. SSE endpoint                    (if .events(): GET /events/stream [+ POST token])
+10. lifecycle.afterRoutes(app)
+11. app.onError(ErrorHandler(...)) (if middleware.errorHandler !== false)
 ```
 
 - Each built-in is opt-out via `.middleware({ logger: false, cors: false, errorHandler: false })`.
+- **`proxyGuard`** is opt-in (`mode: 'off'` by default). When enabled via `.proxyGuard({...})`
+  it verifies the trusted-proxy HMAC signature + origin allowlist and tags `c.get('clientType')`.
+  The health-check path is skipped automatically so k8s probes are never blocked. See
+  `@spfn/core/middleware` and the root `PROXY-BACKEND-AUTH-SPEC.md`.
 - `.middleware({ onError })` forwards an error callback into `ErrorHandler` (e.g. Slack
   notifier) — it runs async and does not block the response.
 - Named `middlewares` (from `.middlewares()` / `.routes()`) are applied **per route** inside

--- a/packages/core/src/server/config-builder.ts
+++ b/packages/core/src/server/config-builder.ts
@@ -119,6 +119,16 @@ export class ServerConfigBuilder
     }
 
     /**
+     * Configure proxy-guard (verify trusted-proxy signature + origin → clientType)
+     */
+    proxyGuard(proxyGuard: ServerConfig['proxyGuard']): this
+    {
+        this.config.proxyGuard = proxyGuard;
+
+        return this;
+    }
+
+    /**
      * Register define-route based router
      *
      * Automatically applies:

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -194,13 +194,14 @@ async function applyProxyGuard(app: Hono, config?: ServerConfig): Promise<void>
     }
 
     // Auto-skip endpoints that browsers reach WITHOUT going through the RPC proxy
-    // (so they carry no proxy signature): health probes, SSE streams (EventSource
-    // can't send custom headers), the SSE token endpoint, and WebSocket upgrades.
+    // (so they carry no proxy signature): health probes, the SSE stream (EventSource
+    // can't send custom headers), and WebSocket upgrades. The SSE *token* endpoint
+    // (POST) is deliberately NOT skipped — it goes through the proxy like any RPC
+    // call and mints credentials, so it must stay guarded.
     const autoSkip = [config?.healthCheck?.path ?? '/health'];
     if (config?.events)
     {
-        const streamPath = config.eventsConfig?.path ?? '/events/stream';
-        autoSkip.push(streamPath, streamPath.replace(/\/[^/]+$/, '/token'));
+        autoSkip.push(config.eventsConfig?.path ?? '/events/stream');
     }
     if (config?.websockets)
     {
@@ -214,6 +215,7 @@ async function applyProxyGuard(app: Hono, config?: ServerConfig): Promise<void>
         previousSecrets: proxyGuardConfig?.previousSecrets,
         windowMs: proxyGuardConfig?.windowMs,
         allowedOrigins: proxyGuardConfig?.allowedOrigins,
+        maxBodyBytes: proxyGuardConfig?.maxBodyBytes,
         nonceStore,
         skipPaths,
     }));

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -18,6 +18,7 @@ import { createHealthCheckHandler } from './helpers';
 import { serverLogger } from './logger';
 
 import type { ServerConfig, AppFactory } from './types';
+import type { NonceStore } from '@spfn/core/middleware';
 
 // Extend Hono context with error handler flag
 declare module 'hono'
@@ -102,6 +103,9 @@ async function createAutoConfiguredApp(config?: ServerConfig): Promise<Hono>
     // 2. Default middleware
     applyDefaultMiddleware(app, config, enableLogger, enableCors);
 
+    // 2.5 Proxy-guard (trusted-proxy signature + origin verification)
+    await applyProxyGuard(app, config);
+
     // 3. Custom middleware
     if (Array.isArray(config?.use))
     {
@@ -151,6 +155,59 @@ function applyDefaultMiddleware(
         const corsOptions = config?.cors !== false ? config?.cors : undefined;
         app.use('*', cors(corsOptions));
     }
+}
+
+async function applyProxyGuard(app: Hono, config?: ServerConfig): Promise<void>
+{
+    const proxyGuardConfig = config?.proxyGuard;
+    const mode = proxyGuardConfig?.mode ?? 'off';
+
+    if (mode === 'off')
+    {
+        return;
+    }
+
+    const { createProxyGuard, createCacheNonceStore } = await import('@spfn/core/middleware');
+
+    // Optionally enable Redis-backed nonce replay rejection
+    let nonceStore: NonceStore | undefined;
+    if (proxyGuardConfig?.nonce)
+    {
+        try
+        {
+            const { getCache } = await import('@spfn/core/cache');
+            const cache = getCache();
+            if (cache)
+            {
+                nonceStore = createCacheNonceStore(cache);
+                serverLogger.info('Proxy-guard nonce replay rejection: cache (Redis/Valkey)');
+            }
+            else
+            {
+                serverLogger.warn('Proxy-guard nonce enabled but no cache available — using timestamp window only');
+            }
+        }
+        catch
+        {
+            serverLogger.warn('Proxy-guard nonce enabled but cache module unavailable — using timestamp window only');
+        }
+    }
+
+    // Always skip the health check path so k8s probes are not blocked
+    const healthPath = config?.healthCheck?.path ?? '/health';
+    const skipPaths = [...(proxyGuardConfig?.skipPaths ?? []), healthPath];
+
+    app.use('*', createProxyGuard({
+        mode,
+        secret: proxyGuardConfig?.secret,
+        previousSecrets: proxyGuardConfig?.previousSecrets,
+        windowMs: proxyGuardConfig?.windowMs,
+        allowedOrigins: proxyGuardConfig?.allowedOrigins,
+        nonceStore,
+        skipPaths,
+    }));
+
+    serverLogger.info(`✓ Proxy-guard enabled (mode: ${mode})`);
 }
 
 function registerHealthCheckEndpoint(app: Hono, config?: ServerConfig): void

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -193,9 +193,20 @@ async function applyProxyGuard(app: Hono, config?: ServerConfig): Promise<void>
         }
     }
 
-    // Always skip the health check path so k8s probes are not blocked
-    const healthPath = config?.healthCheck?.path ?? '/health';
-    const skipPaths = [...(proxyGuardConfig?.skipPaths ?? []), healthPath];
+    // Auto-skip endpoints that browsers reach WITHOUT going through the RPC proxy
+    // (so they carry no proxy signature): health probes, SSE streams (EventSource
+    // can't send custom headers), the SSE token endpoint, and WebSocket upgrades.
+    const autoSkip = [config?.healthCheck?.path ?? '/health'];
+    if (config?.events)
+    {
+        const streamPath = config.eventsConfig?.path ?? '/events/stream';
+        autoSkip.push(streamPath, streamPath.replace(/\/[^/]+$/, '/token'));
+    }
+    if (config?.websockets)
+    {
+        autoSkip.push(config.websocketsConfig?.path ?? '/ws');
+    }
+    const skipPaths = [...(proxyGuardConfig?.skipPaths ?? []), ...autoSkip];
 
     app.use('*', createProxyGuard({
         mode,

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -134,20 +134,24 @@ export interface ServerConfig
         /** Allowed clock skew / replay window in ms. @default 30000 */
         windowMs?: number;
 
-        /** Browser origin allowlist — enforced in strict mode only. */
+        /**
+         * Browser origin allowlist. Evaluated in BOTH modes: strict rejects a
+         * disallowed Origin, tag tags it `untrusted`. Requires the proxy to forward
+         * the Origin header (it does). Requests without an Origin defer to the signature.
+         */
         allowedOrigins?: string[];
 
         /**
-         * Reject (413) requests whose Content-Length exceeds this before the guard
-         * buffers the body for hashing. Bounds per-request memory. @default no cap
+         * Reject (413) once the streamed body exceeds this many bytes. Measured as it
+         * streams (Content-Length not trusted). Bounds per-request memory. @default no cap
          */
         maxBodyBytes?: number;
 
         /**
-         * Enable hard replay rejection via a Redis nonce store (strict mode only).
-         * Requires a cache (CACHE_URL); without one, falls back to the timestamp
-         * window. Degrades to the window if the store is briefly unavailable.
-         * @default false
+         * Enable hard replay rejection via a Redis nonce store. Evaluated in BOTH modes
+         * (tag observes replays, strict rejects). Requires a cache (CACHE_URL); without
+         * one, falls back to the timestamp window. Degrades to the window if the store
+         * is briefly unavailable. @default false
          */
         nonce?: boolean;
 

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -100,6 +100,55 @@ export interface ServerConfig
     use?: MiddlewareHandler[];
 
     /**
+     * Proxy-guard: verify requests came through the trusted Next.js RPC proxy
+     * (HMAC signature) and/or an allowed browser origin, then tag `clientType`.
+     * Lets the backend reject direct-to-backend calls that bypass the proxy.
+     *
+     * Disabled by default (`mode: 'off'`). Requires the same `SPFN_PROXY_SECRET`
+     * on the proxy and the backend. See PROXY-BACKEND-AUTH-SPEC.md.
+     *
+     * @example
+     * ```typescript
+     * .proxyGuard({ mode: 'strict', allowedOrigins: ['https://app.example.com'] })
+     * ```
+     */
+    proxyGuard?: {
+        /**
+         * Enforcement mode.
+         * - `off` (default): no-op.
+         * - `tag`: verify and set `clientType`, never reject (observe first).
+         * - `strict`: reject unverified requests with 403.
+         */
+        mode?: 'off' | 'tag' | 'strict';
+
+        /** Active shared HMAC secret (`<keyId>:<secret>`). @default env.SPFN_PROXY_SECRET */
+        secret?: string;
+
+        /**
+         * Previous (grace) keys still accepted during rotation — comma-separated
+         * `<keyId>:<secret>`. Verification-only; the proxy never signs with these.
+         * @default env.SPFN_PROXY_SECRET_PREVIOUS
+         */
+        previousSecrets?: string;
+
+        /** Allowed clock skew / replay window in ms. @default 30000 */
+        windowMs?: number;
+
+        /** Browser origin allowlist (cross-origin guard). */
+        allowedOrigins?: string[];
+
+        /**
+         * Enable hard replay rejection via a Redis nonce store. Requires a cache
+         * (CACHE_URL); without one, falls back to the timestamp window only.
+         * @default false
+         */
+        nonce?: boolean;
+
+        /** Paths to skip (health check path is always skipped automatically). */
+        skipPaths?: string[];
+    };
+
+    /**
      * Global middlewares with names for route-level skip control
      * Use defineMiddleware() for type-safe middleware definitions
      *

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -134,12 +134,19 @@ export interface ServerConfig
         /** Allowed clock skew / replay window in ms. @default 30000 */
         windowMs?: number;
 
-        /** Browser origin allowlist (cross-origin guard). */
+        /** Browser origin allowlist — enforced in strict mode only. */
         allowedOrigins?: string[];
 
         /**
-         * Enable hard replay rejection via a Redis nonce store. Requires a cache
-         * (CACHE_URL); without one, falls back to the timestamp window only.
+         * Reject (413) requests whose Content-Length exceeds this before the guard
+         * buffers the body for hashing. Bounds per-request memory. @default no cap
+         */
+        maxBodyBytes?: number;
+
+        /**
+         * Enable hard replay rejection via a Redis nonce store (strict mode only).
+         * Requires a cache (CACHE_URL); without one, falls back to the timestamp
+         * window. Degrades to the window if the store is briefly unavailable.
          * @default false
          */
         nonce?: boolean;

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -2,7 +2,7 @@ import type { Hono, MiddlewareHandler } from 'hono';
 import { cors } from 'hono/cors';
 import type { serve } from '@hono/node-server';
 import type { Router, NamedMiddleware } from '@spfn/core/route';
-import type { OnErrorContext } from '@spfn/core/middleware';
+import type { OnErrorContext, ProxyGuardConfig } from '@spfn/core/middleware';
 import type { JobRouter, BossOptions } from '../job';
 import type { EventRouterDef } from '../event/router';
 import type { SSEHandlerConfig } from '../event/sse/types';
@@ -112,41 +112,7 @@ export interface ServerConfig
      * .proxyGuard({ mode: 'strict', allowedOrigins: ['https://app.example.com'] })
      * ```
      */
-    proxyGuard?: {
-        /**
-         * Enforcement mode.
-         * - `off` (default): no-op.
-         * - `tag`: verify and set `clientType`, never reject (observe first).
-         * - `strict`: reject unverified requests with 403.
-         */
-        mode?: 'off' | 'tag' | 'strict';
-
-        /** Active shared HMAC secret (`<keyId>:<secret>`). @default env.SPFN_PROXY_SECRET */
-        secret?: string;
-
-        /**
-         * Previous (grace) keys still accepted during rotation — comma-separated
-         * `<keyId>:<secret>`. Verification-only; the proxy never signs with these.
-         * @default env.SPFN_PROXY_SECRET_PREVIOUS
-         */
-        previousSecrets?: string;
-
-        /** Allowed clock skew / replay window in ms. @default 30000 */
-        windowMs?: number;
-
-        /**
-         * Browser origin allowlist. Evaluated in BOTH modes: strict rejects a
-         * disallowed Origin, tag tags it `untrusted`. Requires the proxy to forward
-         * the Origin header (it does). Requests without an Origin defer to the signature.
-         */
-        allowedOrigins?: string[];
-
-        /**
-         * Reject (413) once the streamed body exceeds this many bytes. Measured as it
-         * streams (Content-Length not trusted). Bounds per-request memory. @default no cap
-         */
-        maxBodyBytes?: number;
-
+    proxyGuard?: Omit<ProxyGuardConfig, 'nonceStore'> & {
         /**
          * Enable hard replay rejection via a Redis nonce store. Evaluated in BOTH modes
          * (tag observes replays, strict rejects). Requires a cache (CACHE_URL); without
@@ -154,9 +120,6 @@ export interface ServerConfig
          * is briefly unavailable. @default false
          */
         nonce?: boolean;
-
-        /** Paths to skip (health check path is always skipped automatically). */
-        skipPaths?: string[];
     };
 
     /**


### PR DESCRIPTION
## What

Adds an opt-in **proxy-guard** layer so the SPFN backend can reject
direct-to-backend calls that bypass the Next.js RPC proxy, plus the
proxy-side HMAC signing that makes it work.

The backend must be publicly reachable (mobile clients hit it directly), so
this answers "did this request come through our trusted proxy?" via an
HMAC-SHA256 signature, and tags each request with a `clientType`. It does NOT
replace user auth (JWT) — it's a separate "what kind of client is this?" gate.

## Threat model

- **A — unauthenticated outsiders** (direct-to-backend hits, endpoint fuzzing,
  proxy bypass): blocked. An attacker who skips the proxy has no signature.
- **B — an authenticated user automating their own account** with a hand-rolled
  client: fundamentally cannot be fully stopped on the web; this raises the cost.
  Mobile attestation (App Attest / Play Integrity) is the documented follow-up
  that OR's into the same `clientType` gate.

See `PROXY-BACKEND-AUTH-SPEC.md` for the full design, key rotation, and `.env`
placement.

## How

- **Signature** (`security/proxy-signature.ts`): shared HMAC-SHA256 over
  `method + path + query + bodyHash`, keyed by `keyId` for zero-downtime
  rotation (active + grace key set). Wire path/query (not decoded) so both sides
  agree byte-for-byte.
- **Proxy** (`nextjs/proxy/rpc.ts`): signs the forwarded request; forwards the
  `Origin` header so the allowlist can work.
- **Backend** (`middleware/proxy-guard.ts`): verifies signature + origin
  allowlist, tags `clientType`. Modes `off`/`tag`/`strict` — every gate is
  evaluated in both modes, only enforcement differs. Optional Redis nonce-store
  replay rejection; `maxBodyBytes` stream-measured cap.
- **Wiring** (`server/`): `.proxyGuard({...})` builder, auto-skip for
  health/SSE/WS/preflight, fail-closed (strict with no key throws at startup).
- **Config**: `SPFN_PROXY_SECRET` (`.env.local`, both processes),
  `SPFN_PROXY_SECRET_PREVIOUS` (`.env.server`, backend-only grace keys).

## Review

Hardened over 7 adversarial review rounds (findings converged
10/10/10/9/6/4/1 → 0 structural defects). Rounds surfaced and fixed: fail-open
in strict mode, body-tamper via content-type, unsigned query params, a dead
`allowedOrigins` (Origin wasn't forwarded), client-abort 500s, and several
fix-introduced regressions. hashBody string/Buffer parity and sentinel-flow
safety were empirically verified.

**Known, accepted trade-offs**: the nonce store degrades to the timestamp
window on a brief outage (availability over hard replay rejection); the guard
buffers a signed body once for hashing while the handler parses it again
(inherent to hashing without consuming).

## Verification

`pnpm build` (incl. madge circular check), `pnpm lint`, and the new test
suites (48 tests: signing round-trip, key rotation, tamper, fail-closed,
origin, nonce replay/degrade, body cap, OPTIONS) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
