### PR TITLE
perf(notification): buffer + batch tracking-event inserts (P-H1)

### DIFF
--- a/packages/notification/src/tracking/__tests__/tracking-buffer.test.ts
+++ b/packages/notification/src/tracking/__tests__/tracking-buffer.test.ts
@@ -1,0 +1,47 @@
+/**
+ * tracking.service — buffered batch insert (P-H1)
+ *
+ * Open/click hits are buffered and flushed as a single multi-row INSERT once the
+ * buffer reaches FLUSH_SIZE, instead of one INSERT per hit.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { valuesSpy, insertSpy } = vi.hoisted(() =>
+{
+    const valuesSpy = vi.fn(async () => undefined);
+    const insertSpy = vi.fn(() => ({ values: valuesSpy }));
+
+    return { valuesSpy, insertSpy };
+});
+
+vi.mock('@spfn/core/db', async (importOriginal) =>
+{
+    const actual = await importOriginal<typeof import('@spfn/core/db')>();
+
+    return { ...actual, getDatabase: () => ({ insert: insertSpy }) };
+});
+
+import { recordOpenEvent } from '../tracking.service';
+
+describe('tracking buffer', () =>
+{
+    beforeEach(() => vi.clearAllMocks());
+
+    it('flushes one multi-row INSERT once FLUSH_SIZE (200) hits accumulate', async () =>
+    {
+        for (let i = 0; i < 200; i++)
+        {
+            recordOpenEvent(i);
+        }
+
+        // size-triggered flush runs on a microtask
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(insertSpy).toHaveBeenCalledTimes(1);
+        expect(valuesSpy).toHaveBeenCalledTimes(1);
+        // a single batch carrying all 200 events
+        expect(valuesSpy.mock.calls[0][0]).toHaveLength(200);
+    });
+});

--- a/packages/notification/src/tracking/tracking.service.ts
+++ b/packages/notification/src/tracking/tracking.service.ts
@@ -4,7 +4,7 @@
  * Records engagement events and provides analytics queries.
  */
 
-import { create, getDatabase } from '@spfn/core/db';
+import { getDatabase } from '@spfn/core/db';
 import { eq, and, gte, lte, count as drizzleCount, countDistinct } from 'drizzle-orm';
 import { trackingEvents, type TrackingEventType } from '../entities';
 import { notifications, type NotificationChannel } from '../entities';
@@ -12,29 +12,90 @@ import { logger } from '@spfn/core/logger';
 
 const log = logger.child('@spfn/notification:tracking');
 
-// ─── Record Functions (fire-and-forget) ───────────────────────────
+// ─── Record Functions (fire-and-forget, buffered) ─────────────────
+//
+// Open/click routes are public (.skip(['auth'])) and email clients prefetch them,
+// so a blast can fire tens of thousands of hits. One INSERT per hit would contend
+// for the bounded write pool. Buffer hits and flush as a single multi-row INSERT
+// on size/interval. Best-effort analytics: a crash may drop the unflushed tail,
+// and a hard cap sheds excess under a blast rather than growing unbounded.
+
+type PendingTrackingEvent = typeof trackingEvents.$inferInsert;
+
+const FLUSH_SIZE = 200;
+const FLUSH_INTERVAL_MS = 2000;
+const MAX_BUFFER = 10_000;
+
+const buffer: PendingTrackingEvent[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+async function flushTrackingEvents(): Promise<void>
+{
+    if (flushTimer)
+    {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+    }
+
+    if (buffer.length === 0)
+    {
+        return;
+    }
+
+    const batch = buffer.splice(0, buffer.length);
+
+    try
+    {
+        await getDatabase('write').insert(trackingEvents).values(batch);
+    }
+    catch (error)
+    {
+        log.warn(`Failed to flush ${batch.length} tracking events`, error as Error);
+    }
+}
+
+function enqueueTrackingEvent(event: PendingTrackingEvent): void
+{
+    if (buffer.length >= MAX_BUFFER)
+    {
+        // Shed load instead of growing the heap unbounded under a blast.
+        log.warn('Tracking buffer full — dropping event');
+
+        return;
+    }
+
+    buffer.push(event);
+
+    if (buffer.length >= FLUSH_SIZE)
+    {
+        void flushTrackingEvents();
+    }
+    else if (!flushTimer)
+    {
+        flushTimer = setTimeout(() => void flushTrackingEvents(), FLUSH_INTERVAL_MS);
+        // Don't keep the process alive just for a pending flush.
+        flushTimer.unref?.();
+    }
+}
 
 /**
- * Record an open event (fire-and-forget)
+ * Record an open event (fire-and-forget, buffered)
  */
 export function recordOpenEvent(
     notificationId: number,
     meta?: { ipAddress?: string; userAgent?: string },
 ): void
 {
-    create(trackingEvents, {
+    enqueueTrackingEvent({
         notificationId,
         type: 'open',
         ipAddress: meta?.ipAddress,
         userAgent: meta?.userAgent,
-    }).catch((error) =>
-    {
-        log.warn('Failed to record open event', error as Error);
     });
 }
 
 /**
- * Record a click event (fire-and-forget)
+ * Record a click event (fire-and-forget, buffered)
  */
 export function recordClickEvent(
     notificationId: number,
@@ -43,16 +104,13 @@ export function recordClickEvent(
     meta?: { ipAddress?: string; userAgent?: string },
 ): void
 {
-    create(trackingEvents, {
+    enqueueTrackingEvent({
         notificationId,
         type: 'click',
         linkUrl,
         linkIndex,
         ipAddress: meta?.ipAddress,
         userAgent: meta?.userAgent,
-    }).catch((error) =>
-    {
-        log.warn('Failed to record click event', error as Error);
     });
 }
 


### PR DESCRIPTION
From the ancillary audit (P-H1, high).

## The problem
`recordOpenEvent`/`recordClickEvent` did **one INSERT per hit** (fire-and-forget) on the public (`.skip(['auth'])`) open/click routes that email clients prefetch. A 100k blast → ~100k individual INSERTs contending for the bounded write pool, bot-amplifiable.

## The fix
Buffer hits and flush as a **single multi-row INSERT** on size (200) or interval (2s). A hard cap (10k) sheds load instead of growing the heap unbounded under a blast. Best-effort analytics semantics unchanged (already fire-and-forget); a crash may drop the unflushed tail. The flush timer is `unref`'d so it never holds the process open.

Per-IP rate limiting was **intentionally not** added: Gmail proxies open-pixel fetches through shared Google IPs, so per-IP limits would drop legitimate opens. The buffer cap bounds the amplification instead.

## Verification
notification type-check + build + madge clean; tracking suite green (27, incl. a new test asserting 200 hits → one 200-row batch insert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)