### PR TITLE
fix(auth): pin legacy verifyToken to HS256 + cap password at bcrypt's 72 bytes (S-L1/S-I3)

### DIFF
--- a/packages/auth/src/__tests__/unit/jwt.test.ts
+++ b/packages/auth/src/__tests__/unit/jwt.test.ts
@@ -10,6 +10,8 @@ import {
     verifyClientToken,
     verifyKeyFingerprint,
     decodeToken,
+    generateToken,
+    verifyToken,
 } from '@/server/helpers/jwt';
 import { generateKeyPair, generateClientToken } from '@/server/lib/crypto';
 
@@ -337,6 +339,22 @@ describe('JWT - Algorithm Enforcement', () =>
         {
             verifyClientToken(token, publicKey, 'RS256');
         }).toThrow();
+    });
+
+    it('legacy verifyToken round-trips an HS256 server-signed token', () =>
+    {
+        const token = generateToken({ userId: '777' });
+
+        expect(verifyToken(token).userId).toBe('777');
+    });
+
+    it('legacy verifyToken rejects an alg:none (unsigned) token', () =>
+    {
+        const jwt = require('jsonwebtoken');
+        // Classic algorithm-confusion: an unsigned token. The HS256 allow-list must reject it.
+        const token = jwt.sign({ userId: '777' }, '', { algorithm: 'none' });
+
+        expect(() => verifyToken(token)).toThrow();
     });
 });
 

--- a/packages/auth/src/server/helpers/jwt.ts
+++ b/packages/auth/src/server/helpers/jwt.ts
@@ -95,7 +95,10 @@ export function generateToken(payload: SessionPayload): string
  */
 export function verifyToken(token: string): TokenPayload
 {
-    return jwt.verify(token, env.SPFN_AUTH_JWT_SECRET) as TokenPayload;
+    // Pin the algorithm to the symmetric HMAC this secret signs with — without an
+    // allow-list, jsonwebtoken accepts whatever alg the token header claims
+    // (algorithm-confusion risk).
+    return jwt.verify(token, env.SPFN_AUTH_JWT_SECRET, { algorithms: ['HS256'] }) as TokenPayload;
 }
 
 /**

--- a/packages/auth/src/server/routes/schema.ts
+++ b/packages/auth/src/server/routes/schema.ts
@@ -24,7 +24,8 @@ export const PhoneSchema = Type.String({
 
 export const PasswordSchema = Type.String({
     minLength: 8,
-    description: 'User password (minimum 8 characters)',
+    maxLength: 72,
+    description: 'User password (8–72 characters). bcrypt silently ignores bytes past 72, so longer inputs are rejected rather than truncated.',
 });
 
 // ============================================================================


### PR DESCRIPTION
First P3 batch — auth credential hygiene. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## S-L1 — `verifyToken` had no algorithm allow-list

The legacy server-signed `verifyToken()` called `jwt.verify(token, secret)` with no `algorithms` option, so jsonwebtoken would accept whatever `alg` the token header claimed — including `alg:none`. Pinned to `['HS256']` (the symmetric HMAC the shared secret signs with). Tested: HS256 round-trip still verifies; an `alg:none` unsigned token is now rejected.

## S-I3 — password had no max length (bcrypt 72-byte truncation)

`PasswordSchema` enforced `minLength: 8` but no max. bcrypt silently ignores bytes past 72, so a >72-char password is truncated — and any 72-byte prefix would then authenticate. Added `maxLength: 72` so over-long inputs are rejected at validation instead of being silently shortened.

## Verification

auth type-check clean; jwt unit suite 32 passed (incl. 2 new verifyToken cases), password unit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)