### PR TITLE
test(auth): type the notification mock so account-exists test type-checks

### DIFF
--- a/packages/auth/src/__tests__/unit/account-exists-notice.test.ts
+++ b/packages/auth/src/__tests__/unit/account-exists-notice.test.ts
@@ -11,8 +11,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { sendEmail, sendSMS } = vi.hoisted(() => ({
-    sendEmail: vi.fn(async () => ({ success: true })),
-    sendSMS: vi.fn(async () => ({ success: true })),
+    sendEmail: vi.fn(async (_opts: { to: string; template: string; data?: unknown }) => ({ success: true })),
+    sendSMS: vi.fn(async (_opts: { to: string; template: string; data?: unknown }) => ({ success: true })),
 }));
 
 vi.mock('@spfn/notification/server', () => ({ sendEmail, sendSMS }));


### PR DESCRIPTION
Follow-up to #38. The `account-exists-notice` test asserted `sendEmail.mock.calls[0][0]`, but the hoisted mock fns took no args so `tsc` typed each call tuple as `[]` → TS2493 on integrated main. Give the mocks a typed options param. Runtime behavior unchanged (3/3); the gap was that `tsc --noEmit` wasn't re-run over the new test file before #38 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)