### PR TITLE
fix(core): idle-in-transaction backstop + loud slow-tx hint (P-H1/P-M1)

### DIFF
--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -185,6 +185,12 @@ export const coreEnvSchema = defineEnvSchema({
         examples: [10000, 30000, 60000],
     }),
 
+    TRANSACTION_IDLE_TIMEOUT: envNumber({
+        description: 'Max time (ms) a transaction may sit idle (no running query) before Postgres terminates it and reclaims the pooled connection. Guards against external I/O held inside a transaction starving the connection pool. 0 disables.',
+        default: 30000,
+        examples: [10000, 30000, 0],
+    }),
+
     // ========================================================================
     // Database - Development
     // ========================================================================

--- a/packages/core/src/db/transaction/README.md
+++ b/packages/core/src/db/transaction/README.md
@@ -189,6 +189,14 @@ transaction (via `sql.raw`, since `SET` can't be parameterized). Resolution orde
 Timeout is applied **only to root transactions**. In a nested call the timeout is ignored
 (and a `warn` is logged), because `SET LOCAL` would re-scope the entire outer transaction.
 
+`idleTimeout` is the companion knob: `SET LOCAL idle_in_transaction_session_timeout = <ms>`,
+also root-only, resolved as `options.idleTimeout ?? env.TRANSACTION_IDLE_TIMEOUT` (default
+30000). Where `statement_timeout` bounds a single query's run time, this bounds how long the
+transaction may sit **idle** (no query running) — e.g. while the handler awaits external I/O.
+On expiry Postgres terminates the session and rolls back, **reclaiming the pooled connection**
+instead of letting one stuck request hold it (and its row locks) indefinitely. `0` disables it.
+This is a backstop, not a license — see the anti-pattern below.
+
 ### Validation / errors
 
 `runInTransaction` fails fast with a `TransactionError` (before opening a transaction) when:
@@ -292,6 +300,17 @@ await db.transaction(async (tx) =>
 
 ## Pitfalls & anti-patterns
 
+- **Never do external I/O inside a transaction.** A transaction holds a pooled connection
+  (and any row locks taken) from `BEGIN` to `COMMIT`. If the handler awaits an external API,
+  queue, or other non-DB work while the transaction is open, that connection sits idle but
+  reserved — under load, in-flight requests cap out at the pool size and everything else
+  queues. Route-level `Transactional()` wraps the **whole handler**, so it's especially easy
+  to fall into; prefer scoping the transaction to the DB statements (call `runInTransaction`
+  inside a service around just the writes). The `idle_in_transaction_session_timeout` backstop
+  reaps the worst case, and a "Slow transaction" `warn` flags offenders — but the fix is to
+  move the I/O out. If you have a write → external-call → write flow where the external call
+  has a side effect (charge, send), don't span it with a transaction at all — commit intent,
+  call outside the transaction, then commit the result (outbox / saga).
 - **Import from `@spfn/core/db`, not `@spfn/core/db/transaction` or `@spfn/core`.** Neither
   of the latter is a real package export — they don't resolve.
 - **`runWithTransaction` is `(tx, txId, callback)`.** Calling it with two args silently

--- a/packages/core/src/db/transaction/__tests__/transaction.test.ts
+++ b/packages/core/src/db/transaction/__tests__/transaction.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { sql } from 'drizzle-orm';
 import { createDbTestFixture } from '../../__tests__/helpers/db-fixture';
+import { runInTransaction } from '../runner';
 
 describe('Transaction Timeout Configuration', () =>
 {
@@ -265,6 +266,35 @@ describe('Transaction Timeout Configuration', () =>
                 const result = await tx.execute<{ statement_timeout: string }>(sql`SHOW statement_timeout`);
                 expect(result[0].statement_timeout).toBe('0');
             });
+        });
+    });
+
+    describe('Idle-in-transaction backstop', () =>
+    {
+        it('sets idle_in_transaction_session_timeout on a root transaction', async () =>
+        {
+            if (!dbFixture.isAvailable) return;
+
+            await runInTransaction(async (tx) =>
+            {
+                const result = await tx.execute<{ idle_in_transaction_session_timeout: string }>(
+                    sql`SHOW idle_in_transaction_session_timeout`,
+                );
+                expect(result[0].idle_in_transaction_session_timeout).toBe('7s');
+            }, { idleTimeout: 7000, timeout: 5000, enableLogging: false });
+        });
+
+        it('leaves it disabled when idleTimeout is 0', async () =>
+        {
+            if (!dbFixture.isAvailable) return;
+
+            await runInTransaction(async (tx) =>
+            {
+                const result = await tx.execute<{ idle_in_transaction_session_timeout: string }>(
+                    sql`SHOW idle_in_transaction_session_timeout`,
+                );
+                expect(result[0].idle_in_transaction_session_timeout).toBe('0');
+            }, { idleTimeout: 0, timeout: 5000, enableLogging: false });
         });
     });
 });

--- a/packages/core/src/db/transaction/middleware.ts
+++ b/packages/core/src/db/transaction/middleware.ts
@@ -57,6 +57,16 @@ export interface TransactionalOptions
      * ```
      */
     timeout?: number;
+
+    /**
+     * Idle-in-transaction timeout in milliseconds — Postgres reclaims the pooled
+     * connection if the transaction sits idle (e.g. the handler awaits external
+     * I/O) longer than this. A backstop against pool starvation, not a license
+     * to do non-DB work inside a transaction. `0` disables it.
+     *
+     * @default 30000 (30s) or TRANSACTION_IDLE_TIMEOUT environment variable
+     */
+    idleTimeout?: number;
 }
 
 /**

--- a/packages/core/src/db/transaction/runner.ts
+++ b/packages/core/src/db/transaction/runner.ts
@@ -106,6 +106,22 @@ export interface RunInTransactionOptions
     timeout?: number;
 
     /**
+     * Idle-in-transaction timeout in milliseconds (root transactions only).
+     *
+     * Sets PostgreSQL `idle_in_transaction_session_timeout`: if the transaction
+     * sits open without running a query for longer than this — e.g. while the
+     * handler awaits external I/O inside the transaction — Postgres terminates
+     * the session and rolls back, reclaiming the pooled connection instead of
+     * letting one stuck request hold it (and its row locks) indefinitely.
+     *
+     * Do not put external I/O inside a transaction; this is a backstop, not a
+     * license. `0` disables it.
+     *
+     * @default 30000 (30s) or TRANSACTION_IDLE_TIMEOUT environment variable
+     */
+    idleTimeout?: number;
+
+    /**
      * Context string for logging (e.g., 'migration:add-user', 'script:cleanup')
      * @default 'transaction'
      */
@@ -147,6 +163,9 @@ export async function runInTransaction<T>(
 
     // Handle timeout: null/undefined → default, 0 → disabled, N → N milliseconds
     const timeout = options.timeout ?? defaultTimeout;
+
+    // Idle-in-transaction backstop: 0 disables, else default from env
+    const idleTimeout = options.idleTimeout ?? env.TRANSACTION_IDLE_TIMEOUT;
 
     // Generate transaction ID for debugging
     const txId = `tx_${randomUUID()}`;
@@ -278,6 +297,13 @@ export async function runInTransaction<T>(
                 await tx.execute(sql.raw(`SET LOCAL statement_timeout = ${timeout}`));
             }
 
+            // Idle-in-transaction backstop (root only): reclaims the pooled
+            // connection if the transaction sits idle (e.g. awaiting external I/O)
+            if (idleTimeout > 0 && !isNested)
+            {
+                await tx.execute(sql.raw(`SET LOCAL idle_in_transaction_session_timeout = ${idleTimeout}`));
+            }
+
             // Store transaction in AsyncLocalStorage
             return await runWithTransaction(tx, txId, async () =>
             {
@@ -309,6 +335,7 @@ export async function runInTransaction<T>(
                     context,
                     duration: `${duration}ms`,
                     threshold: `${slowThreshold}ms`,
+                    hint: 'A transaction holds a pooled connection (and row locks) for its whole duration. If this is slow because of non-DB work (external API, etc.) inside the transaction, move that work out — it starves the connection pool.',
                 });
             }
             else
@@ -364,6 +391,7 @@ export async function runInTransaction<T>(
                     threshold: `${slowThreshold}ms`,
                     error: error instanceof Error ? error.message : String(error),
                     errorType: error instanceof Error ? error.name : 'Unknown',
+                    hint: 'If the error is an idle-in-transaction timeout, the transaction held a pooled connection while awaiting non-DB work (external API, etc.). Move that work out of the transaction.',
                 });
             }
             else


### PR DESCRIPTION
P2 (P-H1 + P-M1) from the security/performance audit. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## Problem

`Transactional()` wraps the **whole route handler** in a DB transaction (`runInTransaction(() => next())`). A SQL transaction is bound to one pooled connection from `BEGIN` to `COMMIT`, so any non-DB latency in the handler — a slow external API call inside the transaction — keeps that connection (and any row locks taken) checked out the entire time, doing nothing. Under load, in-flight requests cap out at the write-pool size (default 20) and everything else queues. Existing `SET LOCAL statement_timeout` only bounds a single query's run time, not the *idle* gap between statements, so a hung external call could pin a connection until the socket died.

This is the same footgun as Spring `@Transactional` holding a connection across a remote call — but the Node event loop removes the thread-pool ceiling that would have surfaced it as thread starvation, so it shows up only as silent latency growth.

## Fix (bound + surface, don't pretend it's safe)

- **`idle_in_transaction_session_timeout`** set on root transactions (new `idleTimeout` option / `TRANSACTION_IDLE_TIMEOUT` env, default 30s, `0` disables). Postgres terminates and rolls back a transaction left idle past the limit, reclaiming the connection — a hard backstop against pool starvation. DB atomicity is preserved (clean rollback).
- The existing **slow-transaction warning** now carries an actionable hint identifying external-I/O-in-transaction as the likely cause — restoring the "something is stuck here" signal, and producing a migration map of offending routes.
- **Docs**: the anti-pattern is now spelled out (no external I/O in a transaction; for `write → external-with-side-effect → write`, use outbox/saga rather than spanning the call with a transaction) plus the new knob.

The real fix is narrowing the transaction to the DB statements (run `runInTransaction` inside a service around just the writes); that's a follow-up since it can change handler behavior. This PR bounds and surfaces the damage without changing existing behavior.

## Verification

New integration test asserts `SET LOCAL idle_in_transaction_session_timeout` is issued by `runInTransaction` against a real Postgres (`SHOW` returns the configured value; `0` leaves it disabled). Core db/env/config suites green (95), type-check + madge circular + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)