### PR TITLE
docs(auth): document why oauthFinalize reflecting userId is safe (S-I4)

### DIFF
--- a/packages/auth/src/nextjs/interceptors/oauth.ts
+++ b/packages/auth/src/nextjs/interceptors/oauth.ts
@@ -183,7 +183,12 @@ export const oauthFinalizeInterceptor: InterceptorRule = {
                 return;
             }
 
-            // 세션 생성
+            // 세션 생성.
+            // `userId` here is the value reflected by /_auth/oauth/finalize (a UI
+            // convenience, not a trust anchor). It's safe to seal: keyId was matched
+            // against the pending cookie above, the session is sealed, and the
+            // backend re-derives identity from keyId on every request — see the
+            // SECURITY note on the oauthFinalize route handler.
             const ttl = getSessionTtl();
             const sessionToken = await sealSession({
                 userId,

--- a/packages/auth/src/server/routes/oauth/index.ts
+++ b/packages/auth/src/server/routes/oauth/index.ts
@@ -242,8 +242,20 @@ export const oauthFinalize = route.post('/_auth/oauth/finalize')
     {
         const { body } = await c.data();
 
-        // 인터셉터가 세션을 저장함
-        // userId, keyId를 반환해야 인터셉터가 처리 가능
+        // 인터셉터가 세션을 저장함 — userId, keyId를 반환해야 인터셉터가 처리 가능.
+        //
+        // SECURITY (not a vuln — read before "fixing"): this unauthenticated route
+        // reflects the client-supplied userId. That is intentional and safe — the
+        // reflected userId is a convenience value, never a trust anchor:
+        //   1. The interceptor seals it into the session only after matching keyId
+        //      against the server-sealed `oauth_pending` cookie, and the session is
+        //      sealed with SPFN_AUTH_SESSION_SECRET (the client can't forge/tamper it).
+        //   2. Identity on every backend request is re-derived in `authenticate`
+        //      from the keyId → public-key → DB-owner binding (signature-verified),
+        //      never from this userId. That keyId↔userId binding is created
+        //      server-side in oauthCallbackService from the OAuth-verified identity.
+        // A substituted userId therefore cannot grant another user's identity; it
+        // only populates getSession().userId for client-side UI without a backend call.
         return {
             success: true,
             userId: body.userId,


### PR DESCRIPTION
Audit follow-up (S-I4). The audit flagged `/_auth/oauth/finalize` (unauthenticated) reflecting the client-supplied `userId`. Investigated end-to-end and confirmed it's **not exploitable** — documenting the rationale so future scans/reviews don't re-raise it.

## Why it's safe

The reflected `userId` is a **convenience value, not a trust anchor**:

1. The interceptor seals it into the session only after matching `keyId` against the server-sealed `oauth_pending` cookie, and the session is sealed with `SPFN_AUTH_SESSION_SECRET` — the client can't forge/tamper it.
2. Identity on every backend request is re-derived in `authenticate` from the **keyId → public-key → DB-owner** binding (signature-verified), never from this `userId`. That `keyId↔userId` binding is created **server-side** in `oauthCallbackService` from the OAuth-provider-verified identity.

A substituted `userId` therefore can't grant another user's identity; it only populates `getSession().userId` for client-side UI without a backend call.

## Change

Comments only — a `SECURITY` note at the reflection point (`oauthFinalize` handler) and a short pointer at the interceptor seal. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)