### PR TITLE
fix(notification): escape template html output + timing-safe token compare (S-M1/S-L4)

### DIFF
--- a/packages/notification/src/templates/__tests__/renderer-escape.test.ts
+++ b/packages/notification/src/templates/__tests__/renderer-escape.test.ts
@@ -1,0 +1,51 @@
+/**
+ * render() — HTML escaping on the email html path (S-M1)
+ *
+ * Interpolated caller data must be HTML-escaped by default when escape:true, so a
+ * display name like `<img src=x onerror=...>` can't inject markup. The `| raw`
+ * filter opts a template-author block out. Prototype-pollution path segments are
+ * blocked.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '../renderer';
+
+describe('render — html escaping', () =>
+{
+    it('escapes interpolated values when escape:true', () =>
+    {
+        const out = render('<p>Hi {{name}}</p>', { name: '<img src=x onerror=alert(1)>' }, { escape: true });
+
+        expect(out).toBe('<p>Hi &lt;img src=x onerror=alert(1)&gt;</p>');
+        expect(out).not.toContain('<img');
+    });
+
+    it('escapes & " \' as well', () =>
+    {
+        const out = render('{{v}}', { v: `a&b"c'd` }, { escape: true });
+
+        expect(out).toBe('a&amp;b&quot;c&#39;d');
+    });
+
+    it('does NOT escape when escape is off (subject/text path)', () =>
+    {
+        const out = render('{{v}}', { v: '<b>x</b>' });
+
+        expect(out).toBe('<b>x</b>');
+    });
+
+    it('| raw opts out of escaping (author-controlled blocks)', () =>
+    {
+        const out = render('{{content | raw}}', { content: '<b>rich</b>' }, { escape: true });
+
+        expect(out).toBe('<b>rich</b>');
+    });
+
+    it('blocks prototype-pollution path segments', () =>
+    {
+        const out = render('{{__proto__.polluted}}', {}, { escape: true });
+
+        // unresolved → original token kept
+        expect(out).toBe('{{__proto__.polluted}}');
+    });
+});

--- a/packages/notification/src/templates/registry.ts
+++ b/packages/notification/src/templates/registry.ts
@@ -108,7 +108,8 @@ function renderEmailTemplate(
 {
     return {
         subject: render(template.subject, data),
-        html: template.html ? render(template.html, data) : undefined,
+        // Escape interpolated values on the HTML path (caller data → markup injection).
+        html: template.html ? render(template.html, data, { escape: true }) : undefined,
         text: template.text ? render(template.text, data) : undefined,
     };
 }

--- a/packages/notification/src/templates/renderer.ts
+++ b/packages/notification/src/templates/renderer.ts
@@ -117,6 +117,25 @@ function parseExpression(expr: string): { variable: string; filter?: string; arg
     };
 }
 
+const BLOCKED_PATH_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
+
+const HTML_ESCAPES: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    '\'': '&#39;',
+};
+
+/**
+ * HTML-escape interpolated values so caller data (e.g. a display name like
+ * `<img src=x onerror=...>`) can't inject markup into app-branded email.
+ */
+function escapeHtml(value: string): string
+{
+    return value.replace(/[&<>"']/g, ch => HTML_ESCAPES[ch]);
+}
+
 /**
  * Get nested value from object
  * e.g., getValue({ user: { name: "John" } }, "user.name") -> "John"
@@ -128,6 +147,12 @@ function getValue(data: TemplateData, path: string): unknown
 
     for (const part of parts)
     {
+        // Block prototype-pollution path segments (read-only walk, but defense in depth).
+        if (BLOCKED_PATH_SEGMENTS.has(part))
+        {
+            return undefined;
+        }
+
         if (value === null || value === undefined)
         {
             return undefined;
@@ -138,16 +163,27 @@ function getValue(data: TemplateData, path: string): unknown
     return value;
 }
 
+export interface RenderOptions
+{
+    /**
+     * HTML-escape interpolated values (the email `html` path). Use the `| raw`
+     * filter to opt a template-author-controlled block out — never caller data.
+     */
+    escape?: boolean;
+}
+
 /**
  * Render template string with data
  */
-export function render(template: string, data: TemplateData): string
+export function render(template: string, data: TemplateData, options: RenderOptions = {}): string
 {
+    const escape = options.escape ?? false;
+
     // Match {{...}} patterns
     return template.replace(/\{\{([^}]+)\}\}/g, (match, expr) =>
     {
         const { variable, filter, arg } = parseExpression(expr.trim());
-        let value = getValue(data, variable);
+        const value = getValue(data, variable);
 
         if (value === undefined)
         {
@@ -155,12 +191,15 @@ export function render(template: string, data: TemplateData): string
             return match;
         }
 
-        if (filter && filters[filter])
+        // `raw` opts out of escaping (template-author blocks only).
+        if (filter === 'raw')
         {
-            return filters[filter](value, arg);
+            return String(value);
         }
 
-        return String(value);
+        const rendered = (filter && filters[filter]) ? filters[filter](value, arg) : String(value);
+
+        return escape ? escapeHtml(rendered) : rendered;
     });
 }
 

--- a/packages/notification/src/tracking/token.ts
+++ b/packages/notification/src/tracking/token.ts
@@ -7,7 +7,7 @@
  * Token format: base64url(payload).base64url(hmac)
  */
 
-import { createHmac, createHash } from 'node:crypto';
+import { createHmac, createHash, timingSafeEqual } from 'node:crypto';
 import { getTrackingSecret } from '../config';
 
 /**
@@ -78,7 +78,11 @@ function verify(token: string): { valid: boolean; payload?: string }
     const expectedHmac = createHmac('sha256', secret).update(payload).digest();
     const expectedHmacEncoded = toBase64Url(expectedHmac);
 
-    if (hmacEncoded !== expectedHmacEncoded)
+    // Constant-time compare to avoid a timing side-channel on token verification.
+    const provided = Buffer.from(hmacEncoded);
+    const expected = Buffer.from(expectedHmacEncoded);
+
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected))
     {
         return { valid: false };
     }


### PR DESCRIPTION
From the ancillary audit.

## S-M1 — template interpolation performed no HTML escaping (medium)
`render()` returned raw `String(value)` with no escaping, and built-in templates splice caller data (`params.data`) into email markup — a display name like `<img src=x onerror=...>` was emitted verbatim (HTML/markup/phishing injection; conditional XSS in a non-sanitizing in-app preview).

- HTML-escape (`& < > " '`) interpolated values **by default on the email `html` path**.
- `| raw` filter opts a **template-author-controlled** block out — never caller data.
- Subject / text / SMS / Slack paths stay unescaped (plain-text contexts).
- Block `__proto__` / `prototype` / `constructor` path segments in `getValue`.

## S-L4 — non-constant-time token compare (low)
`verify()` compared HMACs with `!==` (timing side-channel). Now length-checked `crypto.timingSafeEqual`.

## Verification
notification type-check + build + madge clean; templates + tracking suites green (30, incl. new escaping/raw/proto tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)