### PR TITLE
perf(monitor): collapse error-group reopen into a single UPDATE (P-M9)

### DIFF
--- a/packages/monitor/src/__tests__/unit/error-tracking.test.ts
+++ b/packages/monitor/src/__tests__/unit/error-tracking.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../server/repositories', () =>
         create: vi.fn(),
         incrementCount: vi.fn(),
         updateStatus: vi.fn(),
+        reactivate: vi.fn(),
     };
 
     const mockErrorEventsRepo = {
@@ -132,8 +133,7 @@ describe('trackError', () =>
 
         await trackError(new Error('test error'), mockCtx);
 
-        expect(errorGroupsRepository.updateStatus).toHaveBeenCalledWith(1, 'active');
-        expect(errorGroupsRepository.incrementCount).toHaveBeenCalledWith(1);
+        expect(errorGroupsRepository.reactivate).toHaveBeenCalledWith(1);
         expect(errorEventsRepository.create).toHaveBeenCalledTimes(1);
         expect(notifyErrorToSlack).toHaveBeenCalledWith(
             expect.objectContaining({ status: 'active' }),

--- a/packages/monitor/src/server/repositories/error-groups.repository.ts
+++ b/packages/monitor/src/server/repositories/error-groups.repository.ts
@@ -133,6 +133,30 @@ export class ErrorGroupsRepository extends BaseRepository
         return result[0] ?? null;
     }
 
+    /**
+     * Reopen a resolved group: set active, clear resolvedAt, and bump count +
+     * lastSeenAt in a SINGLE UPDATE (the reopen path used to do updateStatus then
+     * incrementCount — two round trips writing the same row, the second clobbering
+     * the first).
+     */
+    async reactivate(id: number): Promise<ErrorGroup | null>
+    {
+        const now = new Date();
+        const result = await this.db
+            .update(errorGroups)
+            .set({
+                status: 'active',
+                resolvedAt: null,
+                count: sql`${errorGroups.count} + 1`,
+                lastSeenAt: now,
+                updatedAt: now,
+            })
+            .where(eq(errorGroups.id, id))
+            .returning();
+
+        return result[0] ?? null;
+    }
+
     async updateStatus(id: number, status: ErrorGroupStatus): Promise<ErrorGroup | null>
     {
         const now = new Date();

--- a/packages/monitor/src/server/services/error-tracking.service.ts
+++ b/packages/monitor/src/server/services/error-tracking.service.ts
@@ -98,9 +98,8 @@ export async function trackError(
 
     if (existing.status === 'resolved')
     {
-        // Reopened — change status back to active + increment + notify
-        await errorGroupsRepository.updateStatus(existing.id, 'active');
-        await errorGroupsRepository.incrementCount(existing.id);
+        // Reopened — back to active + increment + notify (single UPDATE)
+        await errorGroupsRepository.reactivate(existing.id);
 
         const event = await safeCreateEvent(existing.id, err, ctx, metadata);
 


### PR DESCRIPTION
From the ancillary audit (P-M9).

The reopen path did `updateStatus(id,'active')` **then** `incrementCount(id)` — two round trips to the same row, the second re-writing `lastSeenAt`/`updatedAt` the first just set. Add `reactivate(id)`: one `UPDATE SET status='active', resolvedAt=null, count=count+1, lastSeenAt=now, updatedAt=now RETURNING`.

> P-M8 (leading-wildcard `ILIKE` search → seq scan) is **deferred**: the proper fix is a `pg_trgm` GIN index, which requires the `pg_trgm` extension + a migration. The admin searches are already `limit`-bounded.

## Verification
monitor type-check + build + madge clean; unit suite green (17, reopen test updated to assert the single `reactivate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)