### PR TITLE
perf(cms): batch label reads + draft saves (P-M5/M6/M7)

### DIFF
--- a/packages/cms/src/server/repositories/cms-label-values.repository.ts
+++ b/packages/cms/src/server/repositories/cms-label-values.repository.ts
@@ -6,7 +6,7 @@
  */
 
 import { BaseRepository } from '@spfn/core/db';
-import { eq, and, SQL, isNull, gte, lte, inArray, sql } from 'drizzle-orm';
+import { eq, and, or, SQL, isNull, gte, lte, inArray, sql } from 'drizzle-orm';
 import { cmsLabelValues, type CmsLabelValue, type NewCmsLabelValue } from '../entities';
 
 /**
@@ -236,6 +236,51 @@ export class CmsLabelValuesRepository extends BaseRepository
     }
 
     /**
+     * 특정 (labelId, locale) 쌍들의 Draft(breakpoint = null) 일괄 삭제.
+     * saveSectionDraft의 delete-then-insert 배치용 — 저장 대상 locale만 교체한다.
+     * Write primary 사용
+     */
+    async deleteDraftsByLabelLocales(pairs: Array<{ labelId: number; locale: string }>): Promise<void>
+    {
+        if (pairs.length === 0)
+        {
+            return;
+        }
+
+        await this.db
+            .delete(cmsLabelValues)
+            .where(
+                and(
+                    isNull(cmsLabelValues.version),
+                    isNull(cmsLabelValues.breakpoint),
+                    or(
+                        ...pairs.map(p =>
+                            and(
+                                eq(cmsLabelValues.labelId, p.labelId),
+                                eq(cmsLabelValues.locale, p.locale),
+                            ),
+                        ),
+                    ),
+                ),
+            );
+    }
+
+    /**
+     * Draft 값들을 한 번에 multi-row INSERT (saveSectionDraft 배치용).
+     * 호출 전에 같은 (labelId, locale) draft를 삭제한 상태를 전제로 한다.
+     * Write primary 사용
+     */
+    async insertDraftValues(rows: (NewCmsLabelValue & { labelId: number })[]): Promise<void>
+    {
+        if (rows.length === 0)
+        {
+            return;
+        }
+
+        await this.db.insert(cmsLabelValues).values(rows);
+    }
+
+    /**
      * 특정 버전의 모든 값 삭제
      * Write primary 사용
      */
@@ -282,35 +327,36 @@ export class CmsLabelValuesRepository extends BaseRepository
             return new Map();
         }
 
-        // 모든 label의 publishedVersion 값들을 한 번에 조회
+        // (labelId, version) 쌍을 SQL에서 직접 필터 — 예전엔 labelId만으로 모든
+        // 버전을 끌어와 JS로 걸렀다. published 버전은 불변·누적이라 v50을 요청하면
+        // v1..50을 전부 전송하는 read amplification이 발생했다. composite index
+        // (labelId, version)를 타도록 OR(AND(labelId, version))로 좁힌다.
         const allValues = await this.readDb
             .select()
             .from(cmsLabelValues)
             .where(
-                and(
-                    inArray(
-                        cmsLabelValues.labelId,
-                        labelVersions.map(lv => lv.labelId),
+                or(
+                    ...labelVersions.map(lv =>
+                        and(
+                            eq(cmsLabelValues.labelId, lv.labelId),
+                            eq(cmsLabelValues.version, lv.version),
+                        ),
                     ),
                 ),
             );
 
-        // labelId와 version으로 필터링하여 Map 생성
-        const versionMap = new Map(labelVersions.map(lv => [lv.labelId, lv.version]));
         const resultMap = new Map<number, CmsLabelValue[]>();
 
         for (const value of allValues)
         {
-            const expectedVersion = versionMap.get(value.labelId);
-
-            // 해당 labelId의 version이 일치하는 경우만 포함
-            if (expectedVersion !== undefined && value.version === expectedVersion)
+            const list = resultMap.get(value.labelId);
+            if (list)
             {
-                if (!resultMap.has(value.labelId))
-                {
-                    resultMap.set(value.labelId, []);
-                }
-                resultMap.get(value.labelId)!.push(value);
+                list.push(value);
+            }
+            else
+            {
+                resultMap.set(value.labelId, [value]);
             }
         }
 

--- a/packages/cms/src/server/services/publish.service.ts
+++ b/packages/cms/src/server/services/publish.service.ts
@@ -45,11 +45,23 @@ export async function getSectionLabels(
         return { section, locales, labels: [] };
     }
 
-    // 2. 각 라벨의 Draft 값 조회 (version: null)
+    // 2. 모든 라벨의 Draft 값을 한 번에 조회 (라벨당 1쿼리 → 1쿼리, N+1/풀고갈 제거)
     const labelIds = labels.map(l => l.id);
-    const draftValues = await Promise.all(
-        labelIds.map(id => cmsLabelValuesRepository.findDraftsByLabelId(id)),
-    );
+    const allDrafts = await cmsLabelValuesRepository.findDraftsByLabelIds(labelIds);
+
+    const draftsByLabel = new Map<number, CmsLabelValue[]>();
+    for (const draft of allDrafts)
+    {
+        const list = draftsByLabel.get(draft.labelId);
+        if (list)
+        {
+            list.push(draft);
+        }
+        else
+        {
+            draftsByLabel.set(draft.labelId, [draft]);
+        }
+    }
 
     // 3. 각 라벨의 Published 값 조회
     const labelVersions = labels
@@ -61,9 +73,9 @@ export async function getSectionLabels(
         : new Map();
 
     // 4. 결과 조합
-    const result = labels.map((label, index) =>
+    const result = labels.map((label) =>
     {
-        const drafts = draftValues[index];
+        const drafts = draftsByLabel.get(label.id) || [];
         const published = publishedValuesMap.get(label.id) || [];
 
         // Draft를 locale별 Record로 변환
@@ -116,22 +128,36 @@ export async function saveSectionDraft(
 {
     publishLogger.debug('saveSectionDraft', { section, labelCount: labels.length });
 
-    let updated = 0;
+    // 저장 대상 (labelId, locale) 쌍과 새 draft 행을 모은다. 라벨×locale마다
+    // upsert(SELECT+write)를 직렬로 돌리던 것을, 해당 쌍의 draft만 한 번에 삭제하고
+    // 새 값들을 한 번에 INSERT하는 배치로 바꾼다 (트랜잭션으로 원자적).
+    const pairs: Array<{ labelId: number; locale: string }> = [];
+    const rows: (NewCmsLabelValue & { labelId: number })[] = [];
 
     for (const { id, values } of labels)
     {
-        // 각 locale별로 Draft 저장 (version: null)
         for (const [locale, value] of Object.entries(values))
         {
-            await cmsLabelValuesRepository.upsert({
+            pairs.push({ labelId: id, locale });
+            rows.push({
                 labelId: id,
                 version: null,
                 locale,
                 value: { type: 'text', content: value },
             });
-            updated++;
         }
     }
+
+    if (rows.length > 0)
+    {
+        await runInTransaction(async () =>
+        {
+            await cmsLabelValuesRepository.deleteDraftsByLabelLocales(pairs);
+            await cmsLabelValuesRepository.insertDraftValues(rows);
+        });
+    }
+
+    const updated = rows.length;
 
     publishLogger.info('Draft saved', { section, updated });
 


### PR DESCRIPTION
From the ancillary audit (P-M5, P-M6, P-M7).

- **P-M5** `getSectionLabels`: drafts fetched via `Promise.all(labelIds.map(findDraftsByLabelId))` — 200 concurrent queries for a 200-label view, momentarily exhausting the read pool. Now one `findDraftsByLabelIds(ids)` + group by label.
- **P-M6** `findByLabelVersions`: WHERE only constrained `inArray(labelId)`, then filtered version in JS — requesting v50 transferred v1..50 for every locale/breakpoint (read amplification growing with edit history). Push the `(labelId, version)` filter into SQL via `OR(AND(labelId, version))`, hitting the composite index.
- **P-M7** `saveSectionDraft`: doubly-nested loop awaiting `upsert` (SELECT+write) one locale at a time (`L*Loc*2` serial round-trips). Replace with a targeted **delete-then-insert** of the saved `(labelId, locale)` draft rows in a transaction. (Drafts use `version=null`, which the unique constraint treats as distinct, so `ON CONFLICT` can't dedup — delete-then-insert is correct.)

## Verification
cms type-check + build + madge circular clean. (The `cms-label-values` integration test is pre-existing-broken — missing `@/__tests__/helpers/db` — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)