### PR TITLE
fix(core): harden the WebSocket transport (backpressure, liveness, limits)

### DIFF
--- a/packages/core/src/event/README.md
+++ b/packages/core/src/event/README.md
@@ -665,6 +665,22 @@ client.send('ping', {});
 `{ payload, subject?, ws }` (`WSMessageContext`). See `@spfn/core/event/ws` exports for
 `WSHandlerConfig`, `WSAuthConfig`, `WSClientConfig`, etc.
 
+### Resource limits & backpressure (`WSHandlerConfig`)
+
+The WS server is hardened like the SSE path — a slow or dead client cannot exhaust memory
+or connection slots:
+
+| Option | Default | Effect |
+|---|---|---|
+| `maxPayload` | `1048576` (1 MiB) | Max inbound frame size; larger frames are rejected by `ws` before they are buffered/parsed. |
+| `maxBufferedBytes` | `1048576` (1 MiB) | Backpressure cap — if a connection's outbound buffer (`bufferedAmount`) exceeds this, the connection is closed with `1013` instead of buffering more (no OOM from a slow consumer). The client reconnects and re-subscribes. |
+| `maxConnections` | `10000` | Global concurrent-connection cap; connections beyond it are rejected with `1013`. |
+| `maxConnectionsPerSubject` | `0` (unlimited) | Per-authenticated-subject connection cap. |
+
+Keep-alive also tracks **pongs**: a socket that doesn't answer a ping by the next
+`pingInterval` tick is `terminate()`d, so half-open connections (sleeping device, NAT drop)
+are reaped instead of lingering with their subscriptions and buffers.
+
 ---
 
 ## Types reference

--- a/packages/core/src/event/ws/__tests__/safe-send.test.ts
+++ b/packages/core/src/event/ws/__tests__/safe-send.test.ts
@@ -1,0 +1,60 @@
+/**
+ * WebSocket backpressure (safeSend) tests
+ *
+ * safeSend is the gate that protects against OOM from a slow consumer: it must
+ * close the connection once the outbound buffer is past the cap instead of
+ * queueing more frames.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { safeSend } from '../handler';
+
+const OPEN = 1;
+
+function fakeWs(overrides: Record<string, unknown> = {})
+{
+    return {
+        readyState: OPEN,
+        bufferedAmount: 0,
+        send: vi.fn(),
+        close: vi.fn(),
+        ...overrides,
+    };
+}
+
+describe('safeSend (WS backpressure)', () =>
+{
+    it('sends a JSON frame when the buffer is under the cap', () =>
+    {
+        const ws = fakeWs();
+        safeSend(ws, { type: 'x', data: 1 }, 1000);
+
+        expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'x', data: 1 }));
+        expect(ws.close).not.toHaveBeenCalled();
+    });
+
+    it('closes the connection (1013) instead of sending when the buffer is over the cap', () =>
+    {
+        const ws = fakeWs({ bufferedAmount: 2000 });
+        safeSend(ws, { type: 'x', data: 1 }, 1000);
+
+        expect(ws.send).not.toHaveBeenCalled();
+        expect(ws.close).toHaveBeenCalledWith(1013, 'Send buffer overflow');
+    });
+
+    it('does nothing when the socket is not open', () =>
+    {
+        const ws = fakeWs({ readyState: 3 /* CLOSED */ });
+        safeSend(ws, { type: 'x' }, 1000);
+
+        expect(ws.send).not.toHaveBeenCalled();
+        expect(ws.close).not.toHaveBeenCalled();
+    });
+
+    it('swallows a send that throws (socket closed mid-send)', () =>
+    {
+        const ws = fakeWs({ send: vi.fn(() => { throw new Error('closed'); }) });
+
+        expect(() => safeSend(ws, { type: 'x' }, 1000)).not.toThrow();
+    });
+});

--- a/packages/core/src/event/ws/handler.ts
+++ b/packages/core/src/event/ws/handler.ts
@@ -43,6 +43,10 @@ export async function attachWSHandler<
     const {
         pingInterval = 30000,
         path = '/ws',
+        maxPayload = 1_048_576,
+        maxBufferedBytes = 1_048_576,
+        maxConnections = 10_000,
+        maxConnectionsPerSubject = 0,
         auth: authConfig,
     } = config;
 
@@ -54,16 +58,31 @@ export async function attachWSHandler<
         );
     }
 
-    const wss = new WebSocketServer({ server, path });
+    const wss = new WebSocketServer({ server, path, maxPayload });
 
     // Track live connections for graceful shutdown
     const clients = new Set<any>();
+    // Live connection count per authenticated subject (for the per-subject cap)
+    const subjectCounts = new Map<string, number>();
 
     wss.on('connection', (ws: any, req: any) =>
     {
+        // Global connection cap — reject before doing any work
+        if (clients.size >= maxConnections)
+        {
+            ws.close(1013, 'Server at capacity');
+
+            return;
+        }
+
         clients.add(ws);
         ws.on('close', () => clients.delete(ws));
-        handleConnection(ws, req, router, authConfig, tokenManager, pingInterval)
+        handleConnection(ws, req, router, authConfig, tokenManager, {
+            pingInterval,
+            maxBufferedBytes,
+            maxConnectionsPerSubject,
+            subjectCounts,
+        })
             .catch((err: Error) =>
             {
                 wsLogger.error('WebSocket connection handler error', err);
@@ -102,15 +121,24 @@ export async function attachWSHandler<
 // Connection Handler
 // ============================================================================
 
+interface ConnectionOptions
+{
+    pingInterval: number;
+    maxBufferedBytes: number;
+    maxConnectionsPerSubject: number;
+    subjectCounts: Map<string, number>;
+}
+
 async function handleConnection(
     ws: any,
     req: any,
     router: WSRouterDef<any, any>,
     authConfig: WSHandlerAuthConfig | undefined,
     tokenManager: SSETokenManager | undefined,
-    pingInterval: number,
+    opts: ConnectionOptions,
 ): Promise<void>
 {
+    const { pingInterval, maxBufferedBytes, maxConnectionsPerSubject, subjectCounts } = opts;
     // Register close handler before any await — ensures we never miss the event even during auth
     let pingTimer: ReturnType<typeof setInterval> | undefined;
     let connectionUnsubscribes: (() => void)[] = [];
@@ -164,6 +192,26 @@ async function handleConnection(
         return;
     }
 
+    // ── Per-subject connection cap (authenticated subjects only) ──
+    if (maxConnectionsPerSubject > 0 && typeof subject === 'string')
+    {
+        const current = subjectCounts.get(subject) ?? 0;
+        if (current >= maxConnectionsPerSubject)
+        {
+            ws.close(1013, 'Too many connections for this subject');
+
+            return;
+        }
+
+        subjectCounts.set(subject, current + 1);
+        ws.on('close', () =>
+        {
+            const remaining = (subjectCounts.get(subject) ?? 1) - 1;
+            if (remaining <= 0) subjectCounts.delete(subject);
+            else subjectCounts.set(subject, remaining);
+        });
+    }
+
     subscribedEvents = allowedEvents;
     wsLogger.info('WebSocket connection established', {
         events: allowedEvents,
@@ -171,10 +219,10 @@ async function handleConnection(
     });
 
     // ── 4. Build connection wrapper ──
-    const connection = createConnection(ws);
+    const connection = createConnection(ws, maxBufferedBytes);
 
     // ── 5. Subscribe to server-push events ──
-    connectionUnsubscribes = subscribeEvents(ws, router, allowedEvents, subject, authConfig);
+    connectionUnsubscribes = subscribeEvents(ws, router, allowedEvents, subject, authConfig, maxBufferedBytes);
 
     // If socket closed during auth awaits, clean up and bail
     if (ws.readyState !== 1)
@@ -192,12 +240,31 @@ async function handleConnection(
             .catch((err: Error) => wsLogger.error('Unhandled message error', err));
     });
 
-    // ── 7. Keep-alive ping ──
+    // ── 7. Keep-alive ping with liveness (pong) tracking ──
+    // Without reaping un-ponged sockets, a half-open connection (sleeping device,
+    // NAT drop with no FIN) lingers with its subscriptions, timer, and buffers.
     if (pingInterval > 0)
     {
+        ws.isAlive = true;
+        ws.on('pong', () =>
+        {
+            ws.isAlive = true;
+        });
+
         pingTimer = setInterval(() =>
         {
-            if (ws.readyState === 1) ws.ping();
+            if (ws.readyState !== 1) return;
+
+            if (ws.isAlive === false)
+            {
+                // No pong since the previous tick — drop the dead/half-open socket
+                ws.terminate();
+
+                return;
+            }
+
+            ws.isAlive = false;
+            ws.ping();
         }, pingInterval);
     }
 
@@ -280,14 +347,37 @@ async function resolveAllowedEvents(
     return allowed.length === 0 ? null : allowed;
 }
 
-function createConnection(ws: any): WSRawConnection
+/**
+ * Send a JSON frame with backpressure protection. If the socket's outbound
+ * buffer is already past the cap, the consumer is too slow — close the
+ * connection (1013) instead of buffering more and risking OOM. The client
+ * reconnects and re-subscribes.
+ */
+export function safeSend(ws: any, frame: unknown, maxBufferedBytes: number): void
+{
+    if (ws.readyState !== 1) return;
+
+    if (ws.bufferedAmount > maxBufferedBytes)
+    {
+        ws.close(1013, 'Send buffer overflow');
+
+        return;
+    }
+
+    try
+    {
+        ws.send(JSON.stringify(frame));
+    }
+    catch
+    {
+        // Socket closed between the readyState check and send — ignore
+    }
+}
+
+function createConnection(ws: any, maxBufferedBytes: number): WSRawConnection
 {
     return {
-        send: (type, payload) =>
-        {
-            if (ws.readyState !== 1) return;
-            ws.send(JSON.stringify({ type, data: payload }));
-        },
+        send: (type, payload) => safeSend(ws, { type, data: payload }, maxBufferedBytes),
         close: (code, reason) => ws.close(code, reason),
     };
 }
@@ -297,7 +387,8 @@ function subscribeEvents(
     router: WSRouterDef<any, any>,
     allowedEvents: string[],
     subject: string | undefined,
-    authConfig?: WSHandlerAuthConfig,
+    authConfig: WSHandlerAuthConfig | undefined,
+    maxBufferedBytes: number,
 ): (() => void)[]
 {
     const unsubscribes: (() => void)[] = [];
@@ -316,14 +407,7 @@ function subscribeEvents(
                 if (!authConfig.filter[eventName](subject, payload)) return;
             }
 
-            try
-            {
-                ws.send(JSON.stringify({ type: eventName, data: payload }));
-            }
-            catch
-            {
-                // Socket closed between readyState check and send — ignore
-            }
+            safeSend(ws, { type: eventName, data: payload }, maxBufferedBytes);
         });
 
         unsubscribes.push(unsubscribe);

--- a/packages/core/src/event/ws/types.ts
+++ b/packages/core/src/event/ws/types.ts
@@ -149,6 +149,34 @@ export interface WSHandlerConfig
     channelPrefix?: string;
 
     /**
+     * Maximum inbound message size in bytes. Frames larger than this are
+     * rejected by the ws library before they are buffered or parsed.
+     * @default 1048576 (1 MiB)
+     */
+    maxPayload?: number;
+
+    /**
+     * Backpressure cap: if a connection's outbound buffer (`bufferedAmount`)
+     * exceeds this many bytes, the connection is closed (1013) instead of
+     * buffering more — a slow consumer cannot drive the process to OOM.
+     * @default 1048576 (1 MiB)
+     */
+    maxBufferedBytes?: number;
+
+    /**
+     * Maximum number of concurrent connections accepted by this server. New
+     * connections beyond the cap are rejected with close code 1013.
+     * @default 10000
+     */
+    maxConnections?: number;
+
+    /**
+     * Maximum concurrent connections per authenticated subject (0 = unlimited).
+     * @default 0
+     */
+    maxConnectionsPerSubject?: number;
+
+    /**
      * Authentication and authorization configuration
      */
     auth?: WSHandlerAuthConfig;


### PR DESCRIPTION
P2 from the security/performance audit. The SSE path was hardened with a bounded writer + heartbeat in PR #17; the WebSocket path never got the equivalent, so one slow or half-open client could OOM the process or exhaust connection slots (P-H2, P-H3, P-M5, S-L6). Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## Changes

- **Backpressure (P-H2)** — server pushes go through `safeSend()`, which closes the connection (`1013`) when `ws.bufferedAmount` exceeds `maxBufferedBytes` instead of buffering unbounded frames for a slow consumer.
- **Liveness (P-H3)** — keep-alive now tracks pongs and `terminate()`s any socket that didn't answer since the previous ping tick, reaping half-open connections (sleeping device / NAT drop) instead of leaving them with their subscriptions, timer, and buffers.
- **maxPayload (S-L6)** — inbound frames are capped (default 1 MiB) by the `ws` library before they are buffered or `JSON.parse`d.
- **Connection caps (P-M5)** — a global `maxConnections` (default 10k) and an optional `maxConnectionsPerSubject` reject excess connections with `1013`.

New `WSHandlerConfig` knobs (documented in `event/README.md`): `maxPayload`, `maxBufferedBytes`, `maxConnections`, `maxConnectionsPerSubject` — all with safe defaults, so existing apps get the protection automatically.

## Verification

`safeSend` backpressure gate unit-tested (sends under cap, closes `1013` over cap, no-op when closed, swallows mid-send throw). Core event suite green (55), type-check + madge circular + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)