### PR TITLE
fix(auth): bind OAuth state to the browser via CSRF cookie (login CSRF)

### DIFF
--- a/packages/auth/src/__tests__/unit/oauth.test.ts
+++ b/packages/auth/src/__tests__/unit/oauth.test.ts
@@ -94,6 +94,15 @@ describe('OAuth State - Create/Verify', () =>
         expect(verified1.nonce).not.toBe(verified2.nonce);
     });
 
+    it('binds an explicit CSRF nonce into the state (round-trips for cookie match)', async () =>
+    {
+        const state = await createOAuthState({ ...mockStateParams, nonce: 'csrf-nonce-123' });
+        const verified = await verifyOAuthState(state);
+
+        // The callback double-submits this against the oauth_csrf cookie.
+        expect(verified.nonce).toBe('csrf-nonce-123');
+    });
+
     it('should reject tampered state', async () =>
     {
         const state = await createOAuthState(mockStateParams);

--- a/packages/auth/src/nextjs/interceptors/oauth.ts
+++ b/packages/auth/src/nextjs/interceptors/oauth.ts
@@ -7,7 +7,7 @@
 
 import type { InterceptorRule, ResponseInterceptorContext } from '@spfn/core/nextjs/server';
 import { generateKeyPair } from '../../server/lib/crypto';
-import { createOAuthState } from '../../server/lib/oauth/state';
+import { createOAuthState, generateOAuthNonce } from '../../server/lib/oauth/state';
 import { sealSession } from '../../server/lib/session';
 import { COOKIE_NAMES, getSessionTtl } from '../../server/lib/config';
 import { authLogger } from '../../server/logger';
@@ -32,6 +32,10 @@ export const oauthUrlInterceptor: InterceptorRule = {
         // 키쌍 생성
         const keyPair = generateKeyPair('ES256');
 
+        // CSRF nonce: bound into the state AND set as the oauth_csrf cookie below,
+        // so the backend callback can confirm the flow started in THIS browser.
+        const csrfNonce = generateOAuthNonce();
+
         // state 생성 (publicKey 포함)
         const state = await createOAuthState({
             provider,
@@ -40,6 +44,7 @@ export const oauthUrlInterceptor: InterceptorRule = {
             keyId: keyPair.keyId,
             fingerprint: keyPair.fingerprint,
             algorithm: keyPair.algorithm,
+            nonce: csrfNonce,
         });
 
         // body에 state 주입
@@ -55,6 +60,7 @@ export const oauthUrlInterceptor: InterceptorRule = {
             keyId: keyPair.keyId,
             algorithm: keyPair.algorithm,
         };
+        ctx.metadata.oauthCsrf = csrfNonce;
 
         authLogger.interceptor.oauth?.debug?.('OAuth state created', {
             provider,
@@ -84,6 +90,22 @@ export const oauthUrlInterceptor: InterceptorRule = {
                         path: '/',
                     },
                 });
+
+                // CSRF nonce cookie (double-submit against the state.nonce at callback)
+                if (ctx.metadata.oauthCsrf)
+                {
+                    ctx.setCookies.push({
+                        name: COOKIE_NAMES.OAUTH_CSRF,
+                        value: ctx.metadata.oauthCsrf,
+                        options: {
+                            httpOnly: true,
+                            secure: cookieSecure,
+                            sameSite: 'lax',
+                            maxAge: 600,
+                            path: '/',
+                        },
+                    });
+                }
 
                 authLogger.interceptor.oauth?.debug?.('Pending session cookie set', {
                     keyId: ctx.metadata.pendingSession.keyId,

--- a/packages/auth/src/server/lib/config.ts
+++ b/packages/auth/src/server/lib/config.ts
@@ -35,9 +35,14 @@ export const COOKIE_NAMES = {
         return `spfn_session_key_id${getCookieSuffix()}`; 
     },
     /** Pending OAuth session (privateKey, keyId, algorithm) - temporary during OAuth flow */
-    get OAUTH_PENDING() 
+    get OAUTH_PENDING()
     {
-        return `spfn_oauth_pending${getCookieSuffix()}`; 
+        return `spfn_oauth_pending${getCookieSuffix()}`;
+    },
+    /** OAuth CSRF nonce — double-submit against the (encrypted) state.nonce at callback */
+    get OAUTH_CSRF()
+    {
+        return `spfn_oauth_csrf${getCookieSuffix()}`;
     },
 };
 

--- a/packages/auth/src/server/lib/oauth/state.ts
+++ b/packages/auth/src/server/lib/oauth/state.ts
@@ -49,6 +49,16 @@ function generateNonce(): string
     return Array.from(array, b => b.toString(16).padStart(2, '0')).join('');
 }
 
+/**
+ * Generate a CSRF nonce for the OAuth flow. The caller passes it to
+ * createOAuthState AND sets it as the oauth_csrf cookie, so the callback can
+ * double-submit-verify the flow was initiated by this same browser.
+ */
+export function generateOAuthNonce(): string
+{
+    return generateNonce();
+}
+
 export interface CreateOAuthStateParams
 {
     provider: string;
@@ -58,6 +68,11 @@ export interface CreateOAuthStateParams
     fingerprint: string;
     algorithm: KeyAlgorithmType;
     metadata?: Record<string, unknown>;
+    /**
+     * CSRF nonce bound into the state. Pass the same value as the oauth_csrf
+     * cookie. Defaults to a fresh nonce (unbound — legacy/no-CSRF callers).
+     */
+    nonce?: string;
 }
 
 /**
@@ -72,7 +87,7 @@ export async function createOAuthState(params: CreateOAuthStateParams): Promise<
 
     const state: OAuthState = {
         returnUrl: params.returnUrl,
-        nonce: generateNonce(),
+        nonce: params.nonce ?? generateNonce(),
         provider: params.provider,
         publicKey: params.publicKey,
         keyId: params.keyId,

--- a/packages/auth/src/server/routes/oauth/index.ts
+++ b/packages/auth/src/server/routes/oauth/index.ts
@@ -8,12 +8,14 @@
  */
 
 import { Type } from '@sinclair/typebox';
+import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import { Transactional } from '@spfn/core/db';
 import { ValidationError } from '@spfn/core/errors';
 import { rateLimit } from '@spfn/core/middleware';
 import { defineRouter, route } from '@spfn/core/route';
 
 import { KEY_ALGORITHM, SOCIAL_PROVIDERS } from '../../types';
+import { COOKIE_NAMES } from '../../lib/config';
 import {
     oauthStartService,
     oauthCallbackService,
@@ -23,6 +25,7 @@ import {
     requireEnabledProvider,
 } from '../../services';
 import { isGoogleOAuthEnabled, getGoogleAuthUrl, getOAuthProvider } from '../../lib/oauth';
+import { generateOAuthNonce } from '../../lib/oauth/state';
 
 /**
  * path param의 provider 타입 (등록 가능한 모든 소셜 provider)
@@ -106,12 +109,16 @@ export const oauthGoogleCallback = route.get('/_auth/oauth/google/callback')
             return c.redirect(buildOAuthErrorUrl('Missing authorization code or state'));
         }
 
+        const expectedNonce = getCookie(c.raw, COOKIE_NAMES.OAUTH_CSRF);
+        deleteCookie(c.raw, COOKIE_NAMES.OAUTH_CSRF, { path: '/' });
+
         try
         {
             const result = await oauthCallbackService({
                 provider: 'google',
                 code: query.code,
                 state: query.state,
+                expectedNonce,
             });
 
             return c.redirect(result.redirectUrl);
@@ -162,7 +169,17 @@ export const oauthStart = route.post('/_auth/oauth/start')
     {
         const { body } = await c.data();
 
-        const result = await oauthStartService(body);
+        // CSRF: bind the flow to this browser via a cookie matched at the callback.
+        const nonce = generateOAuthNonce();
+        setCookie(c.raw, COOKIE_NAMES.OAUTH_CSRF, nonce, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'Lax',
+            maxAge: 600,
+            path: '/',
+        });
+
+        const result = await oauthStartService({ ...body, nonce });
 
         return result;
     });
@@ -343,12 +360,16 @@ export const oauthProviderCallback = route.get('/_auth/oauth/:provider/callback'
             return c.redirect(buildOAuthErrorUrl('Missing authorization code or state'));
         }
 
+        const expectedNonce = getCookie(c.raw, COOKIE_NAMES.OAUTH_CSRF);
+        deleteCookie(c.raw, COOKIE_NAMES.OAUTH_CSRF, { path: '/' });
+
         try
         {
             const result = await oauthCallbackService({
                 provider: params.provider,
                 code: query.code,
                 state: query.state,
+                expectedNonce,
             });
 
             return c.redirect(result.redirectUrl);

--- a/packages/auth/src/server/services/oauth.service.ts
+++ b/packages/auth/src/server/services/oauth.service.ts
@@ -35,6 +35,8 @@ export interface OAuthStartParams
     fingerprint: string;
     algorithm: KeyAlgorithmType;
     metadata?: Record<string, unknown>;
+    /** CSRF nonce bound into the state; the route sets the matching oauth_csrf cookie. */
+    nonce?: string;
 }
 
 export interface OAuthStartResult
@@ -47,6 +49,13 @@ export interface OAuthCallbackParams
     provider: SocialProvider;
     code: string;
     state: string;
+    /**
+     * Value of the oauth_csrf cookie from the callback request. Must equal the
+     * nonce bound into the (encrypted) state — otherwise the flow wasn't initiated
+     * by this browser (login CSRF). Pass `undefined` when the cookie is absent;
+     * verification then fails closed.
+     */
+    expectedNonce: string | undefined;
 }
 
 export interface OAuthCallbackResult
@@ -108,7 +117,7 @@ export async function oauthStartService(
     params: OAuthStartParams,
 ): Promise<OAuthStartResult>
 {
-    const { provider, returnUrl, publicKey, keyId, fingerprint, algorithm, metadata } = params;
+    const { provider, returnUrl, publicKey, keyId, fingerprint, algorithm, metadata, nonce } = params;
 
     const oauthProvider = requireEnabledProvider(provider);
 
@@ -120,6 +129,7 @@ export async function oauthStartService(
         fingerprint,
         algorithm,
         metadata,
+        nonce,
     });
 
     return { authUrl: oauthProvider.getAuthUrl(state) };
@@ -135,10 +145,20 @@ export async function oauthCallbackService(
     params: OAuthCallbackParams,
 ): Promise<OAuthCallbackResult>
 {
-    const { provider, code, state } = params;
+    const { provider, code, state, expectedNonce } = params;
 
-    // State 검증 및 복호화
+    // State 검증 및 복호화 (jose enforces the 10m expiry on decrypt)
     const stateData = await verifyOAuthState(state);
+
+    // CSRF: the state's nonce must match the oauth_csrf cookie from THIS browser.
+    // A login-CSRF victim (handed the attacker's state) has no matching cookie, so
+    // this fails closed before any account is created or any key is registered.
+    if (!expectedNonce || stateData.nonce !== expectedNonce)
+    {
+        throw new ValidationError({
+            message: 'OAuth state validation failed',
+        });
+    }
 
     if (stateData.provider !== provider)
     {


### PR DESCRIPTION
**High — login CSRF / account takeover.** From the core/auth re-audit.

## The bug
The OAuth `state` carried a `nonce`, but `verifyOAuthState` only decrypts (jose enforces the JWE expiry) — it never checked the nonce against anything **browser-bound**. The state is unforgeable (encrypted), but a valid state the attacker obtained from their **own** flow could be forced onto a victim (login CSRF): the callback would exchange the **victim's** code against the **attacker's** state and register the **attacker's** public key for the victim → account takeover.

## The fix — double-submit (app and backend are same-site)
- `createOAuthState` accepts the nonce; `generateOAuthNonce()` exposes it.
- The web entry points — `oauthUrlInterceptor` and `POST /_auth/oauth/start` — set an httpOnly **`oauth_csrf`** cookie equal to the nonce that's also bound into the encrypted state.
- The callbacks (Google + generic) read the cookie and pass it as `expectedNonce`; `oauthCallbackService` rejects unless `state.nonce === cookie` — **failing closed on a missing cookie** (a CSRF victim has none) **before** any user/key is created. The cookie is cleared afterward.
- **Mobile/native unaffected** — it uses the `id_token` nonce path, not this cookie.

## ⚠️ Verify in staging
The nonce binding is unit-tested (round-trips create→verify), but the **full browser↔provider OAuth round-trip can't be exercised here** — please verify a real Google login in staging before releasing. Both halves (interceptor + callback) ship in `@spfn/auth`, so they deploy together (no version skew); in-flight flows during deploy may need one retry.

## Verification
auth type-check + build + madge circular clean; unit suite green (184, incl. the nonce-binding round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)