### PR TITLE
fix(auth)!: remove account-existence endpoint + equalize login timing (S-L7)

### DIFF
--- a/packages/auth/src/__tests__/integration/api-flow.test.ts
+++ b/packages/auth/src/__tests__/integration/api-flow.test.ts
@@ -176,26 +176,4 @@ describe.skipIf(!dbAvailable)('API Flow Integration', () =>
         expect(response.status).toBe(401);
         expect((await response.json()).__type).toBeDefined();
     });
-
-    it('should check if an account exists', async () =>
-    {
-        await registerViaFlow('exists@example.com', 'Password123!');
-
-        const existsResponse = await app.request('/_auth/exists', {
-            method: 'POST',
-            headers: JSON_HEADERS,
-            body: JSON.stringify({ email: 'exists@example.com' }),
-        });
-
-        expect(existsResponse.status).toBe(200);
-        expect((await existsResponse.json()).exists).toBe(true);
-
-        const notExistsResponse = await app.request('/_auth/exists', {
-            method: 'POST',
-            headers: JSON_HEADERS,
-            body: JSON.stringify({ email: 'notfound@example.com' }),
-        });
-
-        expect((await notExistsResponse.json()).exists).toBe(false);
-    });
 });

--- a/packages/auth/src/__tests__/unit/login-timing.test.ts
+++ b/packages/auth/src/__tests__/unit/login-timing.test.ts
@@ -1,0 +1,58 @@
+/**
+ * loginService — user-enumeration timing equalization (S-L7)
+ *
+ * A login attempt for a non-existent account must still run the password verify
+ * (against a dummy hash) so its response time matches a wrong-password attempt;
+ * otherwise the presence/absence of bcrypt leaks whether the account exists.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../server/repositories', () => ({
+    usersRepository: {
+        findByEmailOrPhone: vi.fn(),
+    },
+}));
+
+vi.mock('../../server/helpers', () => ({
+    hashPassword: vi.fn(async () => '$2b$12$dummydummydummydummydummydummydummydummydummydummydu'),
+    verifyPassword: vi.fn(async () => false),
+}));
+
+vi.mock('../../server/events', () => ({
+    authLoginEvent: { emit: vi.fn() },
+    authRegisterEvent: { emit: vi.fn() },
+}));
+
+vi.mock('../../server/services/verification.service', () => ({
+    validateVerificationToken: vi.fn(),
+}));
+
+import { loginService } from '../../server/services/auth.service';
+import { usersRepository } from '../../server/repositories';
+import { verifyPassword } from '../../server/helpers';
+import { InvalidCredentialsError } from '@spfn/auth/errors';
+
+const loginParams = {
+    email: 'nobody@example.com',
+    password: 'whatever-password',
+    publicKey: 'pk',
+    keyId: 'kid',
+    fingerprint: 'fp',
+    algorithm: 'ES256' as const,
+};
+
+describe('loginService — timing equalization for missing accounts', () =>
+{
+    beforeEach(() => vi.clearAllMocks());
+
+    it('still runs verifyPassword when the account does not exist', async () =>
+    {
+        vi.mocked(usersRepository.findByEmailOrPhone).mockResolvedValue(null);
+
+        await expect(loginService(loginParams)).rejects.toBeInstanceOf(InvalidCredentialsError);
+
+        // The dummy verify must run so a missing account isn't faster than a wrong password.
+        expect(verifyPassword).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/auth/src/generated/route-map.ts
+++ b/packages/auth/src/generated/route-map.ts
@@ -13,7 +13,6 @@ export interface RouteInfo
 }
 
 export const routeMap: Record<string, RouteInfo> = {
-    checkAccountExists: { method: 'POST', path: '/_auth/exists' },
     sendVerificationCode: { method: 'POST', path: '/_auth/codes' },
     verifyCode: { method: 'POST', path: '/_auth/codes/verify' },
     register: { method: 'POST', path: '/_auth/register' },

--- a/packages/auth/src/server/routes/auth/index.ts
+++ b/packages/auth/src/server/routes/auth/index.ts
@@ -9,7 +9,6 @@ import { getAuth, getUser } from '../../helpers';
 import { KEY_ALGORITHM } from '../../types';
 import {
     changePasswordService,
-    checkAccountExistsService,
     loginService,
     logoutService,
     registerService,
@@ -24,25 +23,10 @@ import { Transactional } from '@spfn/core/db';
 import { rateLimit } from '@spfn/core/middleware';
 import { defineRouter, route } from '@spfn/core/route';
 
-/**
- * POST /_auth/exists - Check if account exists
- * Checks if an email or phone number is already registered
- */
-export const checkAccountExists = route.post('/_auth/exists')
-    .input({
-        body: Type.Union([
-            Type.Object({ email: EmailSchema }),
-            Type.Object({ phone: PhoneSchema }),
-        ]),
-    })
-    .use([rateLimit({ limit: 30, windowMs: 60_000 })])
-    .skip(['auth'])
-    .handler(async (c) =>
-    {
-        const { body } = await c.data();
-
-        return await checkAccountExistsService(body);
-    });
+// NOTE: a POST /_auth/exists endpoint was removed deliberately — it answered
+// account existence directly (user enumeration). Existence is no longer exposed;
+// the login path is also timing-equalized (see loginService). Don't reintroduce
+// an existence check without revisiting that posture.
 
 /**
  * POST /_auth/codes - Send verification code
@@ -289,7 +273,6 @@ export const issueOneTimeToken = route.post('/_auth/tokens')
 
 // Export router
 export const authRouter = defineRouter({
-    checkAccountExists: checkAccountExists,
     sendVerificationCode: sendVerificationCode,
     verifyCode: verifyCode,
     register: register,

--- a/packages/auth/src/server/routes/index.ts
+++ b/packages/auth/src/server/routes/index.ts
@@ -6,7 +6,6 @@
 
 import { defineRouter } from '@spfn/core/route';
 import {
-    checkAccountExists,
     sendVerificationCode,
     verifyCode,
     register,
@@ -52,7 +51,7 @@ import {
  * Exports all authentication-related routes
  *
  * Routes:
- * - Auth: /_auth/exists, /_auth/codes, /_auth/login, /_auth/logout, etc.
+ * - Auth: /_auth/codes, /_auth/login, /_auth/logout, etc.
  * - OAuth: /_auth/oauth/google, /_auth/oauth/google/callback, etc.
  * - Invitations: /_auth/invitations/*
  * - Users: /_auth/users/*
@@ -60,7 +59,6 @@ import {
  */
 export const mainAuthRouter = defineRouter({
     // Auth routes
-    checkAccountExists,
     sendVerificationCode,
     verifyCode,
     register,

--- a/packages/auth/src/server/services/auth.service.ts
+++ b/packages/auth/src/server/services/auth.service.ts
@@ -14,7 +14,6 @@ import {
     VerificationTokenTargetMismatchError,
 } from '@spfn/auth/errors';
 
-import { type User } from '../entities/users';
 import { usersRepository } from '../repositories';
 import { type KeyAlgorithmType } from '../types';
 import { hashPassword, verifyPassword } from '../helpers';
@@ -23,17 +22,21 @@ import { registerPublicKeyService, revokeKeyService } from './key.service';
 import { updateLastLoginService } from './user.service';
 import { authLoginEvent, authRegisterEvent } from '../events';
 
-export interface CheckAccountExistsParams
+/**
+ * Dummy bcrypt hash for login timing equalization. A login attempt for a
+ * non-existent account verifies against this so it costs the same as one for a
+ * real account — without it, skipping bcrypt leaks account existence by timing.
+ * Computed once at the configured cost (matches new users' hashes) and reused.
+ */
+let dummyHashPromise: Promise<string> | null = null;
+function getDummyHash(): Promise<string>
 {
-    email?: string;
-    phone?: string;
-}
+    if (!dummyHashPromise)
+    {
+        dummyHashPromise = hashPassword('spfn-nonexistent-account-timing-equalizer');
+    }
 
-export interface CheckAccountExistsResult
-{
-    exists: boolean;
-    identifier: string;
-    identifierType: 'email' | 'phone';
+    return dummyHashPromise;
 }
 
 export interface RegisterParams
@@ -90,43 +93,6 @@ export interface ChangePasswordParams
     currentPassword?: string;
     newPassword: string;
     passwordHash?: string; // Optional: pass user's password hash to avoid re-fetch
-}
-
-/**
- * Check if an account exists by email or phone
- */
-export async function checkAccountExistsService(
-    params: CheckAccountExistsParams,
-): Promise<CheckAccountExistsResult>
-{
-    const { email, phone } = params;
-
-    let identifier: string;
-    let identifierType: 'email' | 'phone';
-    let user: User | null;
-
-    if (email)
-    {
-        identifier = email;
-        identifierType = 'email';
-        user = await usersRepository.findByEmail(email);
-    }
-    else if (phone)
-    {
-        identifier = phone;
-        identifierType = 'phone';
-        user = await usersRepository.findByPhone(phone);
-    }
-    else
-    {
-        throw new ValidationError({ message: 'Either email or phone must be provided' });
-    }
-
-    return {
-        exists: !!user,
-        identifier,
-        identifierType,
-    };
 }
 
 /**
@@ -243,6 +209,10 @@ export async function loginService(
 
     if (!user || !user.passwordHash)
     {
+        // Spend the same time as the real verify path so a non-existent account
+        // can't be told apart from a wrong password by response timing (user
+        // enumeration). The dummy hash is computed once and reused.
+        await verifyPassword(password, await getDummyHash());
         throw new InvalidCredentialsError();
     }
 

--- a/packages/auth/src/server/services/index.ts
+++ b/packages/auth/src/server/services/index.ts
@@ -6,7 +6,6 @@
 
 // Auth Service
 export {
-    checkAccountExistsService,
     registerService,
     loginService,
     logoutService,
@@ -14,8 +13,6 @@ export {
 } from './auth.service';
 
 export type {
-    CheckAccountExistsParams,
-    CheckAccountExistsResult,
     RegisterParams,
     RegisterResult,
     LoginParams,


### PR DESCRIPTION
P3 — account enumeration hardening (S-L7). Two changes that only make sense **together**. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## What & why

Account existence was leaking two ways, both revealing the same bit:

1. **`POST /_auth/exists`** answered existence directly (by design, for signup UX).
2. **Login timing** — `loginService` skipped bcrypt entirely for a non-existent account (fast 401) but ran it for a real account with a wrong password (slow 401). The cost-12 bump (#23) widened that gap.

Fixing the timing while leaving `/_auth/exists` open would be incoherent — an attacker would just call the endpoint. So:

- **Removed** `POST /_auth/exists` + `checkAccountExistsService` + its types; route map regenerated via codegen.
- **`loginService`** now runs a dummy bcrypt verify on the no-account path, so a missing account and a wrong password take the same time. The dummy hash is computed once at the configured cost and reused.

## ⚠️ BREAKING

`POST /_auth/exists` and `authApi.checkAccountExists` are removed. Apps that pre-checked existence in their signup/login UI must switch to a pattern that doesn't reveal it (unified login form, or always-send-a-code). Nothing in this repo (examples/docs) consumed it.

## Scope note

`register` ("user already exists" → 409), the verification-code, and password-reset paths still differ on existence. Full enumeration resistance would extend this posture to them — deliberately **out of scope** here; flagging for a follow-up decision.

## Verification

auth type-check + build + madge circular clean; full unit suite green (178, incl. a new test asserting `verifyPassword` still runs when the account is missing); route map regenerated (36 routes, no `/_auth/exists`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)