### PR TITLE
fix(auth)!: move password hashing off the event loop (native bcrypt, cost 12)

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -53,7 +53,7 @@ SPFN_AUTH_ADMIN_ACCOUNTS='[{"email":"admin@example.com","password":"Admin!@34","
 # ── Optional ─────────────────────────────────────────────────────────
 SPFN_AUTH_JWT_SECRET=your-jwt-secret        # Default: dev-secret (change in production!)
 SPFN_AUTH_JWT_EXPIRES_IN=7d                 # Default: 7d
-SPFN_AUTH_BCRYPT_SALT_ROUNDS=10             # Default: 10
+SPFN_AUTH_BCRYPT_SALT_ROUNDS=12             # Default: 12 (native bcrypt, off the event loop)
 SPFN_AUTH_SESSION_TTL=7d                    # Default: 7d
 
 # ── Email Service (AWS SES) ──────────────────────────────────────────

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -114,7 +114,7 @@ real secret values out of band, never commit them.
 | `SPFN_API_URL` | `.env.local` | — | default `http://localhost:8790` |
 | `SPFN_AUTH_SESSION_TTL` | both | — | default `7d` (e.g. `7d`, `12h`, `45m`) |
 | `SPFN_AUTH_JWT_SECRET` / `SPFN_AUTH_JWT_EXPIRES_IN` | `.env.server` | — | legacy server-signed JWT mode only |
-| `SPFN_AUTH_BCRYPT_SALT_ROUNDS` | `.env.server` | — | default `10` |
+| `SPFN_AUTH_BCRYPT_SALT_ROUNDS` | `.env.server` | — | default `12` (native bcrypt, off the event loop) |
 | `SPFN_AUTH_COOKIE_SECURE` | both | — | override Secure flag (defaults to `NODE_ENV==='production'`) |
 | `SPFN_AUTH_ADMIN_*` | `.env.server` | — | admin seeding (see below) |
 | `SPFN_AUTH_GOOGLE_CLIENT_ID` / `_CLIENT_SECRET` | `.env.server` | — | enables Google OAuth when both set |

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -103,7 +103,7 @@
     "setupMessage": "  📚 Next steps:\n    1. Add lifecycle: .lifecycle(createAuthLifecycle()) in server.config.ts\n    2. Register router: .packages([authRouter]).use([authenticate]) in router.ts\n    3. Add interceptor: import '@spfn/auth/nextjs/api' in RPC proxy route\n    4. Set env vars: SPFN_AUTH_SESSION_SECRET (.env.local), SPFN_AUTH_VERIFICATION_TOKEN_SECRET (.env.server)\n    5. Run migrations: pnpm spfn db migrate\n    6. Full guide: https://spfn.dev/docs/guides/authentication"
   },
   "dependencies": {
-    "bcryptjs": "^2.4.3",
+    "@node-rs/bcrypt": "^1.10.7",
     "drizzle-orm": "^0.45.0",
     "jose": "^6.1.0",
     "jsonwebtoken": "^9.0.2",
@@ -112,7 +112,6 @@
   "devDependencies": {
     "@spfn/core": "workspace:*",
     "@spfn/notification": "workspace:*",
-    "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.11.0",
     "@types/react": "^19.2.2",

--- a/packages/auth/src/__tests__/unit/password.test.ts
+++ b/packages/auth/src/__tests__/unit/password.test.ts
@@ -19,7 +19,7 @@ describe('Password - Hashing', () =>
         const hash = await hashPassword(password);
 
         expect(hash).toBeTruthy();
-        expect(hash).toMatch(/^\$2[ab]\$\d+\$/); // bcrypt format ($2a or $2b)
+        expect(hash).toMatch(/^\$2[aby]\$\d+\$/); // bcrypt format ($2a/$2b/$2y)
         expect(hash.length).toBe(60); // bcrypt always produces 60-char hashes
     });
 
@@ -38,10 +38,10 @@ describe('Password - Hashing', () =>
         await expect(hashPassword('')).rejects.toThrow('Password cannot be empty');
     });
 
-    it('should use default 10 salt rounds', async () =>
+    it('should use default 12 salt rounds', async () =>
     {
         const hash = await hashPassword('test123');
-        expect(hash).toMatch(/^\$2[ab]\$10\$/); // Default: 10 rounds
+        expect(hash).toMatch(/^\$2[aby]\$12\$/); // Default: 12 rounds
     });
 });
 

--- a/packages/auth/src/config/schema.ts
+++ b/packages/auth/src/config/schema.ts
@@ -106,7 +106,7 @@ export const authEnvSchema = defineEnvSchema({
     SPFN_AUTH_BCRYPT_SALT_ROUNDS: {
         ...envNumber({
             description: 'Bcrypt salt rounds (cost factor, higher = more secure but slower)',
-            default: 10,
+            default: 12,
             required: false,
             examples: [10, 12, 14],
         }),

--- a/packages/auth/src/server/helpers/password.ts
+++ b/packages/auth/src/server/helpers/password.ts
@@ -1,16 +1,23 @@
 /**
  * @spfn/auth - Password Helpers
  *
- * Password hashing and verification using bcrypt
+ * Password hashing and verification using bcrypt (@node-rs/bcrypt).
+ *
+ * Uses the native (Rust/napi) implementation, which runs the CPU-bound key
+ * derivation on the libuv threadpool instead of the main event loop — so
+ * concurrent logins run in parallel and don't head-of-line-block other requests.
+ * Hashes are standard bcrypt ($2*$) and verify against existing bcryptjs hashes.
+ * For very high concurrent-login load, raise UV_THREADPOOL_SIZE toward the core
+ * count (default pool is 4).
  *
  * Security:
- * - Adaptive hashing (configurable rounds)
+ * - Adaptive hashing (configurable rounds, default 12)
  * - Automatic salt generation (per-password)
  * - Constant-time comparison (timing attack protection)
  * - Rainbow table protection
  */
 
-import bcrypt from 'bcryptjs';
+import * as bcrypt from '@node-rs/bcrypt';
 import { env } from '@spfn/auth/config';
 import { createPasswordParser } from '@spfn/core/env';
 
@@ -22,10 +29,10 @@ import { createPasswordParser } from '@spfn/core/env';
  * 2. Apply bcrypt key derivation (2^rounds iterations)
  * 3. Return $2b$rounds$[salt][hash] (60 chars)
  *
- * Salt rounds are configured via SPFN_AUTH_BCRYPT_SALT_ROUNDS:
- * - 10 rounds: ~100ms (default, balanced)
- * - 12 rounds: ~400ms (more secure, slower)
- * - 14 rounds: ~1600ms (very secure, too slow for most apps)
+ * Salt rounds are configured via SPFN_AUTH_BCRYPT_SALT_ROUNDS (native timings):
+ * - 12 rounds: ~200ms (default — OWASP-aligned, off the event loop)
+ * - 10 rounds: ~55ms (faster, lower work factor)
+ * - 14 rounds: ~800ms (very secure, heavy)
  *
  * @param password - Plain text password to hash
  * @returns Bcrypt hash string (includes salt)
@@ -79,7 +86,7 @@ export async function verifyPassword(password: string, hash: string): Promise<bo
         throw new Error('Hash cannot be empty');
     }
 
-    return bcrypt.compare(password, hash);
+    return bcrypt.verify(password, hash);
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,9 +230,9 @@ importers:
 
   packages/auth:
     dependencies:
-      bcryptjs:
-        specifier: ^2.4.3
-        version: 2.4.3
+      '@node-rs/bcrypt':
+        specifier: ^1.10.7
+        version: 1.10.7
       drizzle-orm:
         specifier: ^0.45.0
         version: 0.45.0(@types/pg@8.15.6)(gel@2.1.1)(pg@8.16.3)(postgres@3.4.7)
@@ -252,9 +252,6 @@ importers:
       '@spfn/notification':
         specifier: workspace:*
         version: link:../notification
-      '@types/bcryptjs':
-        specifier: ^2.4.6
-        version: 2.4.6
       '@types/jsonwebtoken':
         specifier: ^9.0.6
         version: 9.0.10
@@ -1418,8 +1415,14 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -2092,6 +2095,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@next/env@16.2.2':
     resolution: {integrity: sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==}
 
@@ -2142,6 +2148,93 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@node-rs/bcrypt-android-arm-eabi@1.10.7':
+    resolution: {integrity: sha512-8dO6/PcbeMZXS3VXGEtct9pDYdShp2WBOWlDvSbcRwVqyB580aCBh0BEFmKYtXLzLvUK8Wf+CG3U6sCdILW1lA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/bcrypt-android-arm64@1.10.7':
+    resolution: {integrity: sha512-UASFBS/CucEMHiCtL/2YYsAY01ZqVR1N7vSb94EOvG5iwW7BQO06kXXCTgj+Xbek9azxixrCUmo3WJnkJZ0hTQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/bcrypt-darwin-arm64@1.10.7':
+    resolution: {integrity: sha512-DgzFdAt455KTuiJ/zYIyJcKFobjNDR/hnf9OS7pK5NRS13Nq4gLcSIIyzsgHwZHxsJWbLpHmFc1H23Y7IQoQBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/bcrypt-darwin-x64@1.10.7':
+    resolution: {integrity: sha512-SPWVfQ6sxSokoUWAKWD0EJauvPHqOGQTd7CxmYatcsUgJ/bruvEHxZ4bIwX1iDceC3FkOtmeHO0cPwR480n/xA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/bcrypt-freebsd-x64@1.10.7':
+    resolution: {integrity: sha512-gpa+Ixs6GwEx6U6ehBpsQetzUpuAGuAFbOiuLB2oo4N58yU4AZz1VIcWyWAHrSWRs92O0SHtmo2YPrMrwfBbSw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/bcrypt-linux-arm-gnueabihf@1.10.7':
+    resolution: {integrity: sha512-kYgJnTnpxrzl9sxYqzflobvMp90qoAlaX1oDL7nhNTj8OYJVDIk0jQgblj0bIkjmoPbBed53OJY/iu4uTS+wig==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/bcrypt-linux-arm64-gnu@1.10.7':
+    resolution: {integrity: sha512-7cEkK2RA+gBCj2tCVEI1rDSJV40oLbSq7bQ+PNMHNI6jCoXGmj9Uzo7mg7ZRbNZ7piIyNH5zlJqutjo8hh/tmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/bcrypt-linux-arm64-musl@1.10.7':
+    resolution: {integrity: sha512-X7DRVjshhwxUqzdUKDlF55cwzh+wqWJ2E/tILvZPboO3xaNO07Um568Vf+8cmKcz+tiZCGP7CBmKbBqjvKN/Pw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/bcrypt-linux-x64-gnu@1.10.7':
+    resolution: {integrity: sha512-LXRZsvG65NggPD12hn6YxVgH0W3VR5fsE/o1/o2D5X0nxKcNQGeLWnRzs5cP8KpoFOuk1ilctXQJn8/wq+Gn/Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/bcrypt-linux-x64-musl@1.10.7':
+    resolution: {integrity: sha512-tCjHmct79OfcO3g5q21ME7CNzLzpw1MAsUXCLHLGWH+V6pp/xTvMbIcLwzkDj6TI3mxK6kehTn40SEjBkZ3Rog==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/bcrypt-wasm32-wasi@1.10.7':
+    resolution: {integrity: sha512-4qXSihIKeVXYglfXZEq/QPtYtBUvR8d3S85k15Lilv3z5B6NSGQ9mYiNleZ7QHVLN2gEc5gmi7jM353DMH9GkA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/bcrypt-win32-arm64-msvc@1.10.7':
+    resolution: {integrity: sha512-FdfUQrqmDfvC5jFhntMBkk8EI+fCJTx/I1v7Rj+Ezlr9rez1j1FmuUnywbBj2Cg15/0BDhwYdbyZ5GCMFli2aQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/bcrypt-win32-ia32-msvc@1.10.7':
+    resolution: {integrity: sha512-lZLf4Cx+bShIhU071p5BZft4OvP4PGhyp542EEsb3zk34U5GLsGIyCjOafcF/2DGewZL6u8/aqoxbSuROkgFXg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/bcrypt-win32-x64-msvc@1.10.7':
+    resolution: {integrity: sha512-hdw7tGmN1DxVAMTzICLdaHpXjy+4rxaxnBMgI8seG1JL5e3VcRGsd1/1vVDogVp2cbsmgq+6d6yAY+D9lW/DCg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/bcrypt@1.10.7':
+    resolution: {integrity: sha512-1wk0gHsUQC/ap0j6SJa2K34qNhomxXRcEe3T8cI5s+g6fgHBgLTN7U9LzWTG/HE6G4+2tWWLeCabk1wiYGEQSA==}
+    engines: {node: '>= 10'}
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
@@ -2636,8 +2729,8 @@ packages:
     resolution: {integrity: sha512-w071DSzP94YfN6XiWhOxnLpYT3uqtxJBDYdh6Jdjzt+Ce6DNspJsPQgpC7rbts/B8tEkq0LHoYuIF/O5Jh5rPg==}
     engines: {node: '>=18'}
 
-  '@types/bcryptjs@2.4.6':
-    resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/braces@3.0.5':
     resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
@@ -2894,9 +2987,6 @@ packages:
     resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  bcryptjs@2.4.3:
-    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -6434,7 +6524,18 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.7.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6855,6 +6956,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.7.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@16.2.2': {}
 
   '@next/swc-darwin-arm64@16.2.2':
@@ -6880,6 +6988,67 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.2':
     optional: true
+
+  '@node-rs/bcrypt-android-arm-eabi@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-android-arm64@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-darwin-arm64@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-darwin-x64@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-freebsd-x64@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-linux-arm-gnueabihf@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-linux-arm64-gnu@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-linux-arm64-musl@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-linux-x64-gnu@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-linux-x64-musl@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-wasm32-wasi@1.10.7':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@node-rs/bcrypt-win32-arm64-msvc@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-win32-ia32-msvc@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt-win32-x64-msvc@1.10.7':
+    optional: true
+
+  '@node-rs/bcrypt@1.10.7':
+    optionalDependencies:
+      '@node-rs/bcrypt-android-arm-eabi': 1.10.7
+      '@node-rs/bcrypt-android-arm64': 1.10.7
+      '@node-rs/bcrypt-darwin-arm64': 1.10.7
+      '@node-rs/bcrypt-darwin-x64': 1.10.7
+      '@node-rs/bcrypt-freebsd-x64': 1.10.7
+      '@node-rs/bcrypt-linux-arm-gnueabihf': 1.10.7
+      '@node-rs/bcrypt-linux-arm64-gnu': 1.10.7
+      '@node-rs/bcrypt-linux-arm64-musl': 1.10.7
+      '@node-rs/bcrypt-linux-x64-gnu': 1.10.7
+      '@node-rs/bcrypt-linux-x64-musl': 1.10.7
+      '@node-rs/bcrypt-wasm32-wasi': 1.10.7
+      '@node-rs/bcrypt-win32-arm64-msvc': 1.10.7
+      '@node-rs/bcrypt-win32-ia32-msvc': 1.10.7
+      '@node-rs/bcrypt-win32-x64-msvc': 1.10.7
 
   '@petamoriken/float16@3.9.3':
     optional: true
@@ -7423,7 +7592,10 @@ snapshots:
       '@ts-graphviz/ast': 2.0.7
       '@ts-graphviz/common': 2.1.5
 
-  '@types/bcryptjs@2.4.6': {}
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/braces@3.0.5': {}
 
@@ -7751,8 +7923,6 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.13: {}
-
-  bcryptjs@2.4.3: {}
 
   bl@4.1.0:
     dependencies:


### PR DESCRIPTION
P2 (P-H4 + P-M6) from the security/performance audit. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## Problem

`bcryptjs` is a pure-JS bcrypt: its "async" mode does **not** use a worker thread — it slices the CPU-bound key derivation onto the **same event-loop thread** via `setImmediate`. So every login/registration occupies the main thread for the full hash duration, concurrent logins serialize, and *all* other requests (DB callbacks, serialization, unrelated routes) head-of-line-block behind the KDF work.

## Fix

Swap `bcryptjs` → **`@node-rs/bcrypt`** (Rust/napi), whose async `hash`/`verify` dispatch to the libuv threadpool — concurrent logins run in parallel across cores and the event loop stays free.

Measured locally (8 cores): **8 concurrent cost-10 hashes — 551ms (bcryptjs, main thread) → 122ms (native, threadpool)**.

- **No migration**: hashes are standard bcrypt and cross-verify with existing `bcryptjs`-generated hashes (verified both directions). Stored credentials keep working.
- **Clean install**: napi prebuilt binaries — no node-gyp. Verified installing + loading + cross-verifying in **linux/amd64 Alpine (musl)** and **Debian slim (glibc)** Docker builds (the `RUN node test` step runs inside the image). All platform variants (linux gnu/musl x64+arm64, darwin, win32, wasm) are in the lockfile.
- **Cost 10 → 12 (P-M6)**: now affordable since hashing is off the main thread. Still tunable via `SPFN_AUTH_BCRYPT_SALT_ROUNDS`. Existing cost-10 hashes verify unchanged (cost is per-hash).
- Native bcrypt emits the `$2y$` prefix (a valid bcrypt variant; both libraries verify it). Format tests updated to accept `$2a/$2b/$2y`.

For very high concurrent-login load, raise `UV_THREADPOOL_SIZE` toward the core count (default 4).

## Verification

Password unit tests (28) + full auth unit suite (171) green, type-check + madge circular + build clean. Marked breaking (`!`) only because the hashing dependency changes — the public `hashPassword`/`verifyPassword` API is unchanged.

> Note: this branch is cut from `main`; the integration suite on `main` is pre-existing red (schema-drift harness, fixed separately in #20). Verified at the unit level + the Docker cross-compat checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)