### PR TITLE
perf(core): prompt SSE disconnect teardown + parallel job registration (P-L4/P-L6)

### DIFF
--- a/packages/core/src/event/sse/handler.ts
+++ b/packages/core/src/event/sse/handler.ts
@@ -161,6 +161,9 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
             let connectionDead = false;
             let pingTimer: ReturnType<typeof setInterval>;
             let writer: ReturnType<typeof createBoundedWriter>;
+            // Resolves the disconnect wait below when the connection is closed
+            // server-side (overflow/error), so teardown doesn't wait for the loop.
+            let onClosed: (() => void) | undefined;
 
             const cleanup = (reason?: string) =>
             {
@@ -169,6 +172,7 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
                 clearInterval(pingTimer);
                 unsubscribes.forEach(fn => fn());
                 writer?.close();
+                onClosed?.();
                 sseLogger.info('SSE dead connection cleaned up', {
                     events: allowedEvents,
                     reason,
@@ -247,15 +251,27 @@ export function createSSEHandler<TRouter extends EventRouterDef<any>>(
                 });
             }, pingInterval);
 
-            // Wait for client disconnect using abort signal
+            // Wait for client disconnect (abort) or a server-side close. Waiting on
+            // the abort event instead of polling sleep(pingInterval) means a dropped
+            // client is torn down immediately, not up to one ping interval later.
             const abortSignal = c.req.raw.signal;
 
-            while (!abortSignal.aborted && !connectionDead)
+            if (!abortSignal.aborted && !connectionDead)
             {
-                await stream.sleep(pingInterval);
+                await new Promise<void>((resolve) =>
+                {
+                    const onAbort = () => resolve();
+                    abortSignal.addEventListener('abort', onAbort, { once: true });
+                    // Server-side close (cleanup) resolves the wait and drops the listener.
+                    onClosed = () =>
+                    {
+                        abortSignal.removeEventListener('abort', onAbort);
+                        resolve();
+                    };
+                });
             }
 
-            // Cleanup (normal disconnect path)
+            // Cleanup (normal disconnect path; idempotent if already closed)
             cleanup();
         }, async (err: Error) =>
         {

--- a/packages/core/src/job/register-jobs.ts
+++ b/packages/core/src/job/register-jobs.ts
@@ -102,10 +102,9 @@ export async function registerJobs(router: JobRouter<any>): Promise<void>
         jobLogger.info('Existing jobs cleared');
     }
 
-    for (const job of jobs)
-    {
-        await registerJob(job);
-    }
+    // Each job registers an independent pg-boss queue/worker, so register them
+    // concurrently — sequential awaits made startup scale linearly with job count.
+    await Promise.all(jobs.map((job) => registerJob(job)));
 
     jobLogger.info('All jobs registered successfully');
 }


### PR DESCRIPTION
P3 perf-low batch. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## P-L4 — SSE teardown lagged up to a ping interval

The handler awaited disconnect with a `while (!aborted) await stream.sleep(pingInterval)` poll, so when a client dropped, its event subscriptions and ping timer lingered up to one ping interval (10s default) before `cleanup()` ran. Now it waits on the `abort` event directly (with a server-side close hook for the overflow/error path), so a dropped client is torn down immediately. The keep-alive ping is unaffected (separate timer).

## P-L6 — job registration was sequential at startup

`registerJobs` did `for (job of jobs) await registerJob(job)`, so boot time scaled linearly with the number of jobs. Each job registers an independent pg-boss queue/worker, so they now register concurrently via `Promise.all`.

## Not changed — P-L3

The per-emit `[...handlers]` spread in `event.ts` is intentionally kept: the snapshot gives stable iteration if a handler subscribes/unsubscribes mid-emit, which isn't worth trading for one array allocation.

## Verification

core type-check + event/sse + job suites green (77), madge circular clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)