### PR TITLE
feat(core): WebSocket Origin allow-list (S-L5)

### DIFF
--- a/packages/core/src/event/ws/__tests__/origin.test.ts
+++ b/packages/core/src/event/ws/__tests__/origin.test.ts
@@ -1,0 +1,40 @@
+/**
+ * WebSocket Origin allow-list (isOriginAllowed) tests
+ *
+ * Cross-site WebSocket hijacking protection: a browser-supplied Origin that isn't
+ * allow-listed must be rejected, while a missing Origin (native client) passes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isOriginAllowed } from '../handler';
+
+describe('isOriginAllowed', () =>
+{
+    const allow = new Set(['https://app.example.com', 'https://admin.example.com']);
+
+    it('allows everything when no allow-list is configured', () =>
+    {
+        expect(isOriginAllowed('https://evil.example.com', null)).toBe(true);
+        expect(isOriginAllowed(undefined, null)).toBe(true);
+    });
+
+    it('allows a missing Origin (native / non-browser client)', () =>
+    {
+        expect(isOriginAllowed(undefined, allow)).toBe(true);
+        expect(isOriginAllowed('', allow)).toBe(true);
+    });
+
+    it('allows an allow-listed Origin', () =>
+    {
+        expect(isOriginAllowed('https://app.example.com', allow)).toBe(true);
+        expect(isOriginAllowed('https://admin.example.com', allow)).toBe(true);
+    });
+
+    it('rejects an Origin not on the allow-list', () =>
+    {
+        expect(isOriginAllowed('https://evil.example.com', allow)).toBe(false);
+        // Exact match — scheme/host/port all matter.
+        expect(isOriginAllowed('http://app.example.com', allow)).toBe(false);
+        expect(isOriginAllowed('https://app.example.com:8443', allow)).toBe(false);
+    });
+});

--- a/packages/core/src/event/ws/handler.ts
+++ b/packages/core/src/event/ws/handler.ts
@@ -19,6 +19,31 @@ import { logger } from '@spfn/core/logger';
 
 const wsLogger = logger.child('@spfn/core:ws');
 
+/**
+ * Decide whether a WebSocket upgrade's Origin is permitted.
+ *
+ * - no allow-list configured → allowed (check disabled)
+ * - no Origin header (native/non-browser client) → allowed
+ * - Origin present → must be in the allow-list
+ */
+export function isOriginAllowed(
+    origin: string | undefined,
+    allowList: Set<string> | null,
+): boolean
+{
+    if (!allowList)
+    {
+        return true;
+    }
+
+    if (!origin)
+    {
+        return true;
+    }
+
+    return allowList.has(origin);
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -47,8 +72,13 @@ export async function attachWSHandler<
         maxBufferedBytes = 1_048_576,
         maxConnections = 10_000,
         maxConnectionsPerSubject = 0,
+        allowedOrigins,
         auth: authConfig,
     } = config;
+
+    const originAllowList = allowedOrigins && allowedOrigins.length > 0
+        ? new Set(allowedOrigins)
+        : null;
 
     if (authConfig?.enabled && !tokenManager)
     {
@@ -67,6 +97,18 @@ export async function attachWSHandler<
 
     wss.on('connection', (ws: any, req: any) =>
     {
+        // Origin allow-list (cross-site WebSocket hijacking protection). Browsers
+        // always send Origin on the upgrade; reject one that isn't allowed before
+        // doing any work. A missing Origin (native/non-browser client, which can't
+        // be CSRF'd into using ambient cookies) passes through.
+        if (!isOriginAllowed(req.headers?.origin, originAllowList))
+        {
+            wsLogger.warn('WebSocket rejected: disallowed origin', { origin: req.headers?.origin });
+            ws.close(1008, 'Origin not allowed');
+
+            return;
+        }
+
         // Global connection cap — reject before doing any work
         if (clients.size >= maxConnections)
         {

--- a/packages/core/src/event/ws/types.ts
+++ b/packages/core/src/event/ws/types.ts
@@ -177,6 +177,19 @@ export interface WSHandlerConfig
     maxConnectionsPerSubject?: number;
 
     /**
+     * Allow-list of `Origin` header values permitted to open a WebSocket. A
+     * browser sends Origin on the upgrade, so this blocks cross-site scripts from
+     * connecting with the user's ambient cookies (WebSocket has no same-origin
+     * policy / CORS of its own). Connections whose Origin isn't listed are closed
+     * with 1008. Undefined/empty = no Origin check (default; non-browser clients
+     * such as native apps send no Origin and are always allowed).
+     *
+     * @example ['https://app.example.com', 'https://admin.example.com']
+     * @default undefined (disabled)
+     */
+    allowedOrigins?: string[];
+
+    /**
      * Authentication and authorization configuration
      */
     auth?: WSHandlerAuthConfig;


### PR DESCRIPTION
P3 — WebSocket cross-site hijacking protection. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## S-L5 — no Origin check on WebSocket upgrade

Unlike `fetch`, WebSockets have no same-origin policy or CORS. A script on any origin could open a WS to the backend and the browser would attach the user's ambient cookies (cross-site WebSocket hijacking). The handler accepted every upgrade regardless of `Origin`.

Added an **opt-in `allowedOrigins`** to `WSHandlerConfig`:
- when set, a browser-supplied `Origin` not on the list is rejected with close code **1008** before any work;
- a **missing** `Origin` (native / non-browser client — can't be CSRF'd into sending ambient cookies) passes through;
- undefined/empty = no check (**default, non-breaking**).

The decision is factored into a pure `isOriginAllowed(origin, allowList)` and unit-tested (disabled / missing / allowed / disallowed incl. scheme+port exactness).

## Verification

core type-check clean, ws suite green (8: safe-send + new origin tests), madge circular clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)