### PR TITLE
perf(notification): fire-and-forget post-send history + concurrent sendSMS (P-M2/P-M3)

### DIFF
--- a/packages/notification/src/channels/email/index.ts
+++ b/packages/notification/src/channels/email/index.ts
@@ -179,24 +179,15 @@ export async function sendEmail(params: SendEmailParams): Promise<SendResult>
         log.error('Email send failed', { to: recipients, subject, error: result.error });
     }
 
-    // Update history record
+    // Update history record (fire-and-forget — best-effort history must not add a
+    // serial DB round trip to the send path, e.g. a signup OTP).
     if (historyId && isHistoryEnabled())
     {
-        try
-        {
-            if (result.success)
-            {
-                await markNotificationSent(historyId, result.messageId);
-            }
-            else
-            {
-                await markNotificationFailed(historyId, result.error || 'Unknown error');
-            }
-        }
-        catch (error)
-        {
-            log.warn('Failed to update notification history record', error as Error);
-        }
+        const update = result.success
+            ? markNotificationSent(historyId, result.messageId)
+            : markNotificationFailed(historyId, result.error || 'Unknown error');
+
+        update.catch(error => log.warn('Failed to update notification history record', error as Error));
     }
 
     return result;

--- a/packages/notification/src/channels/slack/index.ts
+++ b/packages/notification/src/channels/slack/index.ts
@@ -152,24 +152,15 @@ export async function sendSlack(params: SendSlackParams): Promise<SendResult>
         log.error('Slack send failed', { error: result.error });
     }
 
-    // Update history record
+    // Update history record (fire-and-forget — best-effort history must not add a
+    // serial DB round trip to the send path).
     if (historyId && isHistoryEnabled())
     {
-        try
-        {
-            if (result.success)
-            {
-                await markNotificationSent(historyId, result.messageId);
-            }
-            else
-            {
-                await markNotificationFailed(historyId, result.error || 'Unknown error');
-            }
-        }
-        catch (error)
-        {
-            log.warn('Failed to update notification history record', error as Error);
-        }
+        const update = result.success
+            ? markNotificationSent(historyId, result.messageId)
+            : markNotificationFailed(historyId, result.error || 'Unknown error');
+
+        update.catch(error => log.warn('Failed to update notification history record', error as Error));
     }
 
     return result;

--- a/packages/notification/src/channels/sms/index.ts
+++ b/packages/notification/src/channels/sms/index.ts
@@ -100,9 +100,8 @@ export async function sendSMS(params: SendSMSParams): Promise<SendResult>
 
     // Send to each recipient
     const provider = getProvider();
-    const results: SendResult[] = [];
-
-    for (const recipient of recipients)
+    // Send one recipient: create history, send, then update history fire-and-forget.
+    const sendOne = async (recipient: string): Promise<SendResult> =>
     {
         const normalizedPhone = normalizePhoneNumber(recipient);
 
@@ -144,28 +143,21 @@ export async function sendSMS(params: SendSMSParams): Promise<SendResult>
             log.error('SMS send failed', { to: normalizedPhone, error: result.error });
         }
 
-        // Update history record
+        // Update history record (fire-and-forget — best-effort, off the send path)
         if (historyId && isHistoryEnabled())
         {
-            try
-            {
-                if (result.success)
-                {
-                    await markNotificationSent(historyId, result.messageId);
-                }
-                else
-                {
-                    await markNotificationFailed(historyId, result.error || 'Unknown error');
-                }
-            }
-            catch (error)
-            {
-                log.warn('Failed to update notification history record', error as Error);
-            }
+            const update = result.success
+                ? markNotificationSent(historyId, result.messageId)
+                : markNotificationFailed(historyId, result.error || 'Unknown error');
+
+            update.catch(error => log.warn('Failed to update notification history record', error as Error));
         }
 
-        results.push(result);
-    }
+        return result;
+    };
+
+    // Process recipients concurrently (was a fully sequential for-of loop).
+    const results: SendResult[] = await runWithConcurrency(recipients, sendOne);
 
     // Return aggregated result
     const allSuccess = results.every(r => r.success);

--- a/packages/notification/src/tracking/__tests__/tracking-buffer.test.ts
+++ b/packages/notification/src/tracking/__tests__/tracking-buffer.test.ts
@@ -9,8 +9,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { valuesSpy, insertSpy } = vi.hoisted(() =>
 {
-    const valuesSpy = vi.fn(async () => undefined);
-    const insertSpy = vi.fn(() => ({ values: valuesSpy }));
+    const valuesSpy = vi.fn(async (_rows: unknown[]) => undefined);
+    const insertSpy = vi.fn((_table: unknown) => ({ values: valuesSpy }));
 
     return { valuesSpy, insertSpy };
 });


### PR DESCRIPTION
From the ancillary audit (P-M2, P-M3).

- **P-M2**: single send bracketed each message with **two** awaited DB round trips — create history before the provider call, update status after. The post-send update is best-effort history, so it shouldn't add a serial round trip to the send path (e.g. a signup OTP). Fire-and-forget the `markNotificationSent`/`Failed` in email/slack/sms single send. (SPFN backends are long-running servers, so the async write completes.)
- **P-M3**: `sendSMS` (non-bulk) processed recipients **fully sequentially** (await create → send → mark per recipient) — 10 numbers ≈ several seconds serial. Route through the same `runWithConcurrency` path `sendSMSBulk` uses (order preserved).

> **P-M1** (bulk status-update fan-out) is intentionally **deferred**: the clean `UPDATE ... WHERE id = ANY(ids)` batch would lose the per-row `providerMessageId` / `errorMessage`; preserving them needs an `UPDATE ... FROM (VALUES ...)`. The bulk updates are already concurrent (`Promise.all`), so this is left for a focused follow-up rather than degrading per-message delivery tracking.

## Verification
notification type-check + build + madge clean; suite green (32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)