### PR TITLE
perf(core): query-row safety ceiling + bounded cache offline-queue/retries (P-M2/P-M10)

### DIFF
--- a/packages/core/src/cache/cache-factory.ts
+++ b/packages/core/src/cache/cache-factory.ts
@@ -4,6 +4,24 @@
 
 import type { Redis, Cluster, RedisOptions, ClusterOptions } from 'ioredis';
 import { logger } from '@spfn/core/logger';
+import { env } from '@spfn/core/config';
+
+/**
+ * Connection-resilience options applied to every cache client.
+ *
+ * ioredis defaults to an unbounded offline command queue and 20 retries per
+ * request, so a post-startup cache outage can buffer every command and hang
+ * awaits. Bound retries (CACHE_MAX_RETRIES_PER_REQUEST, default 3) so commands
+ * fail fast instead of hanging; CACHE_ENABLE_OFFLINE_QUEUE (default true) can be
+ * set false for strict fail-fast (reject immediately while disconnected).
+ */
+function resilienceOptions(): Pick<RedisOptions, 'maxRetriesPerRequest' | 'enableOfflineQueue'>
+{
+    return {
+        maxRetriesPerRequest: env.CACHE_MAX_RETRIES_PER_REQUEST,
+        enableOfflineQueue: env.CACHE_ENABLE_OFFLINE_QUEUE,
+    };
+}
 
 const cacheLogger = logger.child('@spfn/core:cache');
 
@@ -36,7 +54,7 @@ function createClient(
     url: string,
 ): Redis
 {
-    const options: RedisOptions = {};
+    const options: RedisOptions = { ...resilienceOptions() };
 
     // TLS support for secure connections
     if (url.startsWith('rediss://'))
@@ -135,6 +153,7 @@ export async function createCacheFromEnv(): Promise<CacheClients>
             });
 
             const options: RedisOptions = {
+                ...resilienceOptions(),
                 sentinels,
                 name: masterName,
                 password,
@@ -158,6 +177,7 @@ export async function createCacheFromEnv(): Promise<CacheClients>
 
             const clusterOptions: ClusterOptions = {
                 redisOptions: {
+                    ...resilienceOptions(),
                     password,
                 },
             };

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -281,6 +281,28 @@ export const coreEnvSchema = defineEnvSchema({
         examples: [true, false],
     }),
 
+    CACHE_MAX_RETRIES_PER_REQUEST: envNumber({
+        description: 'Max ioredis retries per command before it rejects (fail fast instead of hanging on a cache outage). ioredis default is 20.',
+        default: 3,
+        examples: [1, 3, 20],
+    }),
+
+    CACHE_ENABLE_OFFLINE_QUEUE: envBoolean({
+        description: 'Queue commands while the cache is disconnected (true) vs reject immediately for strict fail-fast (false). Default true keeps resilience to brief blips.',
+        default: true,
+        examples: [true, false],
+    }),
+
+    // ========================================================================
+    // Database - Query limits
+    // ========================================================================
+
+    DB_MAX_ROWS: envNumber({
+        description: 'Safety ceiling for rows returned by repository findMany (0 = unlimited). When >0, an unbounded query is capped and an explicit limit is clamped, guarding against accidentally loading a whole large table.',
+        default: 0,
+        examples: [0, 1000, 10000],
+    }),
+
     // ========================================================================
     // Server - Core
     // ========================================================================

--- a/packages/core/src/db/repository.ts
+++ b/packages/core/src/db/repository.ts
@@ -82,6 +82,7 @@ import { getDatabase } from './manager';
 import { reportDatabaseError } from './manager/reconnect-trigger';
 import { getTransaction } from './transaction';
 import { isSQLWrapper, buildWhereFromObject } from './query-utils';
+import { env } from '@spfn/core/config';
 
 /**
  * Enhanced error class that includes repository context
@@ -325,10 +326,18 @@ export abstract class BaseRepository<TSchema extends Record<string, unknown> = R
             query = query.orderBy(...orderByArray) as any;
         }
 
-        // Apply limit
-        if (options?.limit)
+        // Apply limit, with an optional safety ceiling (DB_MAX_ROWS, 0 = off).
+        // When set, an unbounded _findMany is capped and an explicit limit is
+        // clamped — guards against accidentally loading a whole large table.
+        const maxRows = env.DB_MAX_ROWS;
+        const requestedLimit = options?.limit && options.limit > 0 ? options.limit : undefined;
+        const effectiveLimit = maxRows > 0
+            ? Math.min(requestedLimit ?? maxRows, maxRows)
+            : requestedLimit;
+
+        if (effectiveLimit)
         {
-            query = query.limit(options.limit) as any;
+            query = query.limit(effectiveLimit) as any;
         }
 
         // Apply offset


### PR DESCRIPTION
The **behavior-changing** P2-medium batch from the audit — kept opt-in / config-gated (defaults preserve current behavior, with one fail-faster default flagged). Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## P-M2 — unbounded `_findMany`

`_findMany` applied `.limit()` only if one was passed, so a missing/wrong `where` could load a whole large table into memory. Added a **`DB_MAX_ROWS` safety ceiling** (default `0` = unlimited, **unchanged**): when set, an unbounded findMany is capped and an explicit limit is clamped to it.

The bulk-mutation `.returning()` hydration (the other half of P-M2) is **left as-is** — changing the return contract of `_updateMany`/`_deleteMany` would be breaking — and documented as a caveat to bound with a tighter `where`.

## P-M10 — unbounded cache offline queue + 20 retries

ioredis defaults to an unbounded offline command queue and 20 retries/request, so a post-startup cache outage buffers every command and hangs awaits. Resilience options are now applied to every client (single / sentinel / cluster):

- `maxRetriesPerRequest` = `CACHE_MAX_RETRIES_PER_REQUEST` (**default 3** — fail faster than ioredis's 20 so commands reject instead of hanging; this is the one default that changes).
- `enableOfflineQueue` = `CACHE_ENABLE_OFFLINE_QUEUE` (default `true`; set `false` for strict fail-fast that rejects immediately while disconnected).

## Verification

type-check + madge circular + build clean; config/env unit suites green. 

> Note: the `src/db` and `src/cache` **integration** suites have pre-existing failures in this environment (cross-file `test_users` pollution; valkey test config) — confirmed identical on a clean `main` checkout, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)