### PR TITLE
fix(auth): revoke all sessions on password change (incident response)

### DIFF
--- a/packages/auth/src/__tests__/unit/change-password-revoke.test.ts
+++ b/packages/auth/src/__tests__/unit/change-password-revoke.test.ts
@@ -1,0 +1,44 @@
+/**
+ * changePasswordService — revoke all sessions on password change (#4)
+ *
+ * A password change must revoke every active key for the user, so existing
+ * sessions are logged out (backend authenticate verifies active keys only).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { usersRepository, keysRepository, verifyPassword, hashPassword } = vi.hoisted(() => ({
+    usersRepository: {
+        findById: vi.fn(),
+        updatePassword: vi.fn(async () => undefined),
+    },
+    keysRepository: {
+        revokeAllActiveByUserId: vi.fn(async () => []),
+    },
+    verifyPassword: vi.fn(async () => true),
+    hashPassword: vi.fn(async () => 'new-hash'),
+}));
+
+vi.mock('../../server/repositories', () => ({ usersRepository, keysRepository }));
+vi.mock('../../server/helpers', () => ({ hashPassword, verifyPassword }));
+
+import { changePasswordService } from '../../server/services/auth.service';
+
+describe('changePasswordService — session revocation', () =>
+{
+    beforeEach(() => vi.clearAllMocks());
+
+    it('revokes all active keys after a successful password change', async () =>
+    {
+        await changePasswordService({
+            userId: 7,
+            currentPassword: 'old-password',
+            newPassword: 'new-password',
+            passwordHash: 'old-hash',
+        });
+
+        expect(usersRepository.updatePassword).toHaveBeenCalledWith(7, 'new-hash', true);
+        expect(keysRepository.revokeAllActiveByUserId).toHaveBeenCalledTimes(1);
+        expect(keysRepository.revokeAllActiveByUserId).toHaveBeenCalledWith(7, expect.any(String));
+    });
+});

--- a/packages/auth/src/server/repositories/keys.repository.ts
+++ b/packages/auth/src/server/repositories/keys.repository.ts
@@ -116,6 +116,31 @@ export class KeysRepository extends BaseRepository
     }
 
     /**
+     * 사용자의 모든 활성 공개키 revoke (비활성화)
+     *
+     * 비번 변경 시 전체 세션 로그아웃에 사용. authenticate는 활성 키만 검증하므로,
+     * revoke된 키로 서명한 기존 세션의 요청은 즉시 401이 된다.
+     * Write primary 사용
+     */
+    async revokeAllActiveByUserId(userId: number, reason: string)
+    {
+        return await this.db
+            .update(userPublicKeys)
+            .set({
+                isActive: false,
+                revokedAt: new Date(),
+                revokedReason: reason,
+            })
+            .where(
+                and(
+                    eq(userPublicKeys.userId, userId),
+                    eq(userPublicKeys.isActive, true),
+                ),
+            )
+            .returning();
+    }
+
+    /**
      * 공개키 삭제
      * Write primary 사용
      */

--- a/packages/auth/src/server/services/auth.service.ts
+++ b/packages/auth/src/server/services/auth.service.ts
@@ -14,7 +14,7 @@ import {
     VerificationTokenTargetMismatchError,
 } from '@spfn/auth/errors';
 
-import { usersRepository } from '../repositories';
+import { usersRepository, keysRepository } from '../repositories';
 import { type KeyAlgorithmType } from '../types';
 import { hashPassword, verifyPassword } from '../helpers';
 import { validateVerificationToken } from './verification.service';
@@ -330,4 +330,10 @@ export async function changePasswordService(
 
     // Update password and clear passwordChangeRequired flag
     await usersRepository.updatePassword(userId, newPasswordHash, true);
+
+    // Revoke all existing sessions on password change (incident-response intent:
+    // "change password" should log the user out everywhere). authenticate verifies
+    // against active keys only, so revoked keys' requests immediately fail — no
+    // per-request cost beyond what auth already pays. The user re-authenticates.
+    await keysRepository.revokeAllActiveByUserId(userId, 'Revoked by password change');
 }


### PR DESCRIPTION
From the core/auth re-audit (session revocation).

## The gap
A password change left existing sessions valid until their TTL. So a user changing their password **to lock out a suspected attacker** didn't actually evict that attacker — the stolen session stayed live up to the session TTL (7d default). Password change is the canonical "log me out everywhere" lever; it wasn't.

## The fix
`changePasswordService` now revokes **all** of the user's active keys after the password update. Backend `authenticate` verifies the client token against the user's **active** public key (a DB lookup it already performs per request), so revoking the keys makes every existing session's requests fail immediately — **no added hot-path cost**. The user re-authenticates after changing their password.

Adds `keysRepository.revokeAllActiveByUserId(userId, reason)` (bulk flip of `isActive`, mirroring the existing single-key revoke).

> Future: when the optional Redis cache is present, the per-request active-key lookup in `authenticate` can be cached there.

## Verification
auth type-check + build + madge clean; unit suite green (184, incl. a new test asserting revoke-on-change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)