### PR TITLE
fix(auth)!: enforce OTP attempt cap before code comparison (critical)

### DIFF
--- a/packages/auth/src/__tests__/unit/otp-attempt-cap.test.ts
+++ b/packages/auth/src/__tests__/unit/otp-attempt-cap.test.ts
@@ -1,0 +1,62 @@
+/**
+ * verifyCodeService — OTP attempt-cap enforcement (audit: critical)
+ *
+ * The attempt cap must be checked BEFORE the code comparison, so repeated wrong
+ * guesses actually lock the code. Previously the cap ran only after a correct
+ * match (the wrong-code branch returned early), making it dead code → unlimited
+ * OTP brute force (account takeover via password_reset).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { findValid, incrementAttempts, markAsUsed } = vi.hoisted(() => ({
+    findValid: vi.fn(),
+    incrementAttempts: vi.fn(async () => undefined),
+    markAsUsed: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../server/repositories', () => ({
+    verificationCodesRepository: {
+        findValidByTargetAndPurpose: findValid,
+        incrementAttempts,
+        markAsUsed,
+        create: vi.fn(),
+        invalidatePreviousCodes: vi.fn(),
+    },
+    usersRepository: { findByEmail: vi.fn(), findByPhone: vi.fn() },
+}));
+
+import { verifyCodeService } from '../../server/services/verification.service';
+
+const base = { target: 'a@b.com', targetType: 'email' as const, purpose: 'password_reset' as const };
+const future = new Date(Date.now() + 300_000);
+
+describe('verifyCodeService — OTP attempt cap', () =>
+{
+    beforeEach(() => vi.clearAllMocks());
+
+    it('locks once at the cap, before comparing the code, on a wrong guess', async () =>
+    {
+        findValid.mockResolvedValue({ id: 1, code: '123456', attempts: 5, usedAt: null, expiresAt: future });
+
+        await expect(verifyCodeService({ ...base, code: '000000' })).rejects.toThrow(/too many attempts/i);
+        // Cap is enforced before the wrong-code branch, so it must NOT increment further.
+        expect(incrementAttempts).not.toHaveBeenCalled();
+    });
+
+    it('stays locked even when the correct code is supplied after the cap', async () =>
+    {
+        findValid.mockResolvedValue({ id: 1, code: '123456', attempts: 5, usedAt: null, expiresAt: future });
+
+        await expect(verifyCodeService({ ...base, code: '123456' })).rejects.toThrow(/too many attempts/i);
+        expect(markAsUsed).not.toHaveBeenCalled();
+    });
+
+    it('increments on a wrong guess while still under the cap', async () =>
+    {
+        findValid.mockResolvedValue({ id: 1, code: '123456', attempts: 2, usedAt: null, expiresAt: future });
+
+        await expect(verifyCodeService({ ...base, code: '000000' })).rejects.toThrow();
+        expect(incrementAttempts).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/auth/src/server/services/verification.service.ts
+++ b/packages/auth/src/server/services/verification.service.ts
@@ -116,6 +116,17 @@ async function validateVerificationCode(
         return { valid: false, error: 'Invalid verification code' };
     }
 
+    // Enforce the attempt cap on EVERY attempt — BEFORE the code comparison.
+    // Previously this ran only after a correct match (the wrong-code branch returns
+    // early), so it was dead code: wrong guesses incremented `attempts` forever but
+    // were never blocked — unlimited OTP brute force (account takeover via
+    // password_reset). findValidByTargetAndPurpose does not filter on attempts, so
+    // the cap must be enforced here.
+    if (record.attempts >= MAX_VERIFICATION_ATTEMPTS)
+    {
+        return { valid: false, error: 'Too many attempts, please request a new code' };
+    }
+
     // Check if code matches
     if (record.code !== code)
     {
@@ -135,12 +146,6 @@ async function validateVerificationCode(
     if (new Date() > new Date(record.expiresAt))
     {
         return { valid: false, error: 'Verification code expired' };
-    }
-
-    // Check attempt count
-    if (record.attempts >= MAX_VERIFICATION_ATTEMPTS)
-    {
-        return { valid: false, error: 'Too many attempts, please request a new code' };
     }
 
     return { valid: true, codeId: record.id };


### PR DESCRIPTION
**Critical — account takeover.** Found by re-running the `spfn-security-audit` harness against post-remediation `main` (the original core/auth audit missed it).

## The bug
`validateVerificationCode` returned early on a wrong code (incrementing `attempts`), and the `attempts >= MAX_VERIFICATION_ATTEMPTS` check sat **after** that branch — so it was only ever reached on a **correct** code. `findValidByTargetAndPurpose` also doesn't filter on `attempts`. Net effect: **wrong guesses were never blocked** → unlimited 6-digit OTP brute force → account takeover via `password_reset` (and any code-gated flow). The per-IP rate limit was the only real barrier, and it's bypassable.

```
const record = await findValid(...)          // does NOT filter attempts
if (record.code !== code) { increment; return invalid }   // ← early return
...
if (record.attempts >= MAX) return invalid   // ← DEAD: only on a correct code
```

## The fix
Move the cap check to **before** the code comparison, so every attempt counts and the code locks after `MAX` wrong guesses (request a new code to reset).

Unit-tested: locks at the cap before incrementing, stays locked even with the correct code after the cap, still increments while under the cap.

## ⚠️ Behavior
A code now hard-locks after `MAX_VERIFICATION_ATTEMPTS` wrong tries (was: never). Legitimate users re-request a code.

## Verification
auth type-check + build clean; new `otp-attempt-cap` unit suite green (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)