### PR TITLE
fix(monitor): redact sensitive headers/query before storing + Slack (S-H3/S-M2/S-L3)

### DIFF
--- a/packages/monitor/src/__tests__/unit/error-handler-redaction.test.ts
+++ b/packages/monitor/src/__tests__/unit/error-handler-redaction.test.ts
@@ -1,0 +1,49 @@
+/**
+ * createMonitorErrorHandler — sensitive data redaction (S-H3 / S-M2 / S-L3)
+ *
+ * Request headers and query params are persisted to error_events and forwarded to
+ * Slack, so secrets must be redacted before they leave this handler.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { trackError } = vi.hoisted(() => ({ trackError: vi.fn(async () => undefined) }));
+
+vi.mock('../../server/services', () => ({ trackError }));
+vi.mock('@spfn/monitor/config', () => ({ getMinStatusCode: () => 500 }));
+
+import { createMonitorErrorHandler } from '../../server/integrations/error-handler';
+
+const ctx = {
+    statusCode: 500,
+    path: '/x',
+    method: 'GET',
+    timestamp: new Date().toISOString(),
+    request: {
+        headers: { authorization: 'Bearer secret', cookie: 'sid=abc', 'set-cookie': 'sid=abc', 'content-type': 'application/json' },
+        query: { token: 'reset-secret', code: 'oauth-code', page: '2' },
+    },
+};
+
+describe('createMonitorErrorHandler — redaction', () =>
+{
+    beforeEach(() => vi.clearAllMocks());
+
+    it('redacts sensitive headers and query params before tracking', async () =>
+    {
+        const handler = createMonitorErrorHandler();
+        await handler(new Error('boom'), ctx as any);
+
+        expect(trackError).toHaveBeenCalledTimes(1);
+        const passed = trackError.mock.calls[0][1] as any;
+
+        expect(passed.headers.authorization).toBe('***');
+        expect(passed.headers.cookie).toBe('***');
+        expect(passed.headers['set-cookie']).toBe('***');
+        expect(passed.headers['content-type']).toBe('application/json'); // non-sensitive kept
+
+        expect(passed.query.token).toBe('***');
+        expect(passed.query.code).toBe('***');
+        expect(passed.query.page).toBe('2'); // non-sensitive kept
+    });
+});

--- a/packages/monitor/src/server/integrations/error-handler.ts
+++ b/packages/monitor/src/server/integrations/error-handler.ts
@@ -19,6 +19,32 @@ import { getMinStatusCode } from '@spfn/monitor/config';
 import { trackError, type ErrorTrackingContext } from '../services';
 import { monitorLogger } from '../logger';
 
+// Headers/query params whose VALUES must never be persisted to the error store or
+// posted to Slack. The upstream core error-handler masks a smaller set; the
+// monitor re-redacts a broader denylist here because it durably stores and
+// forwards this data (don't rely on the upstream mask).
+const SENSITIVE_HEADERS = new Set([
+    'authorization', 'proxy-authorization', 'cookie', 'set-cookie',
+    'x-api-key', 'x-auth-token', 'x-csrf-token', 'x-xsrf-token',
+    'x-spfn-proxy-signature', 'x-amz-security-token',
+]);
+const SENSITIVE_QUERY = new Set([
+    'token', 'access_token', 'refresh_token', 'id_token', 'code',
+    'secret', 'client_secret', 'password', 'passwd', 'pwd',
+    'api_key', 'apikey', 'key', 'signature', 'sig', 'session', 'sessionid', 'auth',
+]);
+
+function redact(obj: Record<string, string>, deny: Set<string>): Record<string, string>
+{
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(obj))
+    {
+        out[k] = deny.has(k.toLowerCase()) ? '***' : v;
+    }
+
+    return out;
+}
+
 const logger = monitorLogger.errorTracking;
 
 export interface MonitorErrorHandlerOptions
@@ -78,8 +104,10 @@ export function createMonitorErrorHandler(options: MonitorErrorHandlerOptions = 
             method: ctx.method,
             requestId: ctx.requestId,
             userId: ctx.userId != null ? String(ctx.userId) : undefined,
-            headers: ctx.request.headers,
-            query: ctx.request.query,
+            // Redact secrets before they are persisted (error_events.headers) and
+            // forwarded to Slack (S-H3 / S-M2 / S-L3).
+            headers: redact(ctx.request.headers, SENSITIVE_HEADERS),
+            query: redact(ctx.request.query, SENSITIVE_QUERY),
             environment: options.environment,
         };
 


### PR DESCRIPTION
**High — sensitive data exposure.** From the ancillary audit (S-H3, which the verifier flagged as the root cause of S-M2 and S-L3).

## The bug
`createMonitorErrorHandler` passed `ctx.request.headers` and `ctx.request.query` straight into the tracking context → persisted to `error_events.headers` and iterated wholesale into a Slack block. `Authorization` / `Cookie` / `Set-Cookie` / `x-api-key` and URL-borne tokens (`?token=`, `?code=`) landed in the **monitor DB** and the **Slack channel** in cleartext on every tracked error. The upstream core handler masks only a small set, and the monitor durably stores + forwards this data, so it must redact its own.

## The fix
Redact a broad header denylist + sensitive query params at the **capture point** — the single place that feeds both the DB store and Slack (fixes S-H3, S-M2, S-L3 at once). Non-sensitive fields pass through. Unit-tested.

## Verification
monitor type-check + build + madge circular clean; new redaction unit test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)