### PR TITLE
fix(core): hash SSE one-time tokens at rest (S-I1)

### DIFF
--- a/packages/core/src/event/sse/__tests__/token-hash-at-rest.test.ts
+++ b/packages/core/src/event/sse/__tests__/token-hash-at-rest.test.ts
@@ -1,0 +1,84 @@
+/**
+ * SSE token store — hashed at rest (S-I1)
+ *
+ * The one-time token is a bearer secret. The store must persist only sha256(token)
+ * (key and value), so a store dump can't hand out usable tokens. Verification still
+ * works because the presented token is hashed the same way on lookup.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import { SSETokenManager, CacheTokenStore } from '../token-manager';
+
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex');
+
+class FakeCache
+{
+    store = new Map<string, string>();
+
+    async set(key: string, value: string): Promise<void>
+    {
+        this.store.set(key, value);
+    }
+
+    async get(key: string): Promise<string | null>
+    {
+        return this.store.get(key) ?? null;
+    }
+
+    async getdel(key: string): Promise<string | null>
+    {
+        const v = this.store.get(key) ?? null;
+        this.store.delete(key);
+
+        return v;
+    }
+
+    async del(...keys: string[]): Promise<number>
+    {
+        let n = 0;
+        for (const k of keys)
+        {
+            if (this.store.delete(k)) n++;
+        }
+
+        return n;
+    }
+}
+
+describe('CacheTokenStore — token hashed at rest', () =>
+{
+    it('persists sha256(token), never the raw token, in the key or value', async () =>
+    {
+        const cache = new FakeCache();
+        const manager = new SSETokenManager({ ttl: 5000, store: new CacheTokenStore(cache) });
+
+        const token = await manager.issue('user-123');
+
+        const keys = [...cache.store.keys()];
+        expect(keys).toHaveLength(1);
+
+        // The raw token must not appear anywhere at rest…
+        expect(keys[0]).not.toContain(token);
+        expect(cache.store.get(keys[0])).not.toContain(token);
+        // …only the prefixed hash is the key.
+        expect(keys[0]).toBe(`sse:token:${sha256(token)}`);
+        // Subject is retained (needed to authorize the connection).
+        expect(cache.store.get(keys[0])).toContain('user-123');
+
+        manager.destroy();
+    });
+
+    it('verifies via the hash and stays one-time-use', async () =>
+    {
+        const cache = new FakeCache();
+        const manager = new SSETokenManager({ ttl: 5000, store: new CacheTokenStore(cache) });
+
+        const token = await manager.issue('user-123');
+
+        expect(await manager.verify(token)).toBe('user-123');
+        expect(await manager.verify(token)).toBeNull(); // already consumed
+
+        manager.destroy();
+    });
+});

--- a/packages/core/src/event/sse/token-manager.ts
+++ b/packages/core/src/event/sse/token-manager.ts
@@ -20,7 +20,18 @@
  * ```
  */
 
-import { randomBytes } from 'crypto';
+import { randomBytes, createHash } from 'crypto';
+
+/**
+ * Hash a token for storage. The raw token is a bearer secret — storing it at rest
+ * (e.g. as a Redis key/value) means a store dump hands out live tokens. We persist
+ * only sha256(token) and look up by the same hash; the raw token exists only in
+ * transit and in the issue() return value.
+ */
+function hashToken(token: string): string
+{
+    return createHash('sha256').update(token).digest('hex');
+}
 
 /**
  * Minimal cache client interface (compatible with ioredis Redis | Cluster)
@@ -41,7 +52,6 @@ type CacheClient = {
  */
 export interface SSEToken
 {
-    token: string;
     subject: string;
     expiresAt: number;
 }
@@ -96,18 +106,19 @@ class InMemoryTokenStore implements SSETokenStore
 
     async set(token: string, data: SSEToken): Promise<void>
     {
-        this.tokens.set(token, data);
+        this.tokens.set(hashToken(token), data);
     }
 
     async consume(token: string): Promise<SSEToken | null>
     {
-        const data = this.tokens.get(token);
+        const key = hashToken(token);
+        const data = this.tokens.get(key);
         if (!data)
         {
             return null;
         }
 
-        this.tokens.delete(token);
+        this.tokens.delete(key);
 
         return data;
     }
@@ -116,11 +127,11 @@ class InMemoryTokenStore implements SSETokenStore
     {
         const now = Date.now();
 
-        for (const [token, data] of this.tokens)
+        for (const [key, data] of this.tokens)
         {
             if (data.expiresAt <= now)
             {
-                this.tokens.delete(token);
+                this.tokens.delete(key);
             }
         }
     }
@@ -158,7 +169,7 @@ export class CacheTokenStore implements SSETokenStore
     {
         const ttlSeconds = Math.max(1, Math.ceil((data.expiresAt - Date.now()) / 1000));
         await this.cache.set(
-            this.prefix + token,
+            this.prefix + hashToken(token),
             JSON.stringify(data),
             'EX',
             ttlSeconds,
@@ -167,7 +178,7 @@ export class CacheTokenStore implements SSETokenStore
 
     async consume(token: string): Promise<SSEToken | null>
     {
-        const key = this.prefix + token;
+        const key = this.prefix + hashToken(token);
 
         // GETDEL (Redis 6.2+) for atomic consume, fallback to GET+DEL
         let raw: string | null = null;
@@ -226,8 +237,8 @@ export class SSETokenManager
     {
         const token = randomBytes(32).toString('hex');
 
+        // The store keys by sha256(token); the raw token is never persisted.
         await this.store.set(token, {
-            token,
             subject,
             expiresAt: Date.now() + this.ttl,
         });


### PR DESCRIPTION
P3 — SSE token at-rest hardening. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## S-I1 — one-time SSE/WS tokens stored in plaintext

The connection token (a bearer secret) was stored **verbatim** in the token store: the raw token was the Redis key (`sse:token:<token>`) **and** duplicated inside the value alongside the subject. Anyone able to read the store (dump, backup leak, compromised/shared Redis) saw live, unconsumed tokens and could open an SSE/WS connection as that subject within the TTL.

Now the store persists only **`sha256(token)`** as the key and **`{ subject, expiresAt }`** as the value (the redundant raw-token field is dropped). Verification hashes the presented token the same way, so the round-trip and one-time-use semantics are unchanged. The raw token exists only in transit and in the `issue()` return value. Applied to both the in-memory and cache/Redis stores.

Mitigating context (why it's P3): tokens were already 256-bit random, one-time-use (GETDEL), and short-TTL — this is defense-in-depth against store compromise.

## Notes

- Tokens issued by a **prior version** (keyed by the raw token) won't resolve after deploy; their short TTL (default 30s) makes that a non-issue.
- `SSEToken` no longer carries a `token` field (internal storage type; nothing read it).

## Verification

core type-check clean, SSE token suites green (15: token-auth + new hash-at-rest test asserting the raw token never appears in the stored key/value), madge circular clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)