### PR TITLE
fix(notification): close click-tracking open redirect (S-H2)

### DIFF
--- a/packages/notification/src/tracking/__tests__/processor.test.ts
+++ b/packages/notification/src/tracking/__tests__/processor.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, vi } from 'vitest';
 // Mock token module to return predictable tokens
 vi.mock('../token', () => ({
     generateOpenToken: vi.fn((id: number) => `open-token-${id}`),
-    generateClickToken: vi.fn((id: number, idx: number) => `click-token-${id}-${idx}`),
+    generateClickToken: vi.fn((id: number, idx: number, _url: string) => `click-token-${id}-${idx}`),
 }));
 
 import { processTrackingHtml } from '../processor';

--- a/packages/notification/src/tracking/__tests__/token.test.ts
+++ b/packages/notification/src/tracking/__tests__/token.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../config', () => ({
 import {
     generateOpenToken,
     generateClickToken,
+    hashClickUrl,
     verifyOpenToken,
     verifyClickToken,
 } from '../token';
@@ -50,7 +51,7 @@ describe('tracking/token', () =>
 
         it('should reject a click token as open token', () =>
         {
-            const clickToken = generateClickToken(42, 3);
+            const clickToken = generateClickToken(42, 3, 'https://example.com/x');
             const result = verifyOpenToken(clickToken);
 
             expect(result.valid).toBe(false);
@@ -70,17 +71,28 @@ describe('tracking/token', () =>
     {
         it('should generate and verify a valid click token', () =>
         {
-            const token = generateClickToken(42, 5);
+            const token = generateClickToken(42, 5, 'https://example.com/x');
             const result = verifyClickToken(token);
 
             expect(result.valid).toBe(true);
             expect(result.notificationId).toBe(42);
             expect(result.linkIndex).toBe(5);
+            // The destination URL is bound into the token.
+            expect(result.urlHash).toBe(hashClickUrl('https://example.com/x'));
+        });
+
+        it('binds the destination: different URLs produce different hashes', () =>
+        {
+            const a = verifyClickToken(generateClickToken(1, 0, 'https://good.example.com'));
+            const b = verifyClickToken(generateClickToken(1, 0, 'https://evil.example.com'));
+
+            expect(a.urlHash).toBeDefined();
+            expect(a.urlHash).not.toBe(b.urlHash);
         });
 
         it('should reject a tampered click token', () =>
         {
-            const token = generateClickToken(42, 5);
+            const token = generateClickToken(42, 5, 'https://example.com/x');
             const tampered = 'x' + token.slice(1);
             const result = verifyClickToken(tampered);
 
@@ -97,7 +109,7 @@ describe('tracking/token', () =>
 
         it('should preserve linkIndex 0', () =>
         {
-            const token = generateClickToken(1, 0);
+            const token = generateClickToken(1, 0, 'https://example.com/x');
             const result = verifyClickToken(token);
 
             expect(result.valid).toBe(true);

--- a/packages/notification/src/tracking/processor.ts
+++ b/packages/notification/src/tracking/processor.ts
@@ -71,7 +71,7 @@ export function processTrackingHtml(
             }
 
             const currentIndex = linkIndex++;
-            const clickToken = generateClickToken(notificationId, currentIndex);
+            const clickToken = generateClickToken(notificationId, currentIndex, url);
             const trackingUrl = `${baseUrl}/_noti/t/c/${clickToken}?url=${encodeURIComponent(url)}`;
 
             trackedLinks.push({ index: currentIndex, url });

--- a/packages/notification/src/tracking/routes.ts
+++ b/packages/notification/src/tracking/routes.ts
@@ -8,7 +8,7 @@
 import { route } from '@spfn/core/route';
 import { Type } from '@sinclair/typebox';
 import { defineRouter } from '@spfn/core/route';
-import { verifyOpenToken, verifyClickToken } from './token';
+import { verifyOpenToken, verifyClickToken, hashClickUrl } from './token';
 import { recordOpenEvent, recordClickEvent } from './tracking.service';
 import { logger } from '@spfn/core/logger';
 
@@ -83,19 +83,46 @@ export const trackClick = route.get('/_noti/t/c/:token')
         const targetUrl = query.url;
         const result = verifyClickToken(params.token);
 
-        if (result.valid && result.notificationId != null && result.linkIndex != null)
-        {
-            recordClickEvent(result.notificationId, result.linkIndex, targetUrl, {
-                ipAddress: c.raw.req.header('x-forwarded-for') ?? c.raw.req.header('x-real-ip'),
-                userAgent: c.raw.req.header('user-agent'),
-            });
-        }
-        else
+        // Invalid token → do NOT redirect. The endpoint is .skip(['auth']), so
+        // redirecting on an unverified token would make it an open redirect
+        // (GET /_noti/t/c/<garbage>?url=https://evil.com).
+        if (!result.valid || result.notificationId == null || result.linkIndex == null)
         {
             log.warn('Invalid click tracking token');
+
+            return new Response('Not found', { status: 404 });
         }
 
-        // Always redirect (UX protection)
+        // Only http(s) destinations — block javascript:/data:/relative-protocol.
+        let parsed: URL;
+        try
+        {
+            parsed = new URL(targetUrl);
+        }
+        catch
+        {
+            return new Response('Not found', { status: 404 });
+        }
+
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
+        {
+            return new Response('Not found', { status: 404 });
+        }
+
+        // New tokens bind the destination URL; reject a swapped target. Legacy
+        // tokens (no urlHash) predate binding and are allowed through.
+        if (result.urlHash && hashClickUrl(targetUrl) !== result.urlHash)
+        {
+            log.warn('Click URL does not match signed token');
+
+            return new Response('Not found', { status: 404 });
+        }
+
+        recordClickEvent(result.notificationId, result.linkIndex, targetUrl, {
+            ipAddress: c.raw.req.header('x-forwarded-for') ?? c.raw.req.header('x-real-ip'),
+            userAgent: c.raw.req.header('user-agent'),
+        });
+
         return new Response(null, {
             status: 302,
             headers: {

--- a/packages/notification/src/tracking/token.ts
+++ b/packages/notification/src/tracking/token.ts
@@ -7,8 +7,18 @@
  * Token format: base64url(payload).base64url(hmac)
  */
 
-import { createHmac } from 'node:crypto';
+import { createHmac, createHash } from 'node:crypto';
 import { getTrackingSecret } from '../config';
+
+/**
+ * Short, stable hash of a click destination, bound into the click token so the
+ * redirect target can't be swapped (open redirect). 64 bits is ample to bind a
+ * specific URL; the token's HMAC over the whole payload authenticates it.
+ */
+export function hashClickUrl(url: string): string
+{
+    return createHash('sha256').update(url).digest('hex').slice(0, 16);
+}
 
 /**
  * Base64url encode a buffer
@@ -85,11 +95,12 @@ export function generateOpenToken(notificationId: number): string
 }
 
 /**
- * Generate a click tracking token
+ * Generate a click tracking token. The destination URL is bound into the signed
+ * payload (as a hash) so the redirect target cannot be swapped at click time.
  */
-export function generateClickToken(notificationId: number, linkIndex: number): string
+export function generateClickToken(notificationId: number, linkIndex: number, url: string): string
 {
-    return sign(`c:${notificationId}:${linkIndex}`);
+    return sign(`c:${notificationId}:${linkIndex}:${hashClickUrl(url)}`);
 }
 
 /**
@@ -117,7 +128,7 @@ export function verifyOpenToken(token: string): { valid: boolean; notificationId
  */
 export function verifyClickToken(
     token: string,
-): { valid: boolean; notificationId?: number; linkIndex?: number }
+): { valid: boolean; notificationId?: number; linkIndex?: number; urlHash?: string }
 {
     const result = verify(token);
     if (!result.valid || !result.payload)
@@ -125,7 +136,9 @@ export function verifyClickToken(
         return { valid: false };
     }
 
-    const match = result.payload.match(/^c:(\d+):(\d+)$/);
+    // New tokens bind the destination URL hash (c:id:index:hash); legacy tokens
+    // (c:id:index) from already-sent emails are still accepted but unbound.
+    const match = result.payload.match(/^c:(\d+):(\d+)(?::([0-9a-f]{16}))?$/);
     if (!match)
     {
         return { valid: false };
@@ -135,5 +148,6 @@ export function verifyClickToken(
         valid: true,
         notificationId: Number(match[1]),
         linkIndex: Number(match[2]),
+        urlHash: match[3],
     };
 }


### PR DESCRIPTION
**High — open redirect.** From the ancillary audit (S-H2).

## The bug
`tracking/routes.ts` `trackClick` issued a `302` to `?url=` **unconditionally** ("Always redirect (UX protection)") — even when `verifyClickToken` failed and with no protocol check. The click token signed only `c:<id>:<index>` and never bound the destination. The route is `.skip(['auth'])`, so:
- `GET /_noti/t/c/<garbage>?url=https://evil.com` → a working **open redirect** for phishing; and
- a holder of any valid tracked link could swap `?url=` to redirect anywhere.

## The fix
- **Redirect only when the token verifies**; otherwise `404` (no redirect).
- **Validate the destination is http(s)** — blocks `javascript:`/`data:`/protocol-relative.
- **Bind the destination into the signed token**: `generateClickToken(id, index, url)` now signs `c:id:index:sha256(url)[:16]`; `trackClick` rejects a swapped url. **Legacy** unbound tokens (already-sent emails) still resolve via verified-token + http(s) check for backward compatibility.

## Verification
notification type-check + build + madge circular clean; tracking suite green (26, incl. URL-binding tests). `processor` passes the real URL into the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)