### PR TITLE
fix(cms)!: gate admin routes with authenticate + admin role (S-H1)

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -87,6 +87,7 @@
   },
   "peerDependencies": {
     "@spfn/core": ">=0.2.0-beta.54",
+    "@spfn/auth": ">=0.2.0-beta.70",
     "drizzle-orm": ">=0.44.7",
     "next": "^15.0.0 || ^16.0.0",
     "react": "^18.0.0 || ^19.0.0"
@@ -99,6 +100,7 @@
   },
   "devDependencies": {
     "@spfn/core": "workspace:*",
+    "@spfn/auth": "workspace:*",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.11.0",
     "@types/react": "^19",

--- a/packages/cms/src/server/routes/admin.routes.ts
+++ b/packages/cms/src/server/routes/admin.routes.ts
@@ -6,12 +6,19 @@
 
 import { Type } from '@sinclair/typebox';
 import { defineRouter, route } from '@spfn/core/route';
+import { authenticate, requireRole } from '@spfn/auth/server';
 import {
     getSectionLabels,
     saveSectionDraft,
     publishSection,
     resetSectionDraft,
 } from '../services/publish.service';
+
+// These routes rewrite/publish site-wide CMS content, so they must be gated.
+// Authenticate AND require an admin-tier role at the package level — do NOT rely on
+// the consumer's global auth for authorization (fail closed). requireRole is an
+// exact match, so both admin tiers are listed explicitly.
+const ADMIN_GUARD = [authenticate, requireRole('admin', 'superadmin')];
 
 /**
  * 섹션의 모든 라벨 조회 (테이블 뷰용)
@@ -27,6 +34,7 @@ export const getSectionLabelsRoute = route.get('/_cms/admin/sections/:section/la
             locales: Type.Optional(Type.String()), // comma-separated: "en,ko"
         }),
     })
+    .use(ADMIN_GUARD)
     .handler(async (c) =>
     {
         const { params, query } = await c.data();
@@ -55,6 +63,7 @@ export const saveSectionDraftRoute = route.put('/_cms/admin/sections/:section/dr
             ),
         }),
     })
+    .use(ADMIN_GUARD)
     .handler(async (c) =>
     {
         const { params, body } = await c.data();
@@ -80,6 +89,7 @@ export const publishSectionRoute = route.post('/_cms/admin/sections/:section/pub
             locales: Type.Array(Type.String()),
         }),
     })
+    .use(ADMIN_GUARD)
     .handler(async (c) =>
     {
         const { params, body } = await c.data();
@@ -102,6 +112,7 @@ export const resetSectionDraftRoute = route.delete('/_cms/admin/sections/:sectio
             section: Type.String(),
         }),
     })
+    .use(ADMIN_GUARD)
     .handler(async (c) =>
     {
         const { params } = await c.data();


### PR DESCRIPTION
**High — broken access control.** From the ancillary-package audit (`artifacts/security-perf-review-ancillary-packages-2026-06-27.md`, S-H1).

## The gap
`packages/cms/src/server/routes/admin.routes.ts` — the four admin routes (`getSectionLabels`, `saveSectionDraft`, `publishSection`, `resetSectionDraft`) had only `.input().handler()`, **no `.use([...])` / role middleware**. With the consumer's global `auth` they required authentication but **no authorization** → any logged-in user could `PUT/POST/DELETE` to rewrite, publish, or wipe **site-wide CMS content** served to every visitor. With no global auth, fully open. The package even ships an unused `InsufficientCMSPermissionsError` — the intended-but-missing gate.

## The fix
Gate all four with `[authenticate, requireRole('admin', 'superadmin')]` at the package level (fail closed — not relying on the consumer's global auth), mirroring how `@spfn/monitor` gates its admin routes. `requireRole` is an exact match, so both admin tiers are listed explicitly. The public `getLabelCache` route (separate file, `.skip(['auth'])`) is untouched.

`@spfn/auth` added as a peer dependency (authz primitives live there) + dev workspace dep.

## ⚠️ Breaking
CMS admin routes now require an authenticated `admin`/`superadmin`. Apps relying on the previous (unintended) open access must assign the role. Adjust the role names if your app uses a different content-admin role.

## Verification
cms type-check + build + madge circular clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)