### PR TITLE
feat(auth): notify owner instead of leaking on signup for an existing account

### DIFF
--- a/packages/auth/src/__tests__/unit/account-exists-notice.test.ts
+++ b/packages/auth/src/__tests__/unit/account-exists-notice.test.ts
@@ -1,0 +1,79 @@
+/**
+ * sendVerificationCodeService — account-exists notice on registration (S-L7 follow-up)
+ *
+ * Requesting a registration code for an already-registered target must:
+ *  - notify the owner with the 'account-exists' template (not a usable code),
+ *  - return the SAME response shape as a new account (no enumeration),
+ *  - dedupe repeat notices (anti email-bomb),
+ * while a new target still gets the normal 'verification-code' path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { sendEmail, sendSMS } = vi.hoisted(() => ({
+    sendEmail: vi.fn(async () => ({ success: true })),
+    sendSMS: vi.fn(async () => ({ success: true })),
+}));
+
+vi.mock('@spfn/notification/server', () => ({ sendEmail, sendSMS }));
+
+vi.mock('../../server/repositories', () => ({
+    usersRepository: {
+        findByEmail: vi.fn(),
+        findByPhone: vi.fn(),
+    },
+    verificationCodesRepository: {
+        findValidByTargetAndPurpose: vi.fn(),
+        invalidatePreviousCodes: vi.fn(async () => undefined),
+        create: vi.fn(async () => ({ expiresAt: new Date(Date.now() + 300_000) })),
+    },
+}));
+
+import { sendVerificationCodeService } from '../../server/services/verification.service';
+import { usersRepository, verificationCodesRepository } from '../../server/repositories';
+
+const reg = { target: 'taken@example.com', targetType: 'email' as const, purpose: 'registration' as const };
+
+describe('sendVerificationCodeService — account-exists notice', () =>
+{
+    beforeEach(() => vi.clearAllMocks());
+
+    it('notifies the owner (account-exists template) and returns a uniform response for an existing account', async () =>
+    {
+        vi.mocked(usersRepository.findByEmail).mockResolvedValue({ id: 1 } as any);
+        vi.mocked(verificationCodesRepository.findValidByTargetAndPurpose).mockResolvedValue(null as any);
+
+        const res = await sendVerificationCodeService(reg);
+
+        expect(sendEmail).toHaveBeenCalledTimes(1);
+        expect(sendEmail.mock.calls[0][0]).toMatchObject({ template: 'account-exists' });
+        // A dedupe marker is written…
+        expect(verificationCodesRepository.create).toHaveBeenCalledTimes(1);
+        // …and the response is the same shape as a real code send.
+        expect(res).toMatchObject({ success: true });
+        expect(typeof res.expiresAt).toBe('string');
+    });
+
+    it('dedupes: a recent notice suppresses re-sending', async () =>
+    {
+        vi.mocked(usersRepository.findByEmail).mockResolvedValue({ id: 1 } as any);
+        vi.mocked(verificationCodesRepository.findValidByTargetAndPurpose).mockResolvedValue({ id: 9 } as any);
+
+        const res = await sendVerificationCodeService(reg);
+
+        expect(sendEmail).not.toHaveBeenCalled();
+        expect(verificationCodesRepository.create).not.toHaveBeenCalled();
+        expect(res).toMatchObject({ success: true });
+        expect(typeof res.expiresAt).toBe('string');
+    });
+
+    it('sends the normal verification code for a new (non-existent) account', async () =>
+    {
+        vi.mocked(usersRepository.findByEmail).mockResolvedValue(null as any);
+
+        await sendVerificationCodeService({ ...reg, target: 'new@example.com' });
+
+        expect(sendEmail).toHaveBeenCalledTimes(1);
+        expect(sendEmail.mock.calls[0][0]).toMatchObject({ template: 'verification-code' });
+    });
+});

--- a/packages/auth/src/server/services/verification.service.ts
+++ b/packages/auth/src/server/services/verification.service.ts
@@ -10,8 +10,15 @@ import { InvalidVerificationCodeError } from '@spfn/auth/errors';
 import jwt from 'jsonwebtoken';
 import { sendEmail, sendSMS } from '@spfn/notification/server';
 import { authLogger } from '../logger';
-import { verificationCodesRepository } from '../repositories';
+import { verificationCodesRepository, usersRepository } from '../repositories';
 import type { VerificationTargetType, VerificationPurpose } from '../routes/schema';
+
+/**
+ * How long to suppress repeat "account already exists" notices to the same target.
+ * Bounds the notice to ~once per window so the signup endpoint can't be used to
+ * email-bomb an existing account's owner.
+ */
+const ACCOUNT_EXISTS_NOTICE_DEDUPE_MINUTES = 60;
 
 /**
  * Verification token expiry (15 minutes)
@@ -267,6 +274,41 @@ async function sendVerificationSMS(
     }
 }
 
+/**
+ * Whether an account already exists for the given target.
+ */
+async function accountExistsForTarget(
+    target: string,
+    targetType: VerificationTargetType,
+): Promise<boolean>
+{
+    const user = targetType === 'email'
+        ? await usersRepository.findByEmail(target)
+        : await usersRepository.findByPhone(target);
+
+    return !!user;
+}
+
+/**
+ * Notify the owner that someone tried to sign up with their (already-registered)
+ * address — instead of sending a usable signup code. UX hint + security tripwire.
+ */
+async function sendAccountExistsNotice(
+    target: string,
+    targetType: VerificationTargetType,
+): Promise<void>
+{
+    const result = targetType === 'email'
+        ? await sendEmail({ to: target, template: 'account-exists', data: {} })
+        : await sendSMS({ to: target, template: 'account-exists', data: {} });
+
+    if (!result.success)
+    {
+        const log = targetType === 'email' ? authLogger.email : authLogger.sms;
+        log.error('Failed to send account-exists notice', { target, error: result.error });
+    }
+}
+
 export interface SendVerificationCodeParams
 {
     target: string;
@@ -302,6 +344,40 @@ export async function sendVerificationCodeService(
 ): Promise<SendVerificationCodeResult>
 {
     const { target, targetType, purpose } = params;
+
+    // Registration to an already-registered target: don't send a usable signup code
+    // (the account exists). Notify the owner instead — but return the SAME response
+    // as the new-account path so existence can't be probed (no enumeration), and
+    // dedupe so this can't be used to email-bomb the owner.
+    if (purpose === 'registration' && await accountExistsForTarget(target, targetType))
+    {
+        const recentNotice = await verificationCodesRepository.findValidByTargetAndPurpose(target, purpose);
+
+        if (!recentNotice)
+        {
+            // Undelivered marker row — a dedupe timestamp only. Long expiry so the
+            // dedupe window holds; the code is never sent and is unusable (register
+            // rejects an existing account regardless).
+            const dedupeExpiresAt = new Date(Date.now() + ACCOUNT_EXISTS_NOTICE_DEDUPE_MINUTES * 60_000);
+            await verificationCodesRepository.invalidatePreviousCodes(target, purpose);
+            await verificationCodesRepository.create({
+                target,
+                targetType,
+                code: generateVerificationCode(),
+                purpose,
+                expiresAt: dedupeExpiresAt,
+                attempts: 0,
+            });
+
+            await sendAccountExistsNotice(target, targetType);
+        }
+
+        // Uniform response shape (indistinguishable from a real code send).
+        return {
+            success: true,
+            expiresAt: new Date(Date.now() + VERIFICATION_CODE_EXPIRY_MINUTES * 60_000).toISOString(),
+        };
+    }
 
     // Generate 6-digit verification code
     const code = generateVerificationCode();

--- a/packages/notification/src/templates/builtin/account-exists.ts
+++ b/packages/notification/src/templates/builtin/account-exists.ts
@@ -1,0 +1,54 @@
+/**
+ * @spfn/notification - Account Exists Notice Template
+ *
+ * Sent when someone requests a signup code for an address/number that already has
+ * an account. The signup itself returns an identical response either way (no
+ * account enumeration); this notice goes only to the address owner, both as a UX
+ * hint ("you already have an account") and as a security tripwire ("wasn't you?").
+ */
+
+import type { TemplateDefinition } from '../types';
+
+export const accountExistsTemplate: TemplateDefinition = {
+    name: 'account-exists',
+    channels: ['email', 'sms'],
+
+    email: {
+        subject: '[{{appName}}] 이미 가입된 계정이 있어요',
+        html: `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f5f5f5;">
+    <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; border-radius: 10px 10px 0 0; text-align: center;">
+        <h1 style="color: white; margin: 0; font-size: 24px;">{{appName}}</h1>
+    </div>
+    <div style="background: #ffffff; padding: 30px; border: 1px solid #e0e0e0; border-top: none; border-radius: 0 0 10px 10px;">
+        <p style="margin-bottom: 16px; font-size: 16px;">
+            방금 이 주소로 <strong>새 계정 가입</strong>을 시도한 요청이 있었어요. 그런데 이미 가입된 계정이 있습니다.
+        </p>
+        <p style="margin-bottom: 16px; font-size: 16px;">
+            본인이 한 거라면 새로 가입하실 필요 없이 <strong>로그인</strong>하시거나, 비밀번호가 기억나지 않으면 <strong>비밀번호 재설정</strong>을 이용해주세요.
+        </p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+        <p style="color: #666; font-size: 14px; margin: 0;">
+            본인이 한 게 아니라면 <strong>이 메일을 무시하셔도 됩니다</strong> — 새 계정은 만들어지지 않았고, 기존 계정도 아무것도 바뀌지 않았습니다. 모르는 시도가 계속되면 비밀번호를 한 번 바꿔두시길 권합니다.
+        </p>
+    </div>
+</body>
+</html>`,
+        text: `[{{appName}}] 이미 가입된 계정이 있어요
+
+방금 이 주소로 새 계정 가입을 시도한 요청이 있었습니다. 그런데 이미 가입된 계정이 있어요.
+
+본인이 한 거라면 새로 가입할 필요 없이 로그인하거나, 비밀번호 재설정을 이용해주세요.
+
+본인이 한 게 아니라면 이 메일을 무시하셔도 됩니다 — 새 계정은 만들어지지 않았고 기존 계정도 그대로입니다. 모르는 시도가 계속되면 비밀번호를 바꿔두시길 권합니다.`,
+    },
+
+    sms: {
+        message: '[{{appName}}] 이미 가입된 번호로 새 가입 시도가 있었어요. 본인이면 로그인해주세요. 아니면 무시하셔도 됩니다(새 계정 안 만들어짐).',
+    },
+};

--- a/packages/notification/src/templates/builtin/index.ts
+++ b/packages/notification/src/templates/builtin/index.ts
@@ -4,3 +4,4 @@
 
 export { verificationCodeTemplate } from './verification-code';
 export { welcomeTemplate } from './welcome';
+export { accountExistsTemplate } from './account-exists';

--- a/packages/notification/src/templates/index.ts
+++ b/packages/notification/src/templates/index.ts
@@ -24,7 +24,7 @@ export {
 export { render, registerFilter } from './renderer';
 
 // Built-in templates
-import { verificationCodeTemplate, welcomeTemplate } from './builtin';
+import { verificationCodeTemplate, welcomeTemplate, accountExistsTemplate } from './builtin';
 import { registerTemplate } from './registry';
 
 /**
@@ -34,4 +34,5 @@ export function registerBuiltinTemplates(): void
 {
     registerTemplate(verificationCodeTemplate);
     registerTemplate(welcomeTemplate);
+    registerTemplate(accountExistsTemplate);
 }


### PR DESCRIPTION
Follow-up to the account-enumeration posture (S-L7, #37). This is the "wasn't you?" notice you'd expect when someone tries to sign up with an address that's already registered. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## Behavior

When `POST /_auth/codes` (purpose `registration`) targets an **already-registered** email/phone:

- **Notify the owner** with a new `account-exists` template ("you already have an account — log in / reset; if this wasn't you, ignore it, nothing was created or changed") instead of a useless signup code. It's both a UX hint and a security tripwire.
- **Response stays byte-identical** to the new-account path (`{ success, expiresAt }`), so existence still can't be probed — no enumeration.
- **Dedupe** to ~once per target per hour via an undelivered marker row (cache-independent, survives cleanup), so the endpoint can't email-bomb the owner. New-account code **resend is unaffected** (dedupe only applies to the existing-account branch).

A new account (non-existent target) still gets the normal `verification-code` path unchanged.

## Default template

Ships a built-in `account-exists` template (email + SMS, Korean to match `verification-code`) in `@spfn/notification`, registered alongside the other builtins.

## Verification

auth + notification type-check / build / madge circular clean; auth unit green (180, incl. 3 new tests asserting: existing → `account-exists` template + uniform response, dedupe suppresses re-send, new → `verification-code`); notification suite green (25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)