### PR TITLE
feat(core): in-memory nonce store default + fail-closed option + multipart doc (S-L2/S-I2/S-L3)

### DIFF
--- a/packages/core/src/middleware/__tests__/proxy-guard.test.ts
+++ b/packages/core/src/middleware/__tests__/proxy-guard.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
 
-import { createProxyGuard, type NonceStore } from '../proxy-guard';
+import { createProxyGuard, createInMemoryNonceStore, type NonceStore } from '../proxy-guard';
 import { signProxyRequest, parseProxyKey } from '../../security/proxy-signature';
 
 const SECRET = 'test-shared-secret';
@@ -186,6 +186,41 @@ describe('createProxyGuard', () =>
             });
 
             expect(res.status).toBe(200);
+        });
+
+        it('rejects (fail-closed) when the nonce store throws and nonceFailClosed is set', async () =>
+        {
+            const flakyStore: NonceStore = {
+                async checkAndSet()
+                {
+                    throw new Error('redis unreachable');
+                },
+            };
+            const guard = createProxyGuard({
+                mode: 'strict', secret: SECRET, nonceStore: flakyStore, nonceFailClosed: true,
+            });
+            const app = buildApp(guard);
+
+            const res = await app.request('/users/9', {
+                method: 'GET',
+                headers: { ...signedHeaders('GET', '/users/9') },
+            });
+
+            expect(res.status).toBe(403);
+        });
+
+        it('rejects a replayed nonce with the in-memory store', async () =>
+        {
+            const guard = createProxyGuard({ mode: 'strict', secret: SECRET, nonceStore: createInMemoryNonceStore() });
+            const app = buildApp(guard);
+            // Reuse the SAME signed headers (same nonce) for both requests.
+            const headers = { ...signedHeaders('GET', '/users/9') };
+
+            const first = await app.request('/users/9', { method: 'GET', headers });
+            const replay = await app.request('/users/9', { method: 'GET', headers });
+
+            expect(first.status).toBe(200);
+            expect(replay.status).toBe(403);
         });
 
         it('rejects an oversized body with 413 (strict)', async () =>

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -6,7 +6,7 @@ export { ErrorHandler } from './error-handler';
 export type { ErrorHandlerOptions, OnErrorContext } from './error-handler';
 export { RequestLogger, maskSensitiveData } from './request-logger';
 export type { RequestLoggerOptions, RequestLoggerConfig } from './request-logger';
-export { createProxyGuard, createCacheNonceStore } from './proxy-guard';
+export { createProxyGuard, createCacheNonceStore, createInMemoryNonceStore } from './proxy-guard';
 export type { ProxyGuardConfig, ProxyGuardMode, ClientType, NonceStore } from './proxy-guard';
 export { rateLimit, getClientIp } from './rate-limit';
 export type { RateLimitOptions } from './rate-limit';

--- a/packages/core/src/middleware/proxy-guard.ts
+++ b/packages/core/src/middleware/proxy-guard.ts
@@ -94,8 +94,15 @@ export interface ProxyGuardConfig
      */
     allowedOrigins?: string[];
 
-    /** Optional Redis-backed nonce store for hard replay rejection (strict mode only). */
+    /** Optional nonce store for hard replay rejection. Redis (multi-instance) or in-memory (single). */
     nonceStore?: NonceStore;
+
+    /**
+     * When the nonce store throws (e.g. Redis down), reject the request instead of
+     * falling back to the timestamp window. Trades availability for strictness.
+     * @default false (fall back to the timestamp window)
+     */
+    nonceFailClosed?: boolean;
 
     /** Paths to skip entirely (e.g. health checks). */
     skipPaths?: string[];
@@ -243,6 +250,7 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
     const windowMs = config.windowMs ?? 30_000;
     const allowedOrigins = config.allowedOrigins;
     const nonceStore = config.nonceStore;
+    const nonceFailClosed = config.nonceFailClosed ?? false;
     const skipPaths = new Set(config.skipPaths ?? []);
     const maxBodyBytes = config.maxBodyBytes;
 
@@ -385,6 +393,15 @@ export function createProxyGuard(config: ProxyGuardConfig = {}): MiddlewareHandl
             }
             catch (err)
             {
+                if (nonceFailClosed)
+                {
+                    guardLogger.warn('Nonce store unavailable — rejecting (fail-closed)', {
+                        error: (err as Error).message,
+                    });
+
+                    return reject(c, mode, next, 'nonce-store-unavailable');
+                }
+
                 guardLogger.warn('Nonce store unavailable — falling back to timestamp window', {
                     error: (err as Error).message,
                 });
@@ -426,6 +443,47 @@ export function createCacheNonceStore(cache: CacheClient, prefix = 'spfn:proxy-n
 }
 
 /**
+ * In-process nonce store for hard replay rejection without Redis.
+ *
+ * Good enough for a single instance — each process only knows its own nonces, so
+ * across multiple instances a replay routed to a different pod isn't caught. Use a
+ * cache-backed store (createCacheNonceStore) for multi-instance hard rejection.
+ * Entries self-expire after their TTL; the map is swept opportunistically so it
+ * stays bounded by the request rate within the replay window.
+ */
+export function createInMemoryNonceStore(): NonceStore
+{
+    const seen = new Map<string, number>(); // nonce -> expiry (epoch ms)
+    let lastSweep = 0;
+
+    return {
+        async checkAndSet(nonce: string, ttlMs: number): Promise<boolean>
+        {
+            const now = Date.now();
+
+            if (now - lastSweep > 60_000)
+            {
+                for (const [n, exp] of seen)
+                {
+                    if (exp <= now) seen.delete(n);
+                }
+                lastSweep = now;
+            }
+
+            const existing = seen.get(nonce);
+            if (existing !== undefined && existing > now)
+            {
+                return false; // replay within window
+            }
+
+            seen.set(nonce, now + ttlMs);
+
+            return true;
+        },
+    };
+}
+
+/**
  * Reject (strict) or tag-and-continue (tag). Keeps the rejection response generic
  * so it leaks no detail about why verification failed.
  */
@@ -433,7 +491,7 @@ function reject(
     c: Context,
     mode: ProxyGuardMode,
     next: Next,
-    reason: VerifyFailureReason | 'origin-not-allowed' | 'nonce-replay' | 'body-read-error' | undefined,
+    reason: VerifyFailureReason | 'origin-not-allowed' | 'nonce-replay' | 'nonce-store-unavailable' | 'body-read-error' | undefined,
 )
 {
     if (mode === 'strict')

--- a/packages/core/src/security/proxy-signature.ts
+++ b/packages/core/src/security/proxy-signature.ts
@@ -137,6 +137,16 @@ export interface SignatureParts
      * SHA-256 hex of the raw request body, or empty string when there is no body
      * (GET/HEAD, or multipart uploads which are excluded by design). Bound for ANY
      * non-multipart content-type, not just application/json.
+     *
+     * Multipart is excluded so the proxy can stream large uploads without buffering
+     * them to hash. The signature therefore proves *provenance* (came through the
+     * trusted proxy) and binds method/path/query/timestamp for a multipart request,
+     * but NOT the body bytes. Two consequences, by design:
+     *   - Multipart *content* integrity/validation is the application's job (size,
+     *     type, checksum, business rules) — not the transport signature's.
+     *   - If you don't trust the proxy→backend hop itself, secure it with TLS/mTLS;
+     *     signing a prefix of the stream would be a half-measure (the tail stays
+     *     unprotected) and is intentionally not done.
      */
     bodyHash: string;
 }

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -167,7 +167,7 @@ async function applyProxyGuard(app: Hono, config?: ServerConfig): Promise<void>
         return;
     }
 
-    const { createProxyGuard, createCacheNonceStore } = await import('@spfn/core/middleware');
+    const { createProxyGuard, createCacheNonceStore, createInMemoryNonceStore } = await import('@spfn/core/middleware');
 
     // Optionally enable Redis-backed nonce replay rejection
     let nonceStore: NonceStore | undefined;
@@ -184,12 +184,14 @@ async function applyProxyGuard(app: Hono, config?: ServerConfig): Promise<void>
             }
             else
             {
-                serverLogger.warn('Proxy-guard nonce enabled but no cache available — using timestamp window only');
+                nonceStore = createInMemoryNonceStore();
+                serverLogger.info('Proxy-guard nonce replay rejection: in-memory (single instance only — use a cache for multi-instance)');
             }
         }
         catch
         {
-            serverLogger.warn('Proxy-guard nonce enabled but cache module unavailable — using timestamp window only');
+            nonceStore = createInMemoryNonceStore();
+            serverLogger.warn('Proxy-guard nonce: cache module unavailable — using in-memory store (single instance only)');
         }
     }
 
@@ -217,6 +219,7 @@ async function applyProxyGuard(app: Hono, config?: ServerConfig): Promise<void>
         allowedOrigins: proxyGuardConfig?.allowedOrigins,
         maxBodyBytes: proxyGuardConfig?.maxBodyBytes,
         nonceStore,
+        nonceFailClosed: proxyGuardConfig?.nonceFailClosed,
         skipPaths,
     }));
 


### PR DESCRIPTION
The remaining proxy-guard P3 items, as a single posture change. Full report: `artifacts/security-perf-review-core-auth-2026-06-26.md`.

## S-L2 — hard replay rejection without Redis

Previously, nonce-based replay rejection needed a Redis-backed store; without it the guard fell back to the timestamp window (~30s) only. Added **`createInMemoryNonceStore`** and default to it when nonce rejection is enabled but no cache is configured. Single-instance hard rejection now works out of the box.

> Caveat (logged + documented): in-memory is per-process — across instances a replay routed to a different pod isn't caught. Multi-instance still needs `createCacheNonceStore` (Redis). Same shape as the SSE token store.

## S-I2 — opt-in fail-closed

Added **`nonceFailClosed`** (default `false`). When set, a nonce-store error **rejects** instead of degrading to the timestamp window. Default stays fail-open because a nonce-store DoS only reopens the ~30s replay window and requires internal access to exploit — low risk — so availability wins by default; strict deployments can opt in.

## S-L3 — multipart signing (doc only)

Documented why multipart bodies are excluded from the signature: the proxy streams large uploads without buffering to hash, so the signature still binds provenance + method/path/query/timestamp but not the body bytes. Content integrity is the **application's** job (size/type/checksum/business rules); an untrusted proxy→backend hop is a **TLS/mTLS** problem. Prefix-signing is intentionally not done (the tail would stay unprotected).

## Verification

core type-check + madge circular + build clean; proxy-guard + proxy-signature suites green (50, incl. 2 new: fail-closed rejects on store error, in-memory store rejects a replayed nonce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)