### PR TITLE
perf(auth): cache parsed public keys + throttle lastUsedAt writes (P-M7/P-M8)

### DIFF
--- a/packages/auth/src/__tests__/unit/jwt.test.ts
+++ b/packages/auth/src/__tests__/unit/jwt.test.ts
@@ -4,7 +4,8 @@
  * Tests for server-side JWT verification, fingerprint validation, and token decoding
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import crypto from 'crypto';
 import {
     verifyClientToken,
     verifyKeyFingerprint,
@@ -433,5 +434,26 @@ describe('JWT - Performance', () =>
         const duration = Date.now() - start;
 
         expect(duration).toBeLessThan(5); // Should be nearly instant
+    });
+});
+
+describe('JWT - Public key cache', () =>
+{
+    it('parses each public key only once across verifications', () =>
+    {
+        const { privateKey, publicKey, algorithm } = generateKeyPair('ES256');
+        const token = generateClientToken({ userId: 'cache-test' }, privateKey, algorithm);
+
+        const spy = vi.spyOn(crypto, 'createPublicKey');
+
+        const first = verifyClientToken(token, publicKey, algorithm);
+        const second = verifyClientToken(token, publicKey, algorithm);
+
+        expect(first.userId).toBe('cache-test');
+        expect(second.userId).toBe('cache-test');
+        // First call parses the DER; the second reuses the cached KeyObject
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        spy.mockRestore();
     });
 });

--- a/packages/auth/src/server/helpers/jwt.ts
+++ b/packages/auth/src/server/helpers/jwt.ts
@@ -14,6 +14,44 @@ import crypto from 'crypto';
 import { env } from '@spfn/auth/config';
 import { type KeyAlgorithmType } from '../types';
 
+/**
+ * Parsed public-key cache.
+ *
+ * `createPublicKey` re-parses the DER (ASN.1/SPKI) on every call, which would run
+ * on every authenticated request. The base64 DER fully identifies the key, so we
+ * cache the resulting KeyObject by it. Bounded with FIFO eviction — a miss just
+ * re-parses, so a small cap is safe.
+ */
+const PUBLIC_KEY_CACHE_MAX = 1000;
+const publicKeyCache = new Map<string, crypto.KeyObject>();
+
+function getPublicKeyObject(publicKeyB64: string): crypto.KeyObject
+{
+    const cached = publicKeyCache.get(publicKeyB64);
+    if (cached)
+    {
+        return cached;
+    }
+
+    const keyObject = crypto.createPublicKey({
+        key: Buffer.from(publicKeyB64, 'base64'),
+        format: 'der',
+        type: 'spki',
+    });
+
+    if (publicKeyCache.size >= PUBLIC_KEY_CACHE_MAX)
+    {
+        const oldest = publicKeyCache.keys().next().value;
+        if (oldest !== undefined)
+        {
+            publicKeyCache.delete(oldest);
+        }
+    }
+    publicKeyCache.set(publicKeyB64, keyObject);
+
+    return keyObject;
+}
+
 export interface SessionPayload
 {
     userId: string;
@@ -90,13 +128,8 @@ export function verifyClientToken(
     algorithm: KeyAlgorithmType,
 ): TokenPayload
 {
-    // Convert Base64 DER to key object
-    const publicKeyDER = Buffer.from(publicKeyB64, 'base64');
-    const publicKeyObject = crypto.createPublicKey({
-        key: publicKeyDER,
-        format: 'der',
-        type: 'spki',
-    });
+    // Parse (or reuse a cached) key object from the Base64 DER
+    const publicKeyObject = getPublicKeyObject(publicKeyB64);
 
     let decoded;
 

--- a/packages/auth/src/server/repositories/keys.repository.ts
+++ b/packages/auth/src/server/repositories/keys.repository.ts
@@ -7,7 +7,14 @@
 
 import { NewUserPublicKey, userPublicKeys } from '../entities/user-public-keys';
 import { BaseRepository } from '@spfn/core/db';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, or, isNull, lt } from 'drizzle-orm';
+
+/**
+ * Throttle window for lastUsedAt writes. The column is for audit / inactive-key
+ * detection, so minute granularity is plenty; this avoids a write (and hot-row
+ * lock / MVCC bloat) on every authenticated request.
+ */
+const LAST_USED_THROTTLE_MS = 60_000;
 
 /**
  * User Public Keys Repository 클래스
@@ -171,19 +178,29 @@ export class KeysRepository extends BaseRepository
 
     /**
      * Primary key로 마지막 사용 시간 업데이트 (authenticate용)
-     * Write primary 사용
+     * Write primary 사용.
+     *
+     * Throttled: only writes when lastUsedAt is stale (older than
+     * LAST_USED_THROTTLE_MS), so a busy key isn't UPDATEd on every request. The
+     * throttle lives in the WHERE clause — atomic, no read-then-write race. No
+     * RETURNING (callers fire-and-forget and discard the row).
      */
-    async updateLastUsedById(id: number)
+    async updateLastUsedById(id: number): Promise<void>
     {
-        const result = await this.db
+        const staleBefore = new Date(Date.now() - LAST_USED_THROTTLE_MS);
+
+        await this.db
             .update(userPublicKeys)
             .set({
                 lastUsedAt: new Date(),
             })
-            .where(eq(userPublicKeys.id, id))
-            .returning();
-
-        return result[0] ?? null;
+            .where(and(
+                eq(userPublicKeys.id, id),
+                or(
+                    isNull(userPublicKeys.lastUsedAt),
+                    lt(userPublicKeys.lastUsedAt, staleBefore),
+                ),
+            ));
     }
 }
 


### PR DESCRIPTION
P2-medium (P-M7, P-M8) from the audit — two per-request costs on the authenticated hot path. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## P-M7 — public key re-parsed every request

`verifyClientToken` called `crypto.createPublicKey` (ASN.1/SPKI DER parse) on **every** authenticated request. The base64 DER fully identifies the key, so the resulting `KeyObject` is now cached by it (bounded Map, FIFO eviction — a miss just re-parses, so the cap is safe). Unit test asserts the key is parsed once across repeated verifications.

## P-M8 — lastUsedAt write amplification

`authenticate` fired `UPDATE userPublicKeys SET lastUsedAt = now() … RETURNING *` on **every** request: write amplification, hot-row lock contention, MVCC bloat, and a discarded `RETURNING` payload.

- Drop `RETURNING` (both callers fire-and-forget and discard the row).
- Throttle in the `WHERE` clause: only write when `lastUsedAt` is stale (older than 60s) — atomic, no read-then-write race. Minute granularity is plenty for "last used" / inactive-key auditing, and a busy key is now UPDATEd at most once a minute instead of once per request.

## Verification

Auth unit suites green (171), type-check + build + circular clean. The lastUsedAt throttle is exercised by the auth integration login flow (green once the harness fix #20 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)