### PR TITLE
perf(cms): batch publishSection writes in a transaction (P-H2)

### DIFF
--- a/packages/cms/src/server/repositories/cms-label-values.repository.ts
+++ b/packages/cms/src/server/repositories/cms-label-values.repository.ts
@@ -6,7 +6,7 @@
  */
 
 import { BaseRepository } from '@spfn/core/db';
-import { eq, and, SQL, isNull, gte, lte, inArray } from 'drizzle-orm';
+import { eq, and, SQL, isNull, gte, lte, inArray, sql } from 'drizzle-orm';
 import { cmsLabelValues, type CmsLabelValue, type NewCmsLabelValue } from '../entities';
 
 /**
@@ -164,6 +164,75 @@ export class CmsLabelValuesRepository extends BaseRepository
         }
 
         return results;
+    }
+
+    /**
+     * 여러 라벨의 Draft 값들을 한 번에 조회 (version = null) — publish N+1 제거
+     * Read replica 사용
+     */
+    async findDraftsByLabelIds(labelIds: number[]): Promise<CmsLabelValue[]>
+    {
+        if (labelIds.length === 0)
+        {
+            return [];
+        }
+
+        return this.readDb
+            .select()
+            .from(cmsLabelValues)
+            .where(
+                and(
+                    inArray(cmsLabelValues.labelId, labelIds),
+                    isNull(cmsLabelValues.version),
+                ),
+            );
+    }
+
+    /**
+     * 새 published 버전 값들을 한 번에 multi-row INSERT (publish 배치용).
+     * unique(labelId, version, locale, breakpoint) 충돌 시 value 갱신(멱등).
+     * Write primary 사용
+     */
+    async insertPublishedValues(rows: (NewCmsLabelValue & { labelId: number })[]): Promise<void>
+    {
+        if (rows.length === 0)
+        {
+            return;
+        }
+
+        await this.db
+            .insert(cmsLabelValues)
+            .values(rows)
+            .onConflictDoUpdate({
+                target: [
+                    cmsLabelValues.labelId,
+                    cmsLabelValues.version,
+                    cmsLabelValues.locale,
+                    cmsLabelValues.breakpoint,
+                ],
+                set: { value: sql`excluded.value` },
+            });
+    }
+
+    /**
+     * 여러 라벨의 Draft 값들을 한 번에 삭제 (version = null) — publish 배치용
+     * Write primary 사용
+     */
+    async deleteDraftsByLabelIds(labelIds: number[]): Promise<void>
+    {
+        if (labelIds.length === 0)
+        {
+            return;
+        }
+
+        await this.db
+            .delete(cmsLabelValues)
+            .where(
+                and(
+                    inArray(cmsLabelValues.labelId, labelIds),
+                    isNull(cmsLabelValues.version),
+                ),
+            );
     }
 
     /**

--- a/packages/cms/src/server/services/publish.service.ts
+++ b/packages/cms/src/server/services/publish.service.ts
@@ -5,12 +5,13 @@
  */
 
 import { logger } from '@spfn/core/logger';
+import { runInTransaction } from '@spfn/core/db';
 import {
     cmsLabelsRepository,
     cmsLabelValuesRepository,
     cmsPublishedCacheRepository,
 } from '../repositories';
-import { type CmsLabelValue } from '../entities';
+import { type CmsLabelValue, type NewCmsLabelValue } from '../entities';
 
 const publishLogger = logger.child('@spfn/cms:publish');
 
@@ -163,27 +164,44 @@ export async function publishSection(
         return { published: 0, version: 0, labels: [] };
     }
 
+    // 2. 모든 라벨의 Draft 값을 한 번에 조회 (라벨당 SELECT → 1 SELECT, N+1 제거)
+    const labelIds = labels.map(l => l.id);
+    const allDrafts = await cmsLabelValuesRepository.findDraftsByLabelIds(labelIds);
+
+    const draftsByLabel = new Map<number, CmsLabelValue[]>();
+    for (const draft of allDrafts)
+    {
+        const list = draftsByLabel.get(draft.labelId);
+        if (list)
+        {
+            list.push(draft);
+        }
+        else
+        {
+            draftsByLabel.set(draft.labelId, [draft]);
+        }
+    }
+
+    // 3. 새 버전 행/업데이트를 모은다 (DB는 아래 트랜잭션에서 배치로)
+    const newRows: (NewCmsLabelValue & { labelId: number })[] = [];
+    const versionUpdates: Array<{ id: number; version: number }> = [];
     const publishedLabels: string[] = [];
     let maxVersion = 0;
 
     for (const label of labels)
     {
-        // 2. Draft 값 조회
-        const drafts = await cmsLabelValuesRepository.findDraftsByLabelId(label.id);
-
-        if (drafts.length === 0)
+        const drafts = draftsByLabel.get(label.id);
+        if (!drafts || drafts.length === 0)
         {
             continue;
         }
 
-        // 3. 새 버전 번호 생성
         const newVersion = (label.publishedVersion || 0) + 1;
         maxVersion = Math.max(maxVersion, newVersion);
 
-        // 4. Draft 값을 새 버전으로 복사
         for (const draft of drafts)
         {
-            await cmsLabelValuesRepository.upsert({
+            newRows.push({
                 labelId: label.id,
                 version: newVersion,
                 locale: draft.locale,
@@ -192,20 +210,30 @@ export async function publishSection(
             });
         }
 
-        // 4.5. Draft 삭제 (version: null)
-        await cmsLabelValuesRepository.deleteByVersion(label.id, null);
-
-        // 5. cms_labels.publishedVersion 업데이트
-        await cmsLabelsRepository.updateById(label.id, {
-            publishedVersion: newVersion,
-        });
-
+        versionUpdates.push({ id: label.id, version: newVersion });
         publishedLabels.push(label.key);
     }
 
-    // 6. cms_published_cache 갱신
+    // 4. 발행은 원자적으로 — 새 버전 multi-row INSERT → draft 일괄 삭제 →
+    //    publishedVersion 업데이트. (라벨당 1+2D+1+1 직렬 왕복 → 소수의 배치 쿼리)
     if (publishedLabels.length > 0)
     {
+        const publishedLabelIds = versionUpdates.map(v => v.id);
+
+        await runInTransaction(async () =>
+        {
+            await cmsLabelValuesRepository.insertPublishedValues(newRows);
+            await cmsLabelValuesRepository.deleteDraftsByLabelIds(publishedLabelIds);
+
+            for (const update of versionUpdates)
+            {
+                await cmsLabelsRepository.updateById(update.id, {
+                    publishedVersion: update.version,
+                });
+            }
+        });
+
+        // 5. cms_published_cache 갱신
         await rebuildSectionCache(section, locales);
     }
 


### PR DESCRIPTION
From the ancillary audit (P-H2, high).

## The problem
`publishSection` looped per label — `findDraftsByLabelId` (1 SELECT) → per-draft `upsert` (SELECT+INSERT = 2) → `deleteByVersion` → `updateById`, and **not** in a transaction. ~`L*(1+2D+1+1)` serialized round-trips (≈**454** for a 50-label / 3-locale section) on every publish click, with partial-write risk.

## The fix
- One `findDraftsByLabelIds(labelIds)` instead of N draft SELECTs.
- Collect all new-version rows and insert them with a single multi-row `insertPublishedValues` (`onConflictDoUpdate` on the unique `labelId+version+locale+breakpoint`).
- One `deleteDraftsByLabelIds` across all published labels.
- Wrap insert/delete/`publishedVersion` updates in `runInTransaction` → a publish is now **atomic** (it wasn't before).

≈454 round-trips → a handful + M small version updates, for a 50-label section.

## Verification
cms type-check + build + madge circular clean.
Note: `cms-label-values.test.ts` fails to collect (`Cannot find '@/__tests__/helpers/db'`) — a **pre-existing** broken integration test (missing helper; fails identically on `main`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)