### PR TITLE
perf(core): tunable job polling + independent read-pool sizing + serialize SSE fan-out once

### DIFF
--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -85,6 +85,12 @@ export const coreEnvSchema = defineEnvSchema({
         examples: [10, 20, 50],
     }),
 
+    DB_POOL_READ_MAX: envNumber({
+        description: 'Maximum connections for the read-replica pool. Defaults to DB_POOL_MAX. Set lower so write.max + read.max stays under the server max_connections (each process otherwise opens up to 2 × DB_POOL_MAX when a replica is configured).',
+        required: false,
+        examples: [5, 10, 20],
+    }),
+
     DB_POOL_IDLE_TIMEOUT: envNumber({
         description: 'Database connection idle timeout in seconds',
         default: 30,
@@ -183,6 +189,16 @@ export const coreEnvSchema = defineEnvSchema({
         description: 'Transaction timeout in milliseconds',
         default: 30000,
         examples: [10000, 30000, 60000],
+    }),
+
+    // ========================================================================
+    // Jobs (pg-boss)
+    // ========================================================================
+
+    JOB_POLLING_INTERVAL_SECONDS: envNumber({
+        description: 'How often each pg-boss worker polls the DB for new jobs (seconds). Lower = faster pickup, more idle SELECT load; higher = less DB chatter, slower pickup. Per-job override via job options.',
+        default: 2,
+        examples: [1, 2, 10],
     }),
 
     // ========================================================================

--- a/packages/core/src/db/manager/__tests__/factory.test.ts
+++ b/packages/core/src/db/manager/__tests__/factory.test.ts
@@ -150,7 +150,7 @@ describe('Database Factory', () =>
 
                 expect(createDatabaseConnection).toHaveBeenCalledWith(
                     'postgresql://localhost:5432/db',
-                    { max: 50, idleTimeout: 60 },
+                    expect.objectContaining({ max: 50, idleTimeout: 60 }),
                     expect.any(Object),
                 );
             });
@@ -164,7 +164,7 @@ describe('Database Factory', () =>
 
                 expect(createDatabaseConnection).toHaveBeenCalledWith(
                     'postgresql://localhost:5432/db',
-                    { max: 20, idleTimeout: 30 },
+                    expect.objectContaining({ max: 20, idleTimeout: 30 }),
                     expect.any(Object),
                 );
             });
@@ -181,7 +181,7 @@ describe('Database Factory', () =>
 
                 expect(createDatabaseConnection).toHaveBeenCalledWith(
                     'postgresql://localhost:5432/db',
-                    { max: 100, idleTimeout: 45 },
+                    expect.objectContaining({ max: 100, idleTimeout: 45 }),
                     expect.any(Object),
                 );
             });

--- a/packages/core/src/db/manager/config.ts
+++ b/packages/core/src/db/manager/config.ts
@@ -86,6 +86,13 @@ export interface PoolConfig
     max: number;
     /** Idle connection timeout in seconds */
     idleTimeout: number;
+    /**
+     * Maximum connections for the read-replica pool. Defaults to `max`. Set
+     * separately (DB_POOL_READ_MAX) so a master-replica app can size the two
+     * pools independently and keep `write.max + read.max` under the server's
+     * `max_connections` (otherwise each process opens up to 2 × max).
+     */
+    readMax?: number;
 }
 
 /**
@@ -220,9 +227,13 @@ function parseEnvBoolean(key: string, defaultValue: boolean): boolean
  */
 export function getPoolConfig(options?: Partial<PoolConfig>): PoolConfig
 {
+    const max = options?.max ?? parseEnvNumber('DB_POOL_MAX', 20, 10);
+
     return {
-        max: options?.max ?? parseEnvNumber('DB_POOL_MAX', 20, 10),
+        max,
         idleTimeout: options?.idleTimeout ?? parseEnvNumber('DB_POOL_IDLE_TIMEOUT', 30, 20),
+        // Defaults to the write `max`; DB_POOL_READ_MAX lets ops size the replica pool separately
+        readMax: options?.readMax ?? parseEnvNumber('DB_POOL_READ_MAX', max, max),
     };
 }
 

--- a/packages/core/src/db/manager/factory.ts
+++ b/packages/core/src/db/manager/factory.ts
@@ -134,10 +134,14 @@ async function createWriteReadClients(
         throw new Error(`Write database connection failed: ${errorObj.message}`, { cause: error });
     }
 
-    // Read connection is optional - fallback to write if it fails
+    // Read connection is optional - fallback to write if it fails.
+    // The read pool can be sized independently (readMax) so the two pools don't
+    // each open `max` connections for a total of 2 × max per process.
+    const readPoolConfig = { ...poolConfig, max: poolConfig.readMax ?? poolConfig.max };
+
     try
     {
-        readClient = await createDatabaseConnection(readUrl, poolConfig, retryConfig);
+        readClient = await createDatabaseConnection(readUrl, readPoolConfig, retryConfig);
 
         return {
             write: drizzle(writeClient),

--- a/packages/core/src/event/sse/__tests__/serialize-frame.test.ts
+++ b/packages/core/src/event/sse/__tests__/serialize-frame.test.ts
@@ -1,0 +1,55 @@
+/**
+ * SSE fan-out frame serialization (serializeFrame) tests
+ *
+ * One emit delivers the same payload object to every subscriber, so the frame
+ * must be serialized once and reused — not re-stringified per connection.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { serializeFrame } from '../handler';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('serializeFrame', () =>
+{
+    it('produces the SSE frame shape { event, data }', () =>
+    {
+        const payload = { a: 1 };
+        expect(serializeFrame('user.created', payload)).toBe(
+            JSON.stringify({ event: 'user.created', data: payload }),
+        );
+    });
+
+    it('serializes an object payload only once across repeated emits to subscribers', () =>
+    {
+        const payload = { id: 42, name: 'x' };
+        const spy = vi.spyOn(JSON, 'stringify');
+
+        const a = serializeFrame('evt', payload);  // first subscriber → stringify
+        const b = serializeFrame('evt', payload);  // others → cache hit
+        const c = serializeFrame('evt', payload);
+
+        expect(a).toBe(b);
+        expect(b).toBe(c);
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches per event name for the same payload object', () =>
+    {
+        const payload = { v: 1 };
+        const spy = vi.spyOn(JSON, 'stringify');
+
+        const e1 = serializeFrame('evt.a', payload);
+        const e2 = serializeFrame('evt.b', payload);
+
+        expect(e1).toContain('evt.a');
+        expect(e2).toContain('evt.b');
+        expect(spy).toHaveBeenCalledTimes(2); // distinct events → distinct frames
+    });
+
+    it('handles primitive / null payloads without caching', () =>
+    {
+        expect(serializeFrame('evt', 5)).toBe(JSON.stringify({ event: 'evt', data: 5 }));
+        expect(serializeFrame('evt', null)).toBe(JSON.stringify({ event: 'evt', data: null }));
+    });
+});

--- a/packages/core/src/event/sse/handler.ts
+++ b/packages/core/src/event/sse/handler.ts
@@ -26,6 +26,40 @@ import { createBoundedWriter } from './bounded-writer';
 
 const sseLogger = logger.child('@spfn/core:sse');
 
+/**
+ * Serialize a fan-out frame once per (event, payload).
+ *
+ * One `emit` delivers the same payload object to every subscribed connection, so
+ * without memoization each connection re-`JSON.stringify`s the identical payload
+ * — O(N) for N subscribers on a hot broadcast. Keyed by the payload object
+ * (WeakMap → auto-GC after the emit); primitives are cheap to stringify directly.
+ */
+const frameCache = new WeakMap<object, Map<string, string>>();
+
+export function serializeFrame(eventName: string, payload: unknown): string
+{
+    if (payload === null || typeof payload !== 'object')
+    {
+        return JSON.stringify({ event: eventName, data: payload });
+    }
+
+    let byEvent = frameCache.get(payload);
+    if (!byEvent)
+    {
+        byEvent = new Map<string, string>();
+        frameCache.set(payload, byEvent);
+    }
+
+    let serialized = byEvent.get(eventName);
+    if (serialized === undefined)
+    {
+        serialized = JSON.stringify({ event: eventName, data: payload });
+        byEvent.set(eventName, serialized);
+    }
+
+    return serialized;
+}
+
 /** Default outbound queue cap per connection before a slow consumer is dropped. */
 const DEFAULT_MAX_QUEUE = 1000;
 
@@ -182,11 +216,6 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
 
                     messageId++;
 
-                    const message = {
-                        event: eventName,
-                        data: payload,
-                    };
-
                     sseLogger.debug('SSE sending event', {
                         event: eventName,
                         messageId,
@@ -195,7 +224,7 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
                     writer.enqueue({
                         id: String(messageId),
                         event: eventName as string,
-                        data: JSON.stringify(message),
+                        data: serializeFrame(eventName as string, payload),
                     });
                 });
 

--- a/packages/core/src/job/register-jobs.ts
+++ b/packages/core/src/job/register-jobs.ts
@@ -6,6 +6,7 @@
 
 import type PgBoss from 'pg-boss';
 import { logger } from '@spfn/core/logger';
+import { env } from '@spfn/core/config';
 import type { JobDef, JobOptions, JobRouter } from './types';
 import type { EventDef } from '@spfn/core/event';
 import { collectJobs } from './job-router';
@@ -175,10 +176,11 @@ async function registerWorker(
     await ensureQueue(boss, queueName);
 
     const batchSize = job.options?.batchSize ?? 1;
+    const pollingIntervalSeconds = job.options?.pollingIntervalSeconds ?? env.JOB_POLLING_INTERVAL_SECONDS;
 
     await boss.work(
         queueName,
-        { batchSize },
+        { batchSize, pollingIntervalSeconds },
         async (pgBossJobs) =>
         {
             if (batchSize <= 1)

--- a/packages/core/src/job/types.ts
+++ b/packages/core/src/job/types.ts
@@ -53,6 +53,14 @@ export interface JobOptions
      * @default 1
      */
     batchSize?: number;
+
+    /**
+     * How often this worker polls the DB for new jobs, in seconds. Lower =
+     * faster pickup but more idle SELECT load; higher = less DB chatter but
+     * slower pickup. Overrides the JOB_POLLING_INTERVAL_SECONDS default.
+     * @default 2 (pg-boss default) or JOB_POLLING_INTERVAL_SECONDS
+     */
+    pollingIntervalSeconds?: number;
 }
 
 /**


### PR DESCRIPTION
The **safe** P2-medium perf batch from the audit — all non-breaking (defaults preserve current behavior). Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## P-M9 — pg-boss polling hardcoded to 2s

Each `boss.work()` was called with only `{ batchSize }`, so workers polled the DB for new jobs at pg-boss's 2s default. With N queues × M instances that's constant idle `SELECT`-for-jobs load, and a fixed ≤2s pickup latency that couldn't be tuned. Added `pollingIntervalSeconds` per job option + a `JOB_POLLING_INTERVAL_SECONDS` env default (still 2s) so ops can trade pickup latency vs DB chatter.

## P-M3 — read & write pools both sized to DB_POOL_MAX

`createDatabaseClients` passed the same `poolConfig` to both connections, so a master-replica app opens up to **2 × DB_POOL_MAX** per process. Added `DB_POOL_READ_MAX` (`PoolConfig.readMax`), defaulting to `max`, applied only to the read connection — so the replica pool can be sized down independently to keep `write.max + read.max` under the server's `max_connections`.

## P-M4 — SSE fan-out re-serialized per connection

Each SSE `emit` re-`JSON.stringify`d the identical payload once **per subscribed connection** (O(N) on a hot broadcast). Now serialized once per `(event, payload)` via a WeakMap memo (auto-GC'd after the emit; primitives stringify directly). Unit-tested (asserts a single `stringify` across repeated subscribers).

> The WS fan-out has the same serialize-once opportunity, but its send path is reworked in the WS-hardening PR (#22) — folded there to avoid a merge conflict.

## Verification

Core env/config/event/job suites green (150 + serialize-frame 4), type-check + madge circular + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)