### PR TITLE
fix(core): forward real client IP through the proxy, trust it only when verified (S-I6)

### DIFF
--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -443,4 +443,11 @@ export const coreEnvSchema = defineEnvSchema({
         nextjs: false,
         examples: ['v1:<old secret>', 'v1:<old>,v0:<older>'],
     }),
+
+    TRUSTED_PROXY_HOPS: envNumber({
+        description: 'Number of trusted reverse proxies in front of the Next.js proxy (e.g. cloud LB + nginx = 2). Read by the proxy to extract the real client IP from the inbound X-Forwarded-For (counting from the right, which your own infra appends and a client cannot spoof) and forward it to the backend for rate limiting. Set it to your actual hop count; too low trusts a client-spoofable entry, too high collapses users behind a shared proxy IP.',
+        default: 1,
+        nextjs: true,
+        examples: [1, 2, 3],
+    }),
 });

--- a/packages/core/src/middleware/__tests__/get-client-ip.test.ts
+++ b/packages/core/src/middleware/__tests__/get-client-ip.test.ts
@@ -1,0 +1,48 @@
+/**
+ * getClientIp — trust the proxy-forwarded client IP only when verified (S-I6)
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Context } from 'hono';
+import { getClientIp } from '../rate-limit';
+import { PROXY_CLIENT_IP_HEADER } from '../../security/proxy-signature';
+
+function ctx(headers: Record<string, string>, clientType?: string): Context
+{
+    const lower = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+
+    return {
+        get: (k: string) => (k === 'clientType' ? clientType : undefined),
+        req: { header: (n: string) => lower[n.toLowerCase()] },
+    } as unknown as Context;
+}
+
+describe('getClientIp', () =>
+{
+    it('uses the forwarded client IP when proxy-guard verified the request', () =>
+    {
+        const c = ctx({ [PROXY_CLIENT_IP_HEADER]: '203.0.113.9', 'x-forwarded-for': '10.0.0.1' }, 'web');
+
+        expect(getClientIp(c)).toBe('203.0.113.9');
+    });
+
+    it('ignores the forwarded header on an untrusted request (spoofable)', () =>
+    {
+        const c = ctx({ [PROXY_CLIENT_IP_HEADER]: '1.2.3.4', 'x-forwarded-for': '10.0.0.1' }, 'untrusted');
+
+        expect(getClientIp(c)).toBe('10.0.0.1');
+    });
+
+    it('ignores the forwarded header when proxy-guard did not run (clientType unset)', () =>
+    {
+        const c = ctx({ [PROXY_CLIENT_IP_HEADER]: '1.2.3.4', 'x-forwarded-for': '10.0.0.1' });
+
+        expect(getClientIp(c)).toBe('10.0.0.1');
+    });
+
+    it('falls back through x-real-ip to unknown', () =>
+    {
+        expect(getClientIp(ctx({ 'x-real-ip': '198.51.100.7' }))).toBe('198.51.100.7');
+        expect(getClientIp(ctx({}))).toBe('unknown');
+    });
+});

--- a/packages/core/src/middleware/__tests__/rate-limit.test.ts
+++ b/packages/core/src/middleware/__tests__/rate-limit.test.ts
@@ -30,6 +30,7 @@ function makeCtx(headers: Record<string, string> = {})
             method: 'POST',
             routePath: '/_auth/login',
         },
+        get: () => undefined,
         header: (name: string, value: string) => { setHeaders[name] = value; },
         _setHeaders: setHeaders,
     } as never;

--- a/packages/core/src/middleware/rate-limit.ts
+++ b/packages/core/src/middleware/rate-limit.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Context, MiddlewareHandler } from 'hono';
+import { PROXY_CLIENT_IP_HEADER } from '../security/proxy-signature';
 import { defineMiddlewareFactory } from '../route/define-middleware';
 import { getCache, isCacheDisabled } from '../cache';
 import { TooManyRequestsError } from '../errors';
@@ -62,12 +63,28 @@ export interface RateLimitOptions
 }
 
 /**
- * Best-effort client IP from the proxy chain. Mirrors the request logger; the
- * leftmost X-Forwarded-For hop is client-spoofable, so pair this with an
- * account/target dimension for anything security-sensitive.
+ * Best-effort client IP for rate-limit keying.
+ *
+ * Prefers the proxy-forwarded real client IP, but ONLY when proxy-guard verified
+ * the request came through our proxy (`clientType` set and not 'untrusted') — on a
+ * verified request the proxy is the sole hop, so the value is the true client and
+ * isn't client-spoofable. Otherwise (no proxy-guard, or unverified/direct request)
+ * the forwarded header is attacker-settable, so fall back to the raw chain — whose
+ * leftmost hop is itself spoofable, so still pair with an account/target dimension
+ * for anything security-sensitive.
  */
 export function getClientIp(c: Context): string
 {
+    const clientType = c.get('clientType');
+    if (clientType && clientType !== 'untrusted')
+    {
+        const forwarded = c.req.header(PROXY_CLIENT_IP_HEADER);
+        if (forwarded)
+        {
+            return forwarded;
+        }
+    }
+
     const forwardedFor = c.req.header('x-forwarded-for');
 
     return forwardedFor?.split(',')[0]?.trim()

--- a/packages/core/src/middleware/request-logger.ts
+++ b/packages/core/src/middleware/request-logger.ts
@@ -6,6 +6,7 @@
 import { randomBytes } from 'crypto';
 import type { Context, Next } from 'hono';
 import { logger } from '@spfn/core/logger';
+import { getClientIp } from './rate-limit';
 
 /**
  * Options for RequestLogger middleware
@@ -162,11 +163,9 @@ export function RequestLogger(options?: RequestLoggerOptions)
         const method = c.req.method;
         const userAgent = c.req.header('user-agent');
 
-        // Extract client IP from proxy chain (first IP is the original client)
-        const forwardedFor = c.req.header('x-forwarded-for');
-        const ip = forwardedFor?.split(',')[0]?.trim()
-            || c.req.header('x-real-ip')
-            || 'unknown';
+        // Same resolution as rate limiting: the proxy-forwarded client IP when the
+        // request is proxy-verified, else the (spoofable) raw chain.
+        const ip = getClientIp(c);
 
         const startTime = Date.now();
 

--- a/packages/core/src/nextjs/proxy/__tests__/client-ip.test.ts
+++ b/packages/core/src/nextjs/proxy/__tests__/client-ip.test.ts
@@ -1,0 +1,39 @@
+/**
+ * clientIpFromForwardedChain — hop-aware client IP extraction (S-I6)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { clientIpFromForwardedChain } from '../helpers';
+
+describe('clientIpFromForwardedChain', () =>
+{
+    it('takes the rightmost entry for a single trusted hop', () =>
+    {
+        expect(clientIpFromForwardedChain('203.0.113.9', 1)).toBe('203.0.113.9');
+        expect(clientIpFromForwardedChain('203.0.113.9, 10.0.0.2', 1)).toBe('10.0.0.2');
+    });
+
+    it('counts trusted hops from the right (LB + nginx = 2)', () =>
+    {
+        // client, lb, nginx-appended → real client is 2 from the right
+        expect(clientIpFromForwardedChain('203.0.113.9, 10.0.0.1', 2)).toBe('203.0.113.9');
+    });
+
+    it('ignores a client-prepended spoof', () =>
+    {
+        // attacker prepends 1.2.3.4; real infra appends the rest → still resolves the client
+        expect(clientIpFromForwardedChain('1.2.3.4, 203.0.113.9, 10.0.0.1', 2)).toBe('203.0.113.9');
+    });
+
+    it('best-efforts to leftmost when fewer entries than hops', () =>
+    {
+        expect(clientIpFromForwardedChain('203.0.113.9', 3)).toBe('203.0.113.9');
+    });
+
+    it('returns undefined for empty/missing', () =>
+    {
+        expect(clientIpFromForwardedChain(undefined, 1)).toBeUndefined();
+        expect(clientIpFromForwardedChain('', 1)).toBeUndefined();
+        expect(clientIpFromForwardedChain('  ', 1)).toBeUndefined();
+    });
+});

--- a/packages/core/src/nextjs/proxy/helpers.ts
+++ b/packages/core/src/nextjs/proxy/helpers.ts
@@ -6,9 +6,46 @@ import { NextRequest } from 'next/server';
 import type { CookieOptions, SetCookie } from '../client';
 import type { InterceptorRule, RequestInterceptorContext, ResponseInterceptorContext } from './interceptors/types';
 import type { InterceptorRegistry } from './interceptors';
+import { PROXY_CLIENT_IP_HEADER } from '../../security/proxy-signature';
 
 // Re-export from shared
 export { parseResponseBody } from '../shared';
+
+/**
+ * Resolve the real client IP from a forwarded chain.
+ *
+ * `X-Forwarded-For` is `client, proxy1, proxy2, …` — each trusted hop appends the
+ * address it received the connection from, so the rightmost `trustedHops` entries
+ * are added by our own infra and can't be spoofed. The client as the outermost
+ * trusted hop saw it is `parts[len - trustedHops]`. A client that prepends a fake
+ * value just lengthens the chain to the left and is ignored.
+ *
+ * @param xff - raw X-Forwarded-For header value
+ * @param trustedHops - number of trusted proxies in front (e.g. LB + nginx = 2)
+ */
+export function clientIpFromForwardedChain(
+    xff: string | null | undefined,
+    trustedHops: number,
+): string | undefined
+{
+    if (!xff) return undefined;
+
+    const parts = xff.split(',').map(s => s.trim()).filter(Boolean);
+    if (parts.length === 0) return undefined;
+
+    const idx = parts.length - Math.max(1, trustedHops);
+
+    // Fewer entries than configured hops (misconfig / fewer real hops): best-effort
+    // to the leftmost rather than returning nothing.
+    return parts[idx] ?? parts[0];
+}
+
+function trustedProxyHops(): number
+{
+    const raw = Number.parseInt(process.env.TRUSTED_PROXY_HOPS ?? '', 10);
+
+    return Number.isFinite(raw) && raw > 0 ? raw : 1;
+}
 
 /**
  * Build request headers for proxying
@@ -47,6 +84,18 @@ export function buildProxyHeaders(
         {
             headers.set(header, value);
         }
+    }
+
+    // Forward the real client IP so the backend can rate-limit per user. The
+    // backend trusts this header only on proxy-verified requests, so a direct
+    // caller can't spoof it. Resolved hop-aware from the inbound X-Forwarded-For.
+    const xff = sourceHeaders instanceof Headers
+        ? sourceHeaders.get('x-forwarded-for')
+        : sourceHeaders['x-forwarded-for'];
+    const clientIp = clientIpFromForwardedChain(xff, trustedProxyHops());
+    if (clientIp)
+    {
+        headers.set(PROXY_CLIENT_IP_HEADER, clientIp);
     }
 
     // Add default headers

--- a/packages/core/src/security/proxy-signature.ts
+++ b/packages/core/src/security/proxy-signature.ts
@@ -28,6 +28,12 @@ export const PROXY_SIGNATURE_HEADER = 'x-spfn-proxy-signature';
 export const PROXY_TIMESTAMP_HEADER = 'x-spfn-proxy-timestamp';
 export const PROXY_NONCE_HEADER = 'x-spfn-proxy-nonce';
 export const PROXY_KEY_ID_HEADER = 'x-spfn-proxy-key-id';
+/**
+ * The real client IP, forwarded by the proxy. The backend trusts this only when
+ * the request is proxy-verified (proxy-guard `clientType` ≠ untrusted) — the proxy
+ * itself sees no spoofable hop, so a verified request's value is the true client.
+ */
+export const PROXY_CLIENT_IP_HEADER = 'x-spfn-proxy-client-ip';
 
 /** keyId used when a raw secret carries no `keyId:` prefix (back-compat). */
 export const DEFAULT_KEY_ID = 'default';


### PR DESCRIPTION
P3 — X-Forwarded-For trust (S-I6). Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## The problem (bigger than the audit framing)

Investigating S-I6 surfaced that the Next.js RPC proxy's `buildProxyHeaders` forwards a fixed allow-list (content-type, authorization, cookie, …) and **no client IP at all**. So on the backend:

- `getClientIp` saw the **proxy's** address, not the browser's → the login/codes rate limits (#19) keyed **per proxy pod** — a near-global bucket, not per user.
- The raw `X-Forwarded-For` it fell back to is **client-spoofable** (leftmost hop).

## Fix — forward + trust-on-verification

- **Proxy** resolves the real client IP from the inbound `X-Forwarded-For` **hop-aware** (`TRUSTED_PROXY_HOPS`, counted from the right — your own infra appends those, so a client-prepended fake is ignored) and forwards it as `x-spfn-proxy-client-ip`.
- **Backend** `getClientIp` uses that header **only when proxy-guard verified** the request (`clientType` ≠ `untrusted`). On a verified request the proxy is the sole hop, so the value is the true client and can't be spoofed; otherwise it falls back to the raw chain. With proxy-guard `off` (default), behaviour is unchanged.
- `request-logger` now reuses `getClientIp`, so logs and rate limits resolve the IP the same way.

No HMAC binding of the IP in v1 — trust is anchored on the signature verification, not the header itself (a MITM on the internal hop is a TLS problem, not a header-signing one).

## Config

`TRUSTED_PROXY_HOPS` (default 1; set to your hop count, e.g. cloud LB + nginx = 2). Documented in the core env schema (`nextjs: true` — read by the proxy).

## Verification

core type-check + madge circular + build clean; middleware suite green (87) + new tests: `getClientIp` trusts the forwarded IP only when verified (4) and `clientIpFromForwardedChain` hop math incl. spoof-prepend (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)