### PR TITLE
fix(core): stop leaking DB error text and env secrets in production

### DIFF
--- a/packages/core/src/env/__tests__/validator.test.ts
+++ b/packages/core/src/env/__tests__/validator.test.ts
@@ -203,6 +203,14 @@ describe('parsePostgresUrl', () =>
     {
         expect(() => parsePostgresUrl('mysql://localhost/db')).toThrow('Must be a PostgreSQL URL');
     });
+
+    it('does not echo the value (credentials) in the parse error', () =>
+    {
+        const malformed = 'not a url with s3cr3t-pw';
+        expect(() => parsePostgresUrl(malformed)).toThrow('Invalid PostgreSQL URL');
+        try { parsePostgresUrl(malformed); }
+        catch (e) { expect((e as Error).message).not.toContain('s3cr3t'); }
+    });
 });
 
 describe('parseRedisUrl', () =>
@@ -216,6 +224,14 @@ describe('parseRedisUrl', () =>
     it('should throw on non-Redis URL', () =>
     {
         expect(() => parseRedisUrl('http://localhost')).toThrow('Must be a Redis URL');
+    });
+
+    it('does not echo the value (credentials) in the parse error', () =>
+    {
+        const malformed = 'not a url with s3cr3t-pw';
+        expect(() => parseRedisUrl(malformed)).toThrow('Invalid Redis URL');
+        try { parseRedisUrl(malformed); }
+        catch (e) { expect((e as Error).message).not.toContain('s3cr3t'); }
     });
 });
 

--- a/packages/core/src/env/registry.ts
+++ b/packages/core/src/env/registry.ts
@@ -200,7 +200,12 @@ export class EnvRegistry<T extends EnvSchemaCollection = EnvSchemaCollection>
         }
         catch (error)
         {
-            const errorMsg = `${key} validation failed: ${error instanceof Error ? error.message : String(error)}`;
+            // For sensitive keys, never log the validator's message — it may have
+            // interpolated the secret value (e.g. a DB/Redis URL with credentials).
+            const detail = schema.sensitive
+                ? '(value hidden — sensitive key)'
+                : (error instanceof Error ? error.message : String(error));
+            const errorMsg = `${key} validation failed: ${detail}`;
             envLogger.error(`Environment validation failed:\n  - ${errorMsg}`);
             throw new Error('Environment validation failed');
         }

--- a/packages/core/src/env/validator.ts
+++ b/packages/core/src/env/validator.ts
@@ -371,7 +371,8 @@ export function parsePostgresUrl(value: string): string
     {
         if (error instanceof TypeError)
         {
-            throw new Error(`Invalid PostgreSQL URL: ${value}`);
+            // Never echo the value — these URLs carry embedded credentials
+            throw new Error('Invalid PostgreSQL URL');
         }
         throw error;
     }
@@ -414,7 +415,8 @@ export function parseRedisUrl(value: string): string
     {
         if (error instanceof TypeError)
         {
-            throw new Error(`Invalid Redis URL: ${value}`);
+            // Never echo the value — these URLs carry embedded credentials
+            throw new Error('Invalid Redis URL');
         }
         throw error;
     }

--- a/packages/core/src/errors/database-errors.ts
+++ b/packages/core/src/errors/database-errors.ts
@@ -31,6 +31,18 @@ export class DatabaseError<TDetails extends Record<string, unknown> = Record<str
         this.details = data.details;
         Error.captureStackTrace(this, this.constructor);
     }
+
+    /**
+     * Whether this error's message/details are derived from the raw database
+     * driver (SQL text, table/column/constraint names, parameter values) and
+     * therefore must NOT be exposed to clients in production. Defined as a
+     * prototype getter so it is never serialized into the response by toJSON().
+     * Subclasses with a safe, constructed message override this to `false`.
+     */
+    get internal(): boolean
+    {
+        return true;
+    }
 }
 
 /**
@@ -89,6 +101,12 @@ export class EntityNotFoundError extends QueryError
         this.name = 'EntityNotFoundError';
         this.resource = data.resource;
         this.id = data.id;
+    }
+
+    // Message/details are constructed from the resource + id, not driver text
+    override get internal(): boolean
+    {
+        return false;
     }
 }
 
@@ -163,5 +181,11 @@ export class DuplicateEntryError extends QueryError
         this.name = 'DuplicateEntryError';
         this.field = data.field;
         this.value = data.value;
+    }
+
+    // Message/details are constructed from the parsed field/value, not raw SQL
+    override get internal(): boolean
+    {
+        return false;
     }
 }

--- a/packages/core/src/middleware/README.md
+++ b/packages/core/src/middleware/README.md
@@ -147,6 +147,14 @@ Converts a thrown error into a JSON HTTP response. Register it with **`app.onErr
 - **Standard `Error`** → falls back to `{ __type: 'Error', message }`, status from a
   `statusCode` property on the error if present, else `500`.
 - **`cause` chain** → the root cause message is extracted and added as `cause`.
+- **Production information disclosure** → when `includeStack` is `false` (the production
+  default), the client message is genericized for anything whose text may come from the DB
+  driver: standard (uncaught) `Error`s become `"Internal Server Error"` with no `cause`, and
+  any error exposing `internal === true` (the `DatabaseError` family — `QueryError`,
+  `ConnectionError`, `TransactionError`, … carrying raw SQL / table / column / parameter
+  text) becomes `"Internal server error"` with no `details`. Full detail is still logged
+  server-side. Errors with a safe, constructed message (`EntityNotFoundError`,
+  `DuplicateEntryError`, and all non-DB `SerializableError`s) are returned unchanged.
 - **Logging** (when `enableLogging`): `warn` for 4xx, `error` for 5xx, via the
   `@spfn/core:error-handler` logger.
 - **`onError` callback** → fired non-blocking (`Promise.resolve(...).catch(...)`); never

--- a/packages/core/src/middleware/__tests__/error-handler.test.ts
+++ b/packages/core/src/middleware/__tests__/error-handler.test.ts
@@ -11,6 +11,9 @@ import {
     InternalServerError,
     ValidationError,
 } from '@spfn/core/errors';
+// Imported from source so the `internal` getter under test is exercised
+// regardless of the built dist freshness.
+import { QueryError, EntityNotFoundError } from '../../errors/database-errors';
 
 describe('ErrorHandler Middleware', () =>
 {
@@ -304,6 +307,95 @@ describe('ErrorHandler Middleware', () =>
             const res = await app.request('/error');
 
             expect(res.status).toBe(400);
+        });
+    });
+
+    describe('Production information disclosure', () =>
+    {
+        // Simulate a raw driver error as built by fromPostgresError
+        const RAW_SQL = 'column "secret_col" does not exist';
+
+        it('hides DB-driver message for internal errors in production (includeStack=false)', async () =>
+        {
+            const app = new Hono();
+            app.onError(ErrorHandler({ includeStack: false, enableLogging: false }));
+            app.get('/q', () =>
+            {
+                throw new QueryError({ message: RAW_SQL, statusCode: 500, details: { code: '42703' } });
+            });
+
+            const res = await app.request('/q');
+            const json: any = await res.json();
+
+            expect(res.status).toBe(500);
+            expect(json.__type).toBe('QueryError');
+            expect(json.message).toBe('Internal server error');
+            expect(JSON.stringify(json)).not.toContain('secret_col');
+            expect(json.details).toBeUndefined();
+        });
+
+        it('hides schema-revealing 4xx driver errors too', async () =>
+        {
+            const app = new Hono();
+            app.onError(ErrorHandler({ includeStack: false, enableLogging: false }));
+            app.get('/q', () =>
+            {
+                throw new QueryError({ message: RAW_SQL, statusCode: 400, details: { code: '42703' } });
+            });
+
+            const res = await app.request('/q');
+            const json: any = await res.json();
+
+            expect(res.status).toBe(400);
+            expect(json.message).toBe('Internal server error');
+            expect(JSON.stringify(json)).not.toContain('secret_col');
+        });
+
+        it('keeps the full driver message in development (includeStack=true)', async () =>
+        {
+            const app = new Hono();
+            app.onError(ErrorHandler({ includeStack: true, enableLogging: false }));
+            app.get('/q', () =>
+            {
+                throw new QueryError({ message: RAW_SQL, statusCode: 500 });
+            });
+
+            const json: any = await (await app.request('/q')).json();
+            expect(json.message).toBe(RAW_SQL);
+        });
+
+        it('still exposes errors with a safe constructed message (EntityNotFoundError) in production', async () =>
+        {
+            const app = new Hono();
+            app.onError(ErrorHandler({ includeStack: false, enableLogging: false }));
+            app.get('/e', () =>
+            {
+                throw new EntityNotFoundError({ resource: 'User', id: 42 });
+            });
+
+            const res = await app.request('/e');
+            const json: any = await res.json();
+
+            expect(res.status).toBe(404);
+            expect(json.message).toBe('User with id 42 not found');
+        });
+
+        it('genericizes uncaught standard errors and drops cause in production', async () =>
+        {
+            const app = new Hono();
+            app.onError(ErrorHandler({ includeStack: false, enableLogging: false }));
+            app.get('/raw', () =>
+            {
+                throw new Error('Failed query: select * from users\nparams: secret');
+            });
+
+            const res = await app.request('/raw');
+            const json: any = await res.json();
+
+            expect(res.status).toBe(500);
+            expect(json.message).toBe('Internal Server Error');
+            expect(json.cause).toBeUndefined();
+            expect(JSON.stringify(json)).not.toContain('secret');
         });
     });
 });

--- a/packages/core/src/middleware/error-handler.ts
+++ b/packages/core/src/middleware/error-handler.ts
@@ -259,6 +259,17 @@ export function ErrorHandler(options: ErrorHandlerOptions = {}): (err: Error, c:
                     .catch(e => errorLogger.warn('onError callback failed', e as Error));
             }
 
+            // Internal (DB-driver-derived) errors must not leak SQL text, schema
+            // names, or parameter values to clients in production. Full detail is
+            // kept in the log above; the client gets a generic message.
+            if ((err as { internal?: boolean }).internal === true && !includeStack)
+            {
+                return c.json(
+                    { __type: err.constructor.name, message: 'Internal server error' },
+                    statusCode as ContentfulStatusCode,
+                );
+            }
+
             // Use toJSON() for automatic serialization
             const serialized = err.toJSON();
 
@@ -295,13 +306,15 @@ export function ErrorHandler(options: ErrorHandlerOptions = {}): (err: Error, c:
                 .catch(e => errorLogger.warn('onError callback failed', e as Error));
         }
 
-        // Standard error response
+        // Standard (non-SerializableError) errors are uncaught/internal — their
+        // message and cause may contain raw SQL or driver text (e.g. an uncaught
+        // Drizzle error), so only expose them in development.
         const response: StandardErrorResponse = {
             __type: 'Error',
-            message: err.message || 'Internal Server Error',
+            message: includeStack ? (err.message || 'Internal Server Error') : 'Internal Server Error',
         };
 
-        if (causeMessage)
+        if (causeMessage && includeStack)
         {
             response.cause = causeMessage;
         }


### PR DESCRIPTION
Two information-disclosure fixes from the 2026-06-26 security audit (P1: S-M2, S-M5). Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## S-M2 — DB driver error text reaching clients (CWE-209)

Raw driver text (SQL, table/column/constraint names, submitted parameter values) surfaced in production error responses — `SerializableError.toJSON()` always emitted `message`/`details`, and the standard-error fallback returned `message`/`cause` unconditionally. When `includeStack` is `false` (the production default), the handler now:

- genericizes uncaught standard `Error`s to `"Internal Server Error"` and drops `cause` (an uncaught Drizzle error reads `Failed query: <SQL>\nparams: <…>`);
- genericizes any error exposing `internal === true`. A new prototype getter on `DatabaseError` marks the driver-derived family (`QueryError`/`ConnectionError`/`TransactionError`, including the schema-revealing **4xx** `QueryError`) as internal. `EntityNotFoundError` and `DuplicateEntryError` override it to `false` (their messages are safely constructed). The getter lives on the prototype so it is never serialized by `toJSON()`.

Full detail is still written server-side via the logger. Non-DB `SerializableError`s (NotFound, Validation, …) are unchanged.

## S-M5 — env secrets in validation logs (CWE-532)

`parsePostgresUrl`/`parseRedisUrl` interpolated the raw value (a URL with embedded credentials) into the error on a malformed-URL throw, and the env registry logged it verbatim. The validators no longer echo the value, and the registry redacts the validator message for keys marked `sensitive` (defense-in-depth against custom validators).

## Verification

Core unit suites green (414 passed), type-check clean, madge circular check clean, build succeeds. New tests cover production genericization (internal + standard errors, 4xx schema leak, safe-message passthrough) and that the URL parsers don't echo the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)