### PR TITLE
fix(auth): misc security hardening (JWT default secret, invitation pw cap, session-token log)

### DIFF
--- a/packages/auth/src/nextjs/session-helpers.ts
+++ b/packages/auth/src/nextjs/session-helpers.ts
@@ -131,7 +131,8 @@ export async function getSession(): Promise<PublicSession | null>
 
     try
     {
-        logger.debug('Validating session cookie', { cookie: sessionCookie.value });
+        // Never log the cookie value — it's the sealed session token.
+        logger.debug('Validating session cookie', { present: true });
         const session = await unsealSession(sessionCookie.value);
 
         // Return only public information

--- a/packages/auth/src/server/helpers/jwt.ts
+++ b/packages/auth/src/server/helpers/jwt.ts
@@ -68,6 +68,30 @@ export interface TokenPayload extends SessionPayload
 }
 
 /**
+ * The placeholder default shipped for local DX. It is public knowledge, so it must
+ * never sign or verify real tokens — anyone could forge legacy JWTs with it.
+ */
+const INSECURE_JWT_SECRET = 'dev-secret-key-change-in-production';
+
+/**
+ * Resolve the legacy JWT secret, failing closed in production if it was left at
+ * the public default (or unset). Dev keeps the default for convenience.
+ */
+function getJwtSecret(): string
+{
+    const secret = env.SPFN_AUTH_JWT_SECRET;
+
+    if ((!secret || secret === INSECURE_JWT_SECRET) && process.env.NODE_ENV === 'production')
+    {
+        throw new Error(
+            'SPFN_AUTH_JWT_SECRET must be set to a strong secret in production (the default is public).',
+        );
+    }
+
+    return secret;
+}
+
+/**
  * Generate a JWT token (legacy server-signed)
  *
  * @deprecated Use client-side signing with private keys instead
@@ -78,7 +102,7 @@ export interface TokenPayload extends SessionPayload
  */
 export function generateToken(payload: SessionPayload): string
 {
-    return jwt.sign(payload, env.SPFN_AUTH_JWT_SECRET, {
+    return jwt.sign(payload, getJwtSecret(), {
         expiresIn: env.SPFN_AUTH_JWT_EXPIRES_IN,
     } as SignOptions);
 }
@@ -98,7 +122,7 @@ export function verifyToken(token: string): TokenPayload
     // Pin the algorithm to the symmetric HMAC this secret signs with — without an
     // allow-list, jsonwebtoken accepts whatever alg the token header claims
     // (algorithm-confusion risk).
-    return jwt.verify(token, env.SPFN_AUTH_JWT_SECRET, { algorithms: ['HS256'] }) as TokenPayload;
+    return jwt.verify(token, getJwtSecret(), { algorithms: ['HS256'] }) as TokenPayload;
 }
 
 /**

--- a/packages/auth/src/server/routes/invitations/index.ts
+++ b/packages/auth/src/server/routes/invitations/index.ts
@@ -89,7 +89,8 @@ export const acceptInvitation = route.post('/_auth/invitations/accept')
             }),
             password: Type.String({
                 minLength: 8,
-                description: 'User password (minimum 8 characters)',
+                maxLength: 72,
+                description: 'User password (8–72 characters). bcrypt silently ignores bytes past 72, so longer inputs are rejected rather than truncated.',
             }),
         }),
     })


### PR DESCRIPTION
Three small findings from the core/auth re-audit.

### Legacy JWT secret defaults to a public placeholder (medium)
`SPFN_AUTH_JWT_SECRET` defaults to `'dev-secret-key-change-in-production'` (`required:false`). The general-auth interceptor signs **real** legacy JWTs with it, so an unset secret in production lets anyone forge tokens. `getJwtSecret()` now **fails closed in production** when the secret is unset or left at the default; dev keeps the default for DX.

### Invitation accept password missing the bcrypt cap (medium)
The accept-invitation password had `minLength:8` but no `maxLength:72`, unlike the main `PasswordSchema` — bcrypt silently ignores bytes past 72. Added the cap for parity.

### Session token logged at debug (medium)
`session-helpers` logged the raw session cookie **value** (the sealed session token). Now logs presence only.

## Verification
auth type-check + build + madge clean; unit suite green (183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)