### PR TITLE
chore(release): bundle LICENSE from a single root copy via prepack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ packages/*/.guide/
 .woodpecker.main.yml
 /apps/
 .supervibe/notes/
+
+# Per-package LICENSE is generated from the root LICENSE at pack time (prepack)
+packages/*/LICENSE

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/auth",
-  "version": "0.2.0-beta.69",
+  "version": "0.2.0-beta.70",
   "type": "module",
   "description": "Authentication, authorization, and RBAC module for SPFN",
   "author": "Ray Im <rayim@fxy.global>",
@@ -55,6 +55,7 @@
   ],
   "scripts": {
     "build": "pnpm check:circular && tsup && tsup --config tsup.client.config.ts",
+    "prepack": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\"",
     "watch": "tsup --watch",
     "dev": "tsup --watch",
     "type-check": "tsc --noEmit",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spfn",
-  "version": "0.2.0-beta.50",
+  "version": "0.2.0-beta.51",
   "description": "Superfunction CLI - Add SPFN to your Next.js project",
   "type": "module",
   "bin": {
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "tsup && node scripts/copy-templates.js",
+    "prepack": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\"",
     "dev": "tsup --watch",
     "type-check": "tsc --noEmit"
   },

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/cms",
-  "version": "0.2.0-beta.21",
+  "version": "0.2.0-beta.22",
   "description": "SPFN CMS - Content Management System with type-safe labels and Next.js integration",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,6 +39,7 @@
   ],
   "scripts": {
     "build": "pnpm check:circular && tsup",
+    "prepack": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\"",
     "watch": "tsup --watch",
     "clean": "rm -rf dist",
     "db:generate": "drizzle-kit generate",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spfn/core",
-    "version": "0.2.0-beta.54",
+    "version": "0.2.0-beta.55",
     "description": "SPFN Framework Core - File-based routing, transactions, repository pattern",
     "type": "module",
     "exports": {
@@ -112,6 +112,7 @@
     },
     "scripts": {
         "build": "pnpm check:circular && tsup",
+        "prepack": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\"",
         "dev": "tsup",
         "test": "vitest run",
         "test:watch": "vitest",

--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/monitor",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "type": "module",
   "description": "Error tracking, log management, and monitoring dashboard for SPFN",
   "main": "./dist/index.js",
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "build": "pnpm check:circular && tsup && tsup --config tsup.client.config.ts",
+    "prepack": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\"",
     "dev": "tsup --watch",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/notification",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "type": "module",
   "description": "Multi-channel notification system for SPFN - Email, SMS, Slack, Push",
   "exports": {
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "build": "pnpm check:circular && tsup",
+    "prepack": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\"",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spfn/workflow",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.16",
   "description": "Lightweight workflow engine - Pipeline orchestration for @spfn/core",
   "type": "module",
   "exports": {
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "prepack": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\"",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
The previous release (#42) shipped packages with a `license: MIT` field but **no LICENSE text file** in the tarballs (per-package LICENSE files never existed on main — #31 was never merged). This fixes that **without maintaining N copies**.

## Single-source approach
- The root `LICENSE` stays the only source of truth.
- Each published package gets a `prepack` that copies it in at pack time:
  `node -e "require('fs').copyFileSync('../../LICENSE','LICENSE')"` — `pnpm publish` runs `prepack`, so the tarball includes it. Verified with `pnpm pack`: the tarball now contains `package/LICENSE`.
- `.gitignore packages/*/LICENSE` — the generated copies are **never committed**, so there's nothing to keep in sync.

## Release
Bumps all 7 so the LICENSE-bundled artifacts republish:
core `…beta.55`, auth `…beta.70`, notification `…beta.22`, spfn `…beta.51`, cms `…beta.22`, monitor `…beta.21`, workflow `…alpha.16`. Peer floors unchanged (license-only; existing `>=` ranges still hold).

Supersedes **#31** (which committed a LICENSE file per package — the duplication this avoids); #31 can be closed.

## ⚠️ Merging publishes
Same as before — merging bumps versions → all 7 republish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)