### PR TITLE
chore(release): bump @spfn/* for the security/perf audit fixes

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/auth",
-  "version": "0.2.0-beta.68",
+  "version": "0.2.0-beta.69",
   "type": "module",
   "description": "Authentication, authorization, and RBAC module for SPFN",
   "author": "Ray Im <rayim@fxy.global>",
@@ -128,8 +128,8 @@
     "vitest": "^4.0.6"
   },
   "peerDependencies": {
-    "@spfn/core": ">=0.2.0-beta.49",
-    "@spfn/notification": ">=0.1.0-beta.18",
+    "@spfn/core": ">=0.2.0-beta.54",
+    "@spfn/notification": ">=0.1.0-beta.21",
     "next": "^15.0.0 || ^16.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spfn",
-  "version": "0.2.0-beta.49",
+  "version": "0.2.0-beta.50",
   "description": "Superfunction CLI - Add SPFN to your Next.js project",
   "type": "module",
   "bin": {
@@ -52,7 +52,7 @@
     "node": ">=18.18.0"
   },
   "peerDependencies": {
-    "@spfn/core": ">=0.2.0-beta.30",
+    "@spfn/core": ">=0.2.0-beta.54",
     "typescript": "^5.3.0"
   },
   "peerDependenciesMeta": {

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/cms",
-  "version": "0.2.0-beta.20",
+  "version": "0.2.0-beta.21",
   "description": "SPFN CMS - Content Management System with type-safe labels and Next.js integration",
   "type": "module",
   "main": "./dist/index.js",
@@ -85,7 +85,7 @@
     "setupMessage": "  📚 Next steps:\n    1. Import CMS components: import { useLabels } from '@spfn/cms'\n    2. View labels in Drizzle Studio: pnpm spfn db studio\n    3. CMS API available at: http://localhost:8790/_cms\n    4. Learn more: https://github.com/spfnio/spfn"
   },
   "peerDependencies": {
-    "@spfn/core": ">=0.2.0-beta.49",
+    "@spfn/core": ">=0.2.0-beta.54",
     "drizzle-orm": ">=0.44.7",
     "next": "^15.0.0 || ^16.0.0",
     "react": "^18.0.0 || ^19.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spfn/core",
-    "version": "0.2.0-beta.53",
+    "version": "0.2.0-beta.54",
     "description": "SPFN Framework Core - File-based routing, transactions, repository pattern",
     "type": "module",
     "exports": {

--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/monitor",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "type": "module",
   "description": "Error tracking, log management, and monitoring dashboard for SPFN",
   "main": "./dist/index.js",
@@ -88,9 +88,9 @@
     "vitest": "^4.0.6"
   },
   "peerDependencies": {
-    "@spfn/auth": ">=0.2.0-beta.66",
-    "@spfn/core": ">=0.2.0-beta.49",
-    "@spfn/notification": ">=0.1.0-beta.18",
+    "@spfn/auth": ">=0.2.0-beta.69",
+    "@spfn/core": ">=0.2.0-beta.54",
+    "@spfn/notification": ">=0.1.0-beta.21",
     "next": "^15.0.0 || ^16.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/notification",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "type": "module",
   "description": "Multi-channel notification system for SPFN - Email, SMS, Slack, Push",
   "exports": {
@@ -51,7 +51,7 @@
     "url": "https://github.com/spfn/spfn/issues"
   },
   "peerDependencies": {
-    "@spfn/core": ">=0.2.0-beta.49",
+    "@spfn/core": ">=0.2.0-beta.54",
     "@aws-sdk/client-sesv2": "^3.0.0",
     "@aws-sdk/client-sns": "^3.0.0"
   },

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/workflow",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.15",
   "description": "Lightweight workflow engine - Pipeline orchestration for @spfn/core",
   "type": "module",
   "exports": {
@@ -44,7 +44,7 @@
     "@sinclair/typebox": "^0.34.0"
   },
   "peerDependencies": {
-    "@spfn/core": "^0.2.0-beta.5"
+    "@spfn/core": ">=0.2.0-beta.54"
   },
   "devDependencies": {
     "@spfn/core": "workspace:*",


### PR DESCRIPTION
Release the security/perf audit remediation (P0–P3, merged in #19–#41). Bumps every code-bearing package and raises all `@spfn/*` peer floors to the matched set, so consumers can't pin a patched package against pre-fix peers.

| package | bump | note |
|---|---|---|
| @spfn/core | 0.2.0-beta.53 → **54** | |
| @spfn/auth | 0.2.0-beta.68 → **69** | ⚠️ breaking: native bcrypt (#23), `/_auth/exists` removed (#37) |
| @spfn/notification | 0.1.0-beta.20 → **21** | account-exists template |
| spfn (cli) | 0.2.0-beta.49 → **50** | peer-floor only |
| @spfn/cms | 0.2.0-beta.20 → **21** | peer-floor only |
| @spfn/monitor | 0.1.0-beta.19 → **20** | peer-floor only |
| @spfn/workflow | 0.1.0-alpha.14 → **15** | peer-floor only |

Peer floors now require `>= 0.2.0-beta.54` core / `>= 0.2.0-beta.69` auth / `>= 0.1.0-beta.21` notification across all dependents.

## Verification
- Inter-package structure audited: all `@spfn/*` are peerDeps (ranges) + devDeps (`workspace:*`); nothing leaks into published runtime deps.
- `pnpm install` clean (no peer warnings); full `pnpm build` **10/10**; type-check across core/auth/notification **0 errors**.

## ⚠️ Merging this publishes
Merging to `main` triggers the GitHub Actions publish for each package whose version changed — i.e. **all 7 publish to npm** (irreversible). Beta stays beta (no stable promotion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)