### PR TITLE
perf(monitor): don't materialize every aged row on retention purge (P-H3)

### DIFF
--- a/packages/monitor/src/__tests__/unit/error-handler-redaction.test.ts
+++ b/packages/monitor/src/__tests__/unit/error-handler-redaction.test.ts
@@ -7,7 +7,9 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { trackError } = vi.hoisted(() => ({ trackError: vi.fn(async () => undefined) }));
+const { trackError } = vi.hoisted(() => ({
+    trackError: vi.fn(async (_err: Error, _ctx: unknown, _meta?: unknown) => undefined),
+}));
 
 vi.mock('../../server/services', () => ({ trackError }));
 vi.mock('@spfn/monitor/config', () => ({ getMinStatusCode: () => 500 }));

--- a/packages/monitor/src/server/repositories/error-events.repository.ts
+++ b/packages/monitor/src/server/repositories/error-events.repository.ts
@@ -37,12 +37,15 @@ export class ErrorEventsRepository extends BaseRepository
 
     async deleteOlderThan(date: Date): Promise<number>
     {
+        // No .returning() — see logs.repository: avoid materializing every aged
+        // row (jsonb headers/query/metadata + full stackTrace) just to count them.
         const result = await this.db
             .delete(errorEvents)
-            .where(lt(errorEvents.createdAt, date))
-            .returning();
+            .where(lt(errorEvents.createdAt, date));
 
-        return result.length;
+        return (result as { rowCount?: number; count?: number }).rowCount
+            ?? (result as { count?: number }).count
+            ?? 0;
     }
 }
 

--- a/packages/monitor/src/server/repositories/logs.repository.ts
+++ b/packages/monitor/src/server/repositories/logs.repository.ts
@@ -130,12 +130,17 @@ export class LogsRepository extends BaseRepository
 
     async deleteOlderThan(date: Date): Promise<number>
     {
+        // No .returning() — a retention sweep can match millions of rows, and
+        // RETURNING * would materialize every one (jsonb columns + payloads) into
+        // memory just to count them. Read the affected-row count from the driver
+        // result instead (postgres-js: .count, node-postgres: .rowCount).
         const result = await this.db
             .delete(logs)
-            .where(lt(logs.createdAt, date))
-            .returning();
+            .where(lt(logs.createdAt, date));
 
-        return result.length;
+        return (result as { rowCount?: number; count?: number }).rowCount
+            ?? (result as { count?: number }).count
+            ?? 0;
     }
 }
 


### PR DESCRIPTION
From the ancillary audit (P-H3, high).

## The problem
`logs.repository.deleteOlderThan` and `error-events.repository.deleteOlderThan` did `.delete(...).where(...).returning()` then `result.length` — forcing `DELETE ... RETURNING *`, which materializes **every** aged row (jsonb `headers`/`query`/`metadata` + full `stackTrace`) into the heap just to count them. A retention sweep over millions of rows is a multi-hundred-MB-to-GB memory spike / OOM risk.

## The fix
Drop `.returning()`; read the affected-row count from the driver result (postgres-js `.count` / node-postgres `.rowCount`, read defensively). No rows materialized.

Also typed the `trackError` mock in `error-handler-redaction.test` so monitor `type-check` passes cleanly (`mock.calls[0][1]` needed an argument signature).

## Verification
monitor type-check + build + madge clean; unit suite green (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)