### PR TITLE
fix(core): stop echoing duplicate-value + mask sensitive query params (S-L4/S-L8)

### DIFF
--- a/packages/core/src/db/__tests__/postgres-errors.test.ts
+++ b/packages/core/src/db/__tests__/postgres-errors.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { fromPostgresError } from '../postgres-errors';
+import { DuplicateEntryError } from '../../errors/database-errors';
 
 describe('PostgreSQL Error Conversion', () =>
 {
@@ -132,7 +133,10 @@ describe('PostgreSQL Error Conversion', () =>
 
                 expect(error.name).toBe('DuplicateEntryError');
                 expect(error.message).toContain('email');
-                expect(error.message).toContain('test@example.com');
+                // The value must NOT leak into the client-facing message (enumeration)…
+                expect(error.message).not.toContain('test@example.com');
+                // …but is preserved on the instance for server-side handling.
+                expect((error as DuplicateEntryError).value).toBe('test@example.com');
             });
 
             it('should parse field and value from unique violation', () =>
@@ -145,7 +149,8 @@ describe('PostgreSQL Error Conversion', () =>
 
                 expect(error.name).toBe('DuplicateEntryError');
                 expect(error.message).toContain('username');
-                expect(error.message).toContain('john_doe');
+                expect(error.message).not.toContain('john_doe');
+                expect((error as DuplicateEntryError).value).toBe('john_doe');
             });
 
             it('should handle complex unique violations with multiple fields', () =>

--- a/packages/core/src/errors/__tests__/database-errors.test.ts
+++ b/packages/core/src/errors/__tests__/database-errors.test.ts
@@ -238,9 +238,11 @@ describe('DuplicateEntryError', () =>
         const error = new DuplicateEntryError({ field: 'email', value: 'test@example.com' });
 
         expect(error.name).toBe('DuplicateEntryError');
-        expect(error.message).toBe("email 'test@example.com' already exists");
+        // The value is NOT echoed in the client-facing message/details (enumeration);
+        // it stays on the instance for server-side handling.
+        expect(error.message).toBe('email already exists');
         expect(error.statusCode).toBe(409);
-        expect(error.details).toEqual({ field: 'email', value: 'test@example.com' });
+        expect(error.details).toEqual({ field: 'email' });
         expect(error.field).toBe('email');
         expect(error.value).toBe('test@example.com');
     });
@@ -249,8 +251,8 @@ describe('DuplicateEntryError', () =>
     {
         const error = new DuplicateEntryError({ field: 'user_id', value: 123 });
 
-        expect(error.message).toBe("user_id '123' already exists");
-        expect(error.details).toEqual({ field: 'user_id', value: 123 });
+        expect(error.message).toBe('user_id already exists');
+        expect(error.details).toEqual({ field: 'user_id' });
         expect(error.field).toBe('user_id');
         expect(error.value).toBe(123);
     });

--- a/packages/core/src/errors/database-errors.ts
+++ b/packages/core/src/errors/database-errors.ts
@@ -173,17 +173,20 @@ export class DuplicateEntryError extends QueryError
 
     constructor(data: { field: string; value: string | number })
     {
+        // The client-facing message/details name the field but NOT the value: echoing
+        // the value back (e.g. an email) confirms it exists, an enumeration aid. The
+        // raw value stays on the instance for server-side handling/logging.
         super({
-            message: `${data.field} '${data.value}' already exists`,
+            message: `${data.field} already exists`,
             statusCode: 409,
-            details: { field: data.field, value: data.value },
+            details: { field: data.field },
         });
         this.name = 'DuplicateEntryError';
         this.field = data.field;
         this.value = data.value;
     }
 
-    // Message/details are constructed from the parsed field/value, not raw SQL
+    // Field-only message/details — safe to surface to the client (not internal)
     override get internal(): boolean
     {
         return false;

--- a/packages/core/src/middleware/__tests__/error-handler.test.ts
+++ b/packages/core/src/middleware/__tests__/error-handler.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
-import { ErrorHandler } from '../error-handler';
+import { ErrorHandler, type OnErrorContext } from '../error-handler';
 import {
     NotFoundError,
     BadRequestError,
@@ -396,6 +396,32 @@ describe('ErrorHandler Middleware', () =>
             expect(json.message).toBe('Internal Server Error');
             expect(json.cause).toBeUndefined();
             expect(JSON.stringify(json)).not.toContain('secret');
+        });
+    });
+
+    describe('Request context masking (S-L8)', () =>
+    {
+        it('masks sensitive query params in the onError context', async () =>
+        {
+            let captured: OnErrorContext | undefined;
+
+            const app = new Hono();
+            app.onError(ErrorHandler({
+                enableLogging: false,
+                onError: (_err, ctx) => { captured = ctx; },
+            }));
+            app.get('/x', () =>
+            {
+                throw new Error('boom');
+            });
+
+            await app.request('/x?token=supersecret&code=abc123&page=2');
+            // onError fires asynchronously (fire-and-forget) — flush the microtask queue.
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(captured?.request.query.token).toBe('***');
+            expect(captured?.request.query.code).toBe('***');
+            expect(captured?.request.query.page).toBe('2');
         });
     });
 });

--- a/packages/core/src/middleware/error-handler.ts
+++ b/packages/core/src/middleware/error-handler.ts
@@ -135,6 +135,30 @@ function extractHeaders(c: Context): Record<string, string>
     return headers;
 }
 
+const SENSITIVE_QUERY_PARAMS = new Set([
+    'token', 'access_token', 'refresh_token', 'id_token', 'code',
+    'secret', 'client_secret', 'password', 'passwd', 'pwd',
+    'api_key', 'apikey', 'key', 'signature', 'sig',
+    'session', 'sessionid', 'auth', 'authorization',
+]);
+
+/**
+ * Extract query params from request, masking sensitive values so credentials in
+ * the URL (?token=…, ?code=…) don't reach error logs / the onError callback.
+ */
+function extractQuery(c: Context): Record<string, string>
+{
+    const query = c.req.query();
+    const masked: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(query))
+    {
+        masked[key] = SENSITIVE_QUERY_PARAMS.has(key.toLowerCase()) ? '***' : value;
+    }
+
+    return masked;
+}
+
 /**
  * Build onError context from Hono context
  */
@@ -151,7 +175,7 @@ function buildOnErrorContext(c: Context, statusCode: number): OnErrorContext
         userId: auth?.userId,
         request: {
             headers: extractHeaders(c),
-            query: c.req.query(),
+            query: extractQuery(c),
         },
     };
 }


### PR DESCRIPTION
Second P3 batch — core information disclosure (complements #21). Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## S-L4 — DuplicateEntryError echoed the value

`DuplicateEntryError` built `"<field> '<value>' already exists"` and put `value` in `details` — both client-facing. Echoing the submitted value back confirms it exists (account/record enumeration), and leaks it into any log that records the error. Now the message/details name **only the field** (`"email already exists"`); the raw `value` stays on the instance (`.value`) for server-side handling.

## S-L8 — onError context carried the raw query string

`ErrorHandler`'s `onError` context included `c.req.query()` verbatim, so credentials passed in the URL (`?token=…`, `?code=…`, `?api_key=…`) reached error logs and the user's `onError` callback unmasked — headers were already masked, query wasn't. Added `extractQuery()` mirroring the existing `extractHeaders()` masking against a known set of sensitive param names.

## ⚠️ Behavior change (beta)

`DuplicateEntryError.message` and `.details` no longer contain the value (only the field). Anything matching the old message string or reading `details.value` should read `.value` off the instance instead.

## Verification

core errors + db + middleware suites green (141), madge circular clean, build OK. New tests: value absent from message but present on instance; sensitive query params masked in the onError context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)