### PR TITLE
fix(auth): security audit P0 remediation (RBAC, OTP, deps, rate limiting)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,11 @@
       "react-dom": "^19.0.0",
       "@types/react": "^19",
       "@types/react-dom": "^19",
-      "drizzle-orm": "^0.45.0",
-      "next": "^16.1.7"
+      "drizzle-orm": "^0.45.2",
+      "next": "^16.1.7",
+      "picomatch": "^2.3.2",
+      "shell-quote": "^1.8.4",
+      "jws": "^3.2.3"
     }
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "drizzle-orm": "^0.45.0",
+    "drizzle-orm": "^0.45.2",
     "jose": "^6.1.0",
     "jsonwebtoken": "^9.0.2",
     "postgres": "^3.4.0"
@@ -119,7 +119,7 @@
     "@types/react-dom": "^19.2.2",
     "@vitest/coverage-v8": "^4.0.6",
     "drizzle-kit": "^0.31.6",
-    "hono": "^4.12.4",
+    "hono": "^4.12.25",
     "madge": "^8.0.0",
     "next": "^16.2.2",
     "spfn": "workspace:*",

--- a/packages/auth/src/__tests__/unit/permission.test.ts
+++ b/packages/auth/src/__tests__/unit/permission.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @spfn/auth - Permission Service Tests
+ *
+ * Unit tests for the role-assignment authority guard (assertCanAssignRole).
+ * Repositories are mocked so the privilege rule is tested in isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/server/repositories', () => ({
+    usersRepository: { findById: vi.fn() },
+    rolesRepository: { findById: vi.fn() },
+    permissionsRepository: { findById: vi.fn() },
+    rolePermissionsRepository: { findByRoleId: vi.fn() },
+    userPermissionsRepository: { findValidByUserId: vi.fn() },
+}));
+
+import { assertCanAssignRole } from '@/server/services/permission.service';
+import {
+    usersRepository,
+    rolesRepository,
+    permissionsRepository,
+    rolePermissionsRepository,
+    userPermissionsRepository,
+} from '@/server/repositories';
+
+const SUPERADMIN_ROLE = 1;
+const ADMIN_ROLE = 2;
+const MEMBER_ROLE = 3;
+
+const ROLES: Record<number, { id: number; name: string }> = {
+    [SUPERADMIN_ROLE]: { id: SUPERADMIN_ROLE, name: 'superadmin' },
+    [ADMIN_ROLE]: { id: ADMIN_ROLE, name: 'admin' },
+    [MEMBER_ROLE]: { id: MEMBER_ROLE, name: 'member' },
+};
+
+const CALLER_ID = 10;
+
+/** Set the role the caller currently holds. */
+function setCallerRole(roleId: number): void
+{
+    vi.mocked(usersRepository.findById).mockResolvedValue({ id: CALLER_ID, roleId } as never);
+}
+
+/** Control whether the caller resolves the `admin:promote` permission. */
+function setAdminPromote(granted: boolean): void
+{
+    vi.mocked(rolePermissionsRepository.findByRoleId).mockResolvedValue(
+        (granted ? [{ permissionId: 99 }] : []) as never,
+    );
+    vi.mocked(permissionsRepository.findById).mockResolvedValue(
+        { id: 99, name: 'admin:promote', isActive: true } as never,
+    );
+    vi.mocked(userPermissionsRepository.findValidByUserId).mockResolvedValue([] as never);
+}
+
+describe('assertCanAssignRole', () =>
+{
+    beforeEach(() =>
+    {
+        vi.clearAllMocks();
+        vi.mocked(rolesRepository.findById).mockImplementation(
+            (async (id: number) => ROLES[id] ?? null) as never,
+        );
+        setAdminPromote(false);
+    });
+
+    it('lets a superadmin assign any role, including superadmin', async () =>
+    {
+        setCallerRole(SUPERADMIN_ROLE);
+        await expect(assertCanAssignRole(CALLER_ID, SUPERADMIN_ROLE)).resolves.toBeUndefined();
+    });
+
+    it('blocks a non-superadmin from assigning the superadmin role', async () =>
+    {
+        setCallerRole(ADMIN_ROLE);
+        await expect(assertCanAssignRole(CALLER_ID, SUPERADMIN_ROLE))
+            .rejects.toThrow('Only superadmin can assign superadmin role');
+    });
+
+    it('blocks assigning the admin role without admin:promote', async () =>
+    {
+        setCallerRole(ADMIN_ROLE);
+        setAdminPromote(false);
+        await expect(assertCanAssignRole(CALLER_ID, ADMIN_ROLE))
+            .rejects.toThrow('admin:promote permission required');
+    });
+
+    it('allows assigning the admin role with admin:promote', async () =>
+    {
+        setCallerRole(ADMIN_ROLE);
+        setAdminPromote(true);
+        await expect(assertCanAssignRole(CALLER_ID, ADMIN_ROLE)).resolves.toBeUndefined();
+    });
+
+    it('allows a non-superadmin to assign an ordinary role', async () =>
+    {
+        setCallerRole(ADMIN_ROLE);
+        await expect(assertCanAssignRole(CALLER_ID, MEMBER_ROLE)).resolves.toBeUndefined();
+    });
+});

--- a/packages/auth/src/__tests__/unit/verification.test.ts
+++ b/packages/auth/src/__tests__/unit/verification.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'crypto';
 import {
     generateVerificationCode,
     createVerificationToken,
@@ -35,14 +36,13 @@ describe('Verification Helpers', () =>
 
         it('should pad codes with leading zeros', () =>
         {
-            // Mock Math.random to return small numbers
-            const originalRandom = Math.random;
-            Math.random = () => 0.000001; // Will produce "000001"
+            // CSPRNG returns a small number -> code must be zero-padded to 6 digits
+            const spy = vi.spyOn(crypto, 'randomInt').mockReturnValue(1 as never);
 
             const code = generateVerificationCode();
             expect(code).toBe('000001');
 
-            Math.random = originalRandom;
+            spy.mockRestore();
         });
     });
 

--- a/packages/auth/src/server/routes/admin/index.ts
+++ b/packages/auth/src/server/routes/admin/index.ts
@@ -12,10 +12,9 @@ import {
     deleteRole as _deleteRole,
     updateUserService,
     getUserRole,
-    hasPermission,
+    assertCanAssignRole,
 } from '../../services';
 import { getAuth } from '../../helpers';
-import { rolesRepository } from '../../repositories';
 import { ForbiddenError } from '@spfn/core/errors';
 import { Type } from '@sinclair/typebox';
 import { route } from '@spfn/core/route';
@@ -144,7 +143,6 @@ export const updateUserRole = route.patch('/_auth/admin/users/:userId/role')
     {
         const { params, body } = await c.data();
         const auth = getAuth(c);
-        const callerRole = await getUserRole(auth.userId);
 
         if (params.userId === Number(auth.userId))
         {
@@ -157,25 +155,8 @@ export const updateUserRole = route.patch('/_auth/admin/users/:userId/role')
             throw new ForbiddenError({ message: 'Cannot modify superadmin role' });
         }
 
-        // admin 권한 검증: 대상 role에 따라 제한
-        if (callerRole !== 'superadmin')
-        {
-            const newRole = await rolesRepository.findById(body.roleId);
-
-            if (newRole?.name === 'superadmin')
-            {
-                throw new ForbiddenError({ message: 'Only superadmin can assign superadmin role' });
-            }
-
-            if (newRole?.name === 'admin')
-            {
-                const canPromote = await hasPermission(auth.userId, 'admin:promote');
-                if (!canPromote)
-                {
-                    throw new ForbiddenError({ message: 'admin:promote permission required to assign admin role' });
-                }
-            }
-        }
+        // Caller must have authority over the role being assigned
+        await assertCanAssignRole(auth.userId, body.roleId);
 
         await updateUserService(params.userId, { roleId: body.roleId });
 

--- a/packages/auth/src/server/routes/auth/index.ts
+++ b/packages/auth/src/server/routes/auth/index.ts
@@ -21,6 +21,7 @@ import {
 } from '../../services';
 import { Type } from '@sinclair/typebox';
 import { Transactional } from '@spfn/core/db';
+import { rateLimit } from '@spfn/core/middleware';
 import { defineRouter, route } from '@spfn/core/route';
 
 /**
@@ -34,6 +35,7 @@ export const checkAccountExists = route.post('/_auth/exists')
             Type.Object({ phone: PhoneSchema }),
         ]),
     })
+    .use([rateLimit({ limit: 30, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -56,6 +58,7 @@ export const sendVerificationCode = route.post('/_auth/codes')
             purpose: VerificationPurposeSchema,
         }),
     })
+    .use([rateLimit({ limit: 5, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -84,6 +87,7 @@ export const verifyCode = route.post('/_auth/codes/verify')
             purpose: VerificationPurposeSchema,
         }),
     })
+    .use([rateLimit({ limit: 10, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -158,7 +162,7 @@ export const login = route.post('/_auth/login')
             oldKeyId: Type.Optional(Type.String({ description: 'Previous key ID for rotation' })),
         }),
     })
-    .use([Transactional()])
+    .use([rateLimit({ limit: 10, windowMs: 60_000 }), Transactional()])
     .skip(['auth'])
     .handler(async (c) =>
     {

--- a/packages/auth/src/server/routes/invitations/index.ts
+++ b/packages/auth/src/server/routes/invitations/index.ts
@@ -17,6 +17,7 @@ import {
     cancelInvitation as _cancelInvitation,
     resendInvitation as _resendInvitation,
     deleteInvitation as _deleteInvitation,
+    assertCanAssignRole,
 } from '../../services';
 import { Type } from '@sinclair/typebox';
 import { Transactional } from '@spfn/core/db';
@@ -153,6 +154,10 @@ export const createInvitation = route.post('/_auth/invitations')
     {
         const { body } = await c.data();
         const { userId } = getAuth(c);
+
+        // Caller must have authority over the role being assigned — without this,
+        // a user:invite holder could invite with the superadmin roleId and self-accept
+        await assertCanAssignRole(userId, body.roleId);
 
         const invitation = await _createInvitation({
             email: body.email,

--- a/packages/auth/src/server/routes/oauth/index.ts
+++ b/packages/auth/src/server/routes/oauth/index.ts
@@ -10,6 +10,7 @@
 import { Type } from '@sinclair/typebox';
 import { Transactional } from '@spfn/core/db';
 import { ValidationError } from '@spfn/core/errors';
+import { rateLimit } from '@spfn/core/middleware';
 import { defineRouter, route } from '@spfn/core/route';
 
 import { KEY_ALGORITHM, SOCIAL_PROVIDERS } from '../../types';
@@ -46,6 +47,7 @@ export const oauthGoogleStart = route.get('/_auth/oauth/google')
             }),
         }),
     })
+    .use([rateLimit({ limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -154,6 +156,7 @@ export const oauthStart = route.post('/_auth/oauth/start')
             })),
         }),
     })
+    .use([rateLimit({ limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -268,6 +271,7 @@ export const oauthProviderStart = route.get('/_auth/oauth/:provider')
             }),
         }),
     })
+    .use([rateLimit({ limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {

--- a/packages/auth/src/server/services/index.ts
+++ b/packages/auth/src/server/services/index.ts
@@ -76,6 +76,7 @@ export {
     getUserRole,
     hasRole,
     hasAnyRole,
+    assertCanAssignRole,
 } from './permission.service';
 
 // Role Service

--- a/packages/auth/src/server/services/permission.service.ts
+++ b/packages/auth/src/server/services/permission.service.ts
@@ -11,6 +11,7 @@ import {
     rolePermissionsRepository,
     userPermissionsRepository,
 } from '../repositories';
+import { ForbiddenError } from '@spfn/core/errors';
 
 /**
  * Get all permissions for a user
@@ -222,4 +223,51 @@ export async function hasAnyRole(userId: string | number | bigint, roleNames: st
     }
 
     return false;
+}
+
+/**
+ * Assert that the caller is allowed to assign the given role.
+ *
+ * Centralizes the privilege rule shared by direct role assignment and invitation:
+ * a non-superadmin caller may never grant the superadmin role, and may grant the
+ * admin role only when they hold the `admin:promote` permission. Assigning any
+ * lower role is unrestricted (the route's own permission guard still applies).
+ *
+ * @param callerUserId - User performing the assignment
+ * @param targetRoleId - Role being assigned
+ * @throws ForbiddenError when the caller lacks the authority for the target role
+ *
+ * @example
+ * ```typescript
+ * await assertCanAssignRole(auth.userId, body.roleId);
+ * ```
+ */
+export async function assertCanAssignRole(
+    callerUserId: string | number | bigint,
+    targetRoleId: number,
+): Promise<void>
+{
+    const callerRole = await getUserRole(callerUserId);
+
+    if (callerRole === 'superadmin')
+    {
+        return;
+    }
+
+    const targetRole = await rolesRepository.findById(targetRoleId);
+
+    if (targetRole?.name === 'superadmin')
+    {
+        throw new ForbiddenError({ message: 'Only superadmin can assign superadmin role' });
+    }
+
+    if (targetRole?.name === 'admin')
+    {
+        const canPromote = await hasPermission(callerUserId, 'admin:promote');
+
+        if (!canPromote)
+        {
+            throw new ForbiddenError({ message: 'admin:promote permission required to assign admin role' });
+        }
+    }
 }

--- a/packages/auth/src/server/services/verification.service.ts
+++ b/packages/auth/src/server/services/verification.service.ts
@@ -4,6 +4,7 @@
  * Handles OTP code generation, validation, and delivery
  */
 
+import crypto from 'crypto';
 import { env } from '@spfn/auth/config';
 import { InvalidVerificationCodeError } from '@spfn/auth/errors';
 import jwt from 'jsonwebtoken';
@@ -45,8 +46,9 @@ export interface VerificationTokenPayload
  */
 export function generateVerificationCode(): string
 {
-    // Generate random 6-digit number (000000 - 999999)
-    return Math.floor(Math.random() * 1000000)
+    // Generate random 6-digit number (000000 - 999999) using a CSPRNG —
+    // Math.random() is predictable and must never gate auth/reset codes
+    return crypto.randomInt(0, 1000000)
         .toString()
         .padStart(6, '0');
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -171,25 +171,25 @@
         "node": ">=18.18.0"
     },
     "dependencies": {
-        "@hono/node-server": "^1.0.0",
+        "@hono/node-server": "^1.19.13",
         "@sinclair/typebox": "^0.34.0",
         "chalk": "^5.6.2",
         "chokidar": "^4.0.3",
         "dotenv": "^17.2.3",
-        "drizzle-orm": "^0.45.0",
+        "drizzle-orm": "^0.45.2",
         "drizzle-typebox": "^0.1.0",
-        "hono": "^4.12.4",
+        "hono": "^4.12.25",
         "jiti": "^2.6.1",
         "micromatch": "^4.0.8",
         "pg-boss": "^11.1.2",
         "postgres": "^3.4.0",
         "typescript": "^5.3.3",
-        "undici": "^7.24.0",
+        "undici": "^7.28.0",
         "zod": "^4.1.11"
     },
     "optionalDependencies": {
         "ioredis": "^5.4.1",
-        "ws": "^8.0.0"
+        "ws": "^8.21.0"
     },
     "devDependencies": {
         "@types/micromatch": "^4.0.9",

--- a/packages/core/src/middleware/README.md
+++ b/packages/core/src/middleware/README.md
@@ -1,9 +1,10 @@
-# @spfn/core/middleware — Built-in HTTP middleware (error handling + request logging + proxy-guard)
+# @spfn/core/middleware — Built-in HTTP middleware (error handling + request logging + proxy-guard + rate limiting)
 
 Production Hono middleware factories and a masking helper: `ErrorHandler` (serializes
 thrown errors into HTTP responses), `RequestLogger` (structured request/response logging
-with request IDs, slow-request detection, and sensitive-data masking), and `createProxyGuard`
-(verifies a trusted-proxy HMAC signature + origin allowlist and tags `clientType`).
+with request IDs, slow-request detection, and sensitive-data masking), `createProxyGuard`
+(verifies a trusted-proxy HMAC signature + origin allowlist and tags `clientType`), and
+`rateLimit` (Redis-backed fixed-window limiter for brute-force / DoS protection).
 
 > **These are the exports of this module.** `defineMiddleware` (custom named
 > middleware), `.use()` / `.skip()` (route-level wiring), and `Transactional` (DB
@@ -19,6 +20,8 @@ import {
     maskSensitiveData,
     createProxyGuard,
     createCacheNonceStore,
+    rateLimit,
+    getClientIp,
 } from '@spfn/core/middleware';
 
 import type {
@@ -30,6 +33,7 @@ import type {
     ProxyGuardMode,
     ClientType,
     NonceStore,
+    RateLimitOptions,
 } from '@spfn/core/middleware';
 ```
 
@@ -56,9 +60,14 @@ From `@spfn/core/middleware`:
   not `app.use` directly.
 - `createCacheNonceStore(cache, prefix?)` → `NonceStore` for hard replay rejection (Redis
   `SET … PX NX`). Pass to `proxyGuard.nonceStore` (auto-wired from a cache when `nonce: true`).
+- `rateLimit(options: RateLimitOptions)` → Hono middleware. Redis-backed fixed-window limiter,
+  registered under the named `'rateLimit'` slot so routes can `.skip(['rateLimit'])`. Attach
+  with `.use([rateLimit({...})])`. See [rateLimit](#ratelimit).
+- `getClientIp(c)` → best-effort client IP from the proxy chain (leftmost `X-Forwarded-For`,
+  then `X-Real-IP`, else `'unknown'`). Spoofable — see the caveat in [rateLimit](#ratelimit).
 
 Types: `ErrorHandlerOptions`, `OnErrorContext`, `RequestLoggerOptions`, `RequestLoggerConfig`,
-`ProxyGuardConfig`, `ProxyGuardMode`, `ClientType`, `NonceStore`.
+`ProxyGuardConfig`, `ProxyGuardMode`, `ClientType`, `NonceStore`, `RateLimitOptions`.
 
 See the root `PROXY-BACKEND-AUTH-SPEC.md` for the threat model, key rotation, and `.env`
 placement (`SPFN_PROXY_SECRET` in `.env.local`; grace `SPFN_PROXY_SECRET_PREVIOUS` in `.env.server`).
@@ -312,6 +321,58 @@ maskSensitiveData(
 - Non-objects (`null`, primitives) are returned as-is.
 
 Replacement token is the literal string `'***MASKED***'`.
+
+---
+
+## rateLimit
+
+Redis-backed **fixed-window** rate limiter. Registered under the named `'rateLimit'`
+middleware so a route can opt out with `.skip(['rateLimit'])`. Attach per-route with
+`.use([rateLimit({...})])`.
+
+```typescript
+import { rateLimit, getClientIp } from '@spfn/core/middleware';
+
+// 10 requests / minute per client IP (the default dimension)
+route.post('/_auth/login')
+    .use([rateLimit({ limit: 10, windowMs: 60_000 })])
+    .handler(/* ... */);
+
+// limit on more than one dimension — the strictest wins
+route.post('/_auth/codes')
+    .use([rateLimit({
+        limit: 5,
+        windowMs: 60_000,
+        by: (c) => [getClientIp(c)],
+    })])
+    .handler(/* ... */);
+```
+
+### Options (`RateLimitOptions`)
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `limit` | `number` | — | Max requests per window, applied to **each** dimension. |
+| `windowMs` | `number` | — | Window length in milliseconds. |
+| `scope` | `string` | `` `${method} ${routePath}` `` | Counter-key namespace; defaults to per-route. |
+| `by` | `(c) => (string \| null \| undefined)[]` | `[getClientIp(c)]` | Identity dimensions; each non-empty value is counted separately. |
+| `failClosed` | `boolean` | `false` | Reject with 429 when the cache is unavailable instead of allowing through. |
+| `message` | `string` | generic | 429 response message. |
+
+### Behavior
+
+- **Atomic**: counts via a single Lua `INCR` + `PEXPIRE`, so the expiry is never lost in
+  a race between two requests.
+- **Fail-open by default**: when no cache is configured (or it is disabled), requests pass
+  and a warning is logged — matching the proxy-guard nonce store's graceful degradation, so
+  local dev without Redis still works. Set `failClosed: true` to reject instead.
+- **On exceed**: throws `TooManyRequestsError` (429) and sets a `Retry-After` header derived
+  from the key's remaining TTL.
+- **Storage**: keys are `ratelimit:{scope}:{dimension}` in the shared cache.
+
+> **IP trust caveat**: `getClientIp` reads the leftmost `X-Forwarded-For` hop, which a client
+> can spoof unless a trusted proxy overwrites it. For security-sensitive limits, pair the IP
+> dimension with an account/target dimension rather than relying on IP alone.
 
 ---
 

--- a/packages/core/src/middleware/__tests__/rate-limit.test.ts
+++ b/packages/core/src/middleware/__tests__/rate-limit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @spfn/core - Rate limit middleware tests
+ *
+ * The cache is mocked so the limiter logic is tested without Redis. eval()
+ * returns the [count, pttl] the Lua counter would produce.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const evalMock = vi.fn();
+let cacheClient: { eval: typeof evalMock } | undefined = { eval: evalMock };
+let cacheDisabled = false;
+
+vi.mock('../../cache', () => ({
+    getCache: () => cacheClient,
+    isCacheDisabled: () => cacheDisabled,
+}));
+
+import { rateLimit } from '../rate-limit';
+import { TooManyRequestsError } from '../../errors';
+
+function makeCtx(headers: Record<string, string> = {})
+{
+    const setHeaders: Record<string, string> = {};
+
+    return {
+        req: {
+            header: (name: string) => headers[name.toLowerCase()],
+            path: '/_auth/login',
+            method: 'POST',
+            routePath: '/_auth/login',
+        },
+        header: (name: string, value: string) => { setHeaders[name] = value; },
+        _setHeaders: setHeaders,
+    } as never;
+}
+
+describe('rateLimit middleware', () =>
+{
+    beforeEach(() =>
+    {
+        evalMock.mockReset();
+        cacheClient = { eval: evalMock };
+        cacheDisabled = false;
+    });
+
+    it('allows a request under the limit', async () =>
+    {
+        evalMock.mockResolvedValue([1, 60_000]);
+        const next = vi.fn().mockResolvedValue(undefined);
+
+        await rateLimit({ limit: 5, windowMs: 60_000 })(makeCtx({ 'x-forwarded-for': '1.2.3.4' }), next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects with 429 and Retry-After when over the limit', async () =>
+    {
+        evalMock.mockResolvedValue([6, 30_000]);
+        const ctx = makeCtx({ 'x-forwarded-for': '1.2.3.4' }) as never as { _setHeaders: Record<string, string> };
+        const next = vi.fn();
+
+        await expect(rateLimit({ limit: 5, windowMs: 60_000 })(ctx as never, next))
+            .rejects.toBeInstanceOf(TooManyRequestsError);
+        expect(next).not.toHaveBeenCalled();
+        expect(ctx._setHeaders['Retry-After']).toBe('30');
+    });
+
+    it('fails open (allows through) when the cache is unavailable', async () =>
+    {
+        cacheClient = undefined;
+        const next = vi.fn().mockResolvedValue(undefined);
+
+        await rateLimit({ limit: 5, windowMs: 60_000 })(makeCtx(), next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(evalMock).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when configured and the cache is unavailable', async () =>
+    {
+        cacheClient = undefined;
+        const next = vi.fn();
+
+        await expect(rateLimit({ limit: 5, windowMs: 60_000, failClosed: true })(makeCtx(), next))
+            .rejects.toBeInstanceOf(TooManyRequestsError);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('limits each dimension independently — the strictest wins', async () =>
+    {
+        // IP is fine (1), but the account dimension is over (6)
+        evalMock.mockResolvedValueOnce([1, 60_000]).mockResolvedValueOnce([6, 20_000]);
+        const next = vi.fn();
+
+        await expect(
+            rateLimit({ limit: 5, windowMs: 60_000, by: () => ['1.2.3.4', 'user@example.com'] })(makeCtx(), next),
+        ).rejects.toBeInstanceOf(TooManyRequestsError);
+        expect(next).not.toHaveBeenCalled();
+        expect(evalMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -8,3 +8,5 @@ export { RequestLogger, maskSensitiveData } from './request-logger';
 export type { RequestLoggerOptions, RequestLoggerConfig } from './request-logger';
 export { createProxyGuard, createCacheNonceStore } from './proxy-guard';
 export type { ProxyGuardConfig, ProxyGuardMode, ClientType, NonceStore } from './proxy-guard';
+export { rateLimit, getClientIp } from './rate-limit';
+export type { RateLimitOptions } from './rate-limit';

--- a/packages/core/src/middleware/rate-limit.ts
+++ b/packages/core/src/middleware/rate-limit.ts
@@ -1,0 +1,141 @@
+/**
+ * @spfn/core - Rate limit middleware
+ *
+ * Redis-backed fixed-window rate limiter, registered under the named
+ * 'rateLimit' middleware so routes can opt out with `.skip(['rateLimit'])`.
+ *
+ * Storage is the shared cache (ioredis). The counter is incremented and given
+ * its window expiry in a single atomic Lua call, so concurrent requests cannot
+ * race between INCR and PEXPIRE. When no cache is configured the limiter fails
+ * OPEN by default (logs a warning) — matching the proxy-guard nonce store's
+ * graceful degradation — so development without Redis still works. Set
+ * `failClosed` to reject instead.
+ */
+
+import type { Context, MiddlewareHandler } from 'hono';
+import { defineMiddlewareFactory } from '../route/define-middleware';
+import { getCache, isCacheDisabled } from '../cache';
+import { TooManyRequestsError } from '../errors';
+import { logger } from '../logger';
+
+const rateLimitLogger = logger.child('@spfn/core:rate-limit');
+
+/**
+ * Atomic fixed-window counter: increment, set the window expiry on the first
+ * hit, and return [count, pttlMs]. Keeping incr+expire in one round trip avoids
+ * a leaked key that never expires when a process dies between the two calls.
+ */
+const FIXED_WINDOW_LUA = `
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+    redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+return { count, redis.call('PTTL', KEYS[1]) }
+`;
+
+export interface RateLimitOptions
+{
+    /** Max requests allowed per window, applied to each identity dimension. */
+    limit: number;
+
+    /** Window length in milliseconds. */
+    windowMs: number;
+
+    /**
+     * Namespace for the counter keys. Defaults to `${method} ${routePath}` so
+     * each route is limited independently.
+     */
+    scope?: string;
+
+    /**
+     * Identity dimensions to limit on. Each non-empty value is counted
+     * separately and the strictest wins (e.g. by IP and by account). Defaults
+     * to the client IP only.
+     */
+    by?: (c: Context) => (string | null | undefined)[] | Promise<(string | null | undefined)[]>;
+
+    /** Reject with 429 instead of allowing through when the cache is unavailable. */
+    failClosed?: boolean;
+
+    /** Message for the 429 response. */
+    message?: string;
+}
+
+/**
+ * Best-effort client IP from the proxy chain. Mirrors the request logger; the
+ * leftmost X-Forwarded-For hop is client-spoofable, so pair this with an
+ * account/target dimension for anything security-sensitive.
+ */
+export function getClientIp(c: Context): string
+{
+    const forwardedFor = c.req.header('x-forwarded-for');
+
+    return forwardedFor?.split(',')[0]?.trim()
+        || c.req.header('x-real-ip')
+        || 'unknown';
+}
+
+/**
+ * Redis-backed fixed-window rate limiter.
+ *
+ * @example
+ * ```typescript
+ * route.post('/_auth/login')
+ *     .use([rateLimit({ limit: 10, windowMs: 60_000 })])
+ *     .handler(...);
+ * ```
+ */
+export const rateLimit = defineMiddlewareFactory(
+    'rateLimit',
+    (options: RateLimitOptions): MiddlewareHandler =>
+    {
+        const { limit, windowMs, scope, by, failClosed = false, message } = options;
+
+        return async (c, next) =>
+        {
+            const cache = getCache();
+
+            if (!cache || isCacheDisabled())
+            {
+                if (failClosed)
+                {
+                    throw new TooManyRequestsError({ message: message || 'Rate limiter unavailable' });
+                }
+
+                rateLimitLogger.warn('Cache unavailable — rate limit not enforced (fail-open)', {
+                    path: c.req.path,
+                });
+
+                return next();
+            }
+
+            const dimensions = (by ? await by(c) : [getClientIp(c)])
+                .filter((d): d is string => Boolean(d));
+
+            const ns = scope || `${c.req.method} ${c.req.routePath || c.req.path}`;
+
+            for (const dimension of dimensions)
+            {
+                const [count, pttl] = await cache.eval(
+                    FIXED_WINDOW_LUA,
+                    1,
+                    `ratelimit:${ns}:${dimension}`,
+                    String(windowMs),
+                ) as [number, number];
+
+                if (count > limit)
+                {
+                    const retryAfter = Math.max(1, Math.ceil((pttl > 0 ? pttl : windowMs) / 1000));
+                    c.header('Retry-After', String(retryAfter));
+
+                    throw new TooManyRequestsError({
+                        message: message || 'Too many requests, please try again later',
+                        retryAfter,
+                    });
+                }
+            }
+
+            return next();
+        };
+    },
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,11 @@ overrides:
   react-dom: ^19.0.0
   '@types/react': ^19
   '@types/react-dom': ^19
-  drizzle-orm: ^0.45.0
+  drizzle-orm: ^0.45.2
   next: ^16.1.7
+  picomatch: ^2.3.2
+  shell-quote: ^1.8.4
+  jws: ^3.2.3
 
 importers:
 
@@ -21,7 +24,7 @@ importers:
         version: 0.34.41
       drizzle-typebox:
         specifier: ^0.3.3
-        version: 0.3.3(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
+        version: 0.3.3(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
     devDependencies:
       '@stylistic/eslint-plugin':
         specifier: ^5.10.0
@@ -103,11 +106,11 @@ importers:
         specifier: ^9.2.1
         version: 9.2.1
       drizzle-orm:
-        specifier: ^0.45.0
-        version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
       drizzle-typebox:
         specifier: ^0.1.0
-        version: 0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
+        version: 0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
       next:
         specifier: ^16.1.7
         version: 16.2.2(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -173,11 +176,11 @@ importers:
         specifier: ^9.2.1
         version: 9.2.1
       drizzle-orm:
-        specifier: ^0.45.0
-        version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
       drizzle-typebox:
         specifier: ^0.1.0
-        version: 0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
+        version: 0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
       next:
         specifier: ^16.1.7
         version: 16.2.2(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -234,8 +237,8 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3
       drizzle-orm:
-        specifier: ^0.45.0
-        version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
       jose:
         specifier: ^6.1.0
         version: 6.1.0
@@ -274,8 +277,8 @@ importers:
         specifier: ^0.31.6
         version: 0.31.8
       hono:
-        specifier: ^4.12.4
-        version: 4.12.9
+        specifier: ^4.12.25
+        version: 4.12.27
       madge:
         specifier: ^8.0.0
         version: 8.0.0(typescript@5.9.3)
@@ -316,8 +319,8 @@ importers:
         specifier: ^0.31.6
         version: 0.31.8
       drizzle-orm:
-        specifier: ^0.45.0
-        version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
       execa:
         specifier: ^8.0.1
         version: 8.0.1
@@ -371,8 +374,8 @@ importers:
         specifier: ^0.34.0
         version: 0.34.41
       drizzle-orm:
-        specifier: ^0.45.0
-        version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -409,7 +412,7 @@ importers:
         version: 0.31.8
       drizzle-typebox:
         specifier: ^0.1.0
-        version: 0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
+        version: 0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
       glob:
         specifier: 11.1.0
         version: 11.1.0
@@ -438,8 +441,8 @@ importers:
   packages/core:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.0.0
-        version: 1.19.5(hono@4.12.9)
+        specifier: ^1.19.13
+        version: 1.19.14(hono@4.12.27)
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.41
@@ -453,14 +456,14 @@ importers:
         specifier: ^17.2.3
         version: 17.2.3
       drizzle-orm:
-        specifier: ^0.45.0
-        version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
       drizzle-typebox:
         specifier: ^0.1.0
-        version: 0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
+        version: 0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7))
       hono:
-        specifier: ^4.12.4
-        version: 4.12.9
+        specifier: ^4.12.25
+        version: 4.12.27
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -477,8 +480,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       undici:
-        specifier: ^7.24.0
-        version: 7.24.7
+        specifier: ^7.28.0
+        version: 7.28.0
       zod:
         specifier: ^4.1.11
         version: 4.1.13
@@ -487,8 +490,8 @@ importers:
         specifier: ^5.4.1
         version: 5.8.2
       ws:
-        specifier: ^8.0.0
-        version: 8.18.3
+        specifier: ^8.21.0
+        version: 8.21.0
     devDependencies:
       '@types/micromatch':
         specifier: ^4.0.9
@@ -549,8 +552,8 @@ importers:
         specifier: ^0.31.6
         version: 0.31.8
       drizzle-orm:
-        specifier: ^0.45.0
-        version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
       madge:
         specifier: ^8.0.0
         version: 8.0.0(typescript@5.9.3)
@@ -586,8 +589,8 @@ importers:
         specifier: ^0.31.8
         version: 0.31.8
       drizzle-orm:
-        specifier: ^0.45.0
-        version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
       madge:
         specifier: ^8.0.0
         version: 8.0.0(typescript@5.9.3)
@@ -617,8 +620,8 @@ importers:
         specifier: ^0.31.8
         version: 0.31.8
       drizzle-orm:
-        specifier: ^0.45.0
-        version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2)
@@ -1903,8 +1906,8 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@1.19.5':
-    resolution: {integrity: sha512-iBuhh+uaaggeAuf+TftcjZyWh2GEgZcVGXkNtskLVoWaXhnJtC5HLHrU8W1KHDoucqO1MswwglmkWLFyiDn4WQ==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -3213,8 +3216,8 @@ packages:
     resolution: {integrity: sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==}
     hasBin: true
 
-  drizzle-orm@0.45.0:
-    resolution: {integrity: sha512-lyd9VRk3SXKRjV/gQckQzmJgkoYMvVG3A2JAV0vh3L+Lwk+v9+rK5Gj0H22y+ZBmxsrRBgJ5/RbQCN7DWd1dtQ==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -3309,13 +3312,13 @@ packages:
     resolution: {integrity: sha512-eNIDe+EOCB96/bbRHOPbrC+bsuCXFd2H0/96Fl0cJkY+NKnu2qLTnGI6ILXPbyu82Yr1tsShlzDypw+VeCDqaQ==}
     peerDependencies:
       '@sinclair/typebox': '>=0.17.6'
-      drizzle-orm: ^0.45.0
+      drizzle-orm: ^0.45.2
 
   drizzle-typebox@0.3.3:
     resolution: {integrity: sha512-iJpW9K+BaP8+s/ImHxOFVjoZk9G5N/KXFTOpWcFdz9SugAOWv2fyGaH7FmqgdPo+bVNYQW0OOI3U9dkFIVY41w==}
     peerDependencies:
       '@sinclair/typebox': '>=0.34.8'
-      drizzle-orm: ^0.45.0
+      drizzle-orm: ^0.45.2
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -3483,7 +3486,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^2.3.2
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3608,8 +3611,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.9:
-    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3812,8 +3815,8 @@ packages:
   jwa@1.4.2:
     resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
 
-  jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+  jws@3.2.3:
+    resolution: {integrity: sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4246,13 +4249,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -4481,8 +4480,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -4778,8 +4777,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.24.7:
-    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -4934,8 +4933,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6701,9 +6700,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.5(hono@4.12.9)':
+  '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
-      hono: 4.12.9
+      hono: 4.12.27
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -7238,7 +7237,7 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.3
+      picomatch: 2.3.2
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.5)':
     dependencies:
@@ -7887,7 +7886,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.9.0
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -8078,22 +8077,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7):
+  drizzle-orm@0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7):
     optionalDependencies:
       '@types/pg': 8.15.6
       gel: 2.1.1
       pg: 8.16.3
       postgres: 3.4.7
 
-  drizzle-typebox@0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)):
+  drizzle-typebox@0.1.1(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)):
     dependencies:
       '@sinclair/typebox': 0.34.41
-      drizzle-orm: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+      drizzle-orm: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
 
-  drizzle-typebox@0.3.3(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)):
+  drizzle-typebox@0.3.3(@sinclair/typebox@0.34.41)(drizzle-orm@0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)):
     dependencies:
       '@sinclair/typebox': 0.34.41
-      drizzle-orm: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
+      drizzle-orm: 0.45.2(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
 
   eastasianwidth@0.2.0: {}
 
@@ -8358,9 +8357,9 @@ snapshots:
       path-expression-matcher: 1.2.1
       strnum: 2.2.2
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@2.3.2):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 2.3.2
 
   figures@6.1.0:
     dependencies:
@@ -8430,7 +8429,7 @@ snapshots:
       debug: 4.4.3
       env-paths: 3.0.0
       semver: 7.7.4
-      shell-quote: 1.8.3
+      shell-quote: 1.9.0
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -8503,7 +8502,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.9: {}
+  hono@4.12.27: {}
 
   html-escaper@2.0.2: {}
 
@@ -8661,7 +8660,7 @@ snapshots:
 
   jsonwebtoken@9.0.2:
     dependencies:
-      jws: 3.2.2
+      jws: 3.2.3
       lodash.includes: 4.3.0
       lodash.isboolean: 3.0.3
       lodash.isinteger: 4.0.4
@@ -8678,7 +8677,7 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
-  jws@3.2.2:
+  jws@3.2.3:
     dependencies:
       jwa: 1.4.2
       safe-buffer: 5.2.1
@@ -8848,7 +8847,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mimic-fn@2.1.0: {}
 
@@ -9111,9 +9110,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
+  picomatch@2.3.2: {}
 
   pirates@4.0.7: {}
 
@@ -9380,7 +9377,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.9.0: {}
 
   siginfo@2.0.0: {}
 
@@ -9546,8 +9543,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@2.3.2)
+      picomatch: 2.3.2
 
   tinyrainbow@3.0.3: {}
 
@@ -9663,7 +9660,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.24.7: {}
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -9700,8 +9697,8 @@ snapshots:
   vite@7.1.12(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@2.3.2)
+      picomatch: 2.3.2
       postcss: 8.5.6
       rollup: 4.53.3
       tinyglobby: 0.2.15
@@ -9728,7 +9725,7 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 2.3.2
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
@@ -9789,7 +9786,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.3:
+  ws@8.21.0:
     optional: true
 
   xtend@4.0.2: {}


### PR DESCRIPTION
Addresses the P0 findings from the 2026-06-26 security/performance audit of `@spfn/core` and `@spfn/auth` (full report kept in `artifacts/security-perf-review-core-auth-2026-06-26.md`).

## Changes

**S-H1 — invitation privilege escalation (high).** `createInvitation` accepted an arbitrary `roleId` and only checked the role existed, so any `user:invite` holder could invite with the superadmin roleId and self-accept to bootstrap a superadmin. Centralized the role-assignment authority rule in `assertCanAssignRole` and applied it to both `createInvitation` (was unguarded) and `updateUserRole` (replacing its inline guard).

**S-M3 — OTP entropy (medium).** Verification codes now use `crypto.randomInt` instead of the predictable `Math.random`.

**Dependency CVE bumps.** drizzle-orm ≥0.45.2 (SQL injection), hono ≥4.12.25 (CORS credential reflection + ~19 more), @hono/node-server ≥1.19.13, undici ≥7.28.0, ws ≥8.21.0; pnpm overrides for picomatch ≥2.3.2, shell-quote ≥1.8.4, jws ≥3.2.3.

**S-H2 — rate limiting (high).** New Redis-backed fixed-window `rateLimit` middleware in core (registered under the named `rateLimit` slot, atomic Lua INCR+PEXPIRE, fails open with a warning when no cache is configured). Applied per-IP to `/_auth/login`, `/_auth/codes`, `/_auth/codes/verify`, `/_auth/exists`, and the OAuth start routes.

## Verification

Unit suites green (core 407, auth 176 + 5 rate-limit + 5 guard), type-check, build, madge circular check, and codegen (no route-map diff) all pass. Changes are schema-neutral.

## Notes / follow-ups (not in this PR)

- Per-account/target rate-limit keying needs request-body access in the middleware; deferred to verify against the full route pipeline.
- The auth **integration** harness (`src/__tests__/helpers/db.ts`) has pre-existing schema drift — it hand-maintains table DDL that has fallen out of sync with the entities (missing `metadata`, `public_id`, `username`, …). Unrelated to this PR; tracked for a separate fix (migrate the harness to schema-from-entities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)