### PR TITLE
perf(notification): batch bulk status updates, preserving per-row fields (P-M1)

### DIFF
--- a/packages/notification/src/channels/email/index.ts
+++ b/packages/notification/src/channels/email/index.ts
@@ -14,6 +14,8 @@ import {
     createNotificationRecords,
     markNotificationSent,
     markNotificationFailed,
+    markManySent,
+    markManyFailed,
 } from '../../services/notification.service';
 import { runWithConcurrency } from '../concurrency';
 import { sendBulkEmailItemJob } from '../../jobs/send-bulk-email-item';
@@ -448,7 +450,10 @@ export async function sendEmailBulk(
         results[index] = result;
     }
 
-    const historyUpdates: Promise<unknown>[] = [];
+    // Group history updates by outcome → two batched UPDATEs instead of N
+    // concurrent single-row UPDATEs.
+    const sentItems: Array<{ id: number; providerMessageId?: string }> = [];
+    const failedItems: Array<{ id: number; errorMessage: string }> = [];
 
     for (let i = 0; i < prepared.length; i++)
     {
@@ -471,17 +476,21 @@ export async function sendEmailBulk(
 
         if (historyId && isHistoryEnabled())
         {
-            const promise = result.success
-                ? markNotificationSent(historyId, result.messageId)
-                : markNotificationFailed(historyId, result.error || 'Unknown error');
-
-            historyUpdates.push(
-                promise.catch((err) => log.warn('Failed to update notification history', err)),
-            );
+            if (result.success)
+            {
+                sentItems.push({ id: historyId, providerMessageId: result.messageId });
+            }
+            else
+            {
+                failedItems.push({ id: historyId, errorMessage: result.error || 'Unknown error' });
+            }
         }
     }
 
-    await Promise.all(historyUpdates);
+    await Promise.all([
+        markManySent(sentItems).catch(err => log.warn('Failed to update notification history', err)),
+        markManyFailed(failedItems).catch(err => log.warn('Failed to update notification history', err)),
+    ]);
 
     return { results, successCount, failureCount, batchId };
 }

--- a/packages/notification/src/channels/slack/index.ts
+++ b/packages/notification/src/channels/slack/index.ts
@@ -13,6 +13,8 @@ import {
     createNotificationRecords,
     markNotificationSent,
     markNotificationFailed,
+    markManySent,
+    markManyFailed,
 } from '../../services/notification.service';
 import { runWithConcurrency } from '../concurrency';
 import { sendBulkSlackItemJob } from '../../jobs/send-bulk-slack-item';
@@ -355,7 +357,8 @@ export async function sendSlackBulk(
         results[index] = result;
     }
 
-    const historyUpdates: Promise<unknown>[] = [];
+    const sentItems: Array<{ id: number; providerMessageId?: string }> = [];
+    const failedItems: Array<{ id: number; errorMessage: string }> = [];
 
     for (let i = 0; i < prepared.length; i++)
     {
@@ -378,17 +381,21 @@ export async function sendSlackBulk(
 
         if (historyId && isHistoryEnabled())
         {
-            const promise = result.success
-                ? markNotificationSent(historyId, result.messageId)
-                : markNotificationFailed(historyId, result.error || 'Unknown error');
-
-            historyUpdates.push(
-                promise.catch((err) => log.warn('Failed to update notification history', err)),
-            );
+            if (result.success)
+            {
+                sentItems.push({ id: historyId, providerMessageId: result.messageId });
+            }
+            else
+            {
+                failedItems.push({ id: historyId, errorMessage: result.error || 'Unknown error' });
+            }
         }
     }
 
-    await Promise.all(historyUpdates);
+    await Promise.all([
+        markManySent(sentItems).catch(err => log.warn('Failed to update notification history', err)),
+        markManyFailed(failedItems).catch(err => log.warn('Failed to update notification history', err)),
+    ]);
 
     return { results, successCount, failureCount, batchId };
 }

--- a/packages/notification/src/channels/sms/index.ts
+++ b/packages/notification/src/channels/sms/index.ts
@@ -13,6 +13,8 @@ import {
     createNotificationRecords,
     markNotificationSent,
     markNotificationFailed,
+    markManySent,
+    markManyFailed,
 } from '../../services/notification.service';
 import { runWithConcurrency } from '../concurrency';
 import { sendBulkSmsItemJob } from '../../jobs/send-bulk-sms-item';
@@ -357,7 +359,8 @@ export async function sendSMSBulk(
 
     // 5. Build per-item aggregated results + update history
     const resultsMap = new Map<number, SendResult[]>();
-    const historyUpdates: Promise<unknown>[] = [];
+    const sentItems: Array<{ id: number; providerMessageId?: string }> = [];
+    const failedItems: Array<{ id: number; errorMessage: string }> = [];
 
     for (let i = 0; i < prepared.length; i++)
     {
@@ -383,17 +386,21 @@ export async function sendSMSBulk(
 
         if (historyId && isHistoryEnabled())
         {
-            const promise = result.success
-                ? markNotificationSent(historyId, result.messageId)
-                : markNotificationFailed(historyId, result.error || 'Unknown error');
-
-            historyUpdates.push(
-                promise.catch((err) => log.warn('Failed to update notification history', err)),
-            );
+            if (result.success)
+            {
+                sentItems.push({ id: historyId, providerMessageId: result.messageId });
+            }
+            else
+            {
+                failedItems.push({ id: historyId, errorMessage: result.error || 'Unknown error' });
+            }
         }
     }
 
-    await Promise.all(historyUpdates);
+    await Promise.all([
+        markManySent(sentItems).catch(err => log.warn('Failed to update notification history', err)),
+        markManyFailed(failedItems).catch(err => log.warn('Failed to update notification history', err)),
+    ]);
 
     // 6. Aggregate results per original item
     const results: SendResult[] = new Array(items.length);

--- a/packages/notification/src/services/notification.service.ts
+++ b/packages/notification/src/services/notification.service.ts
@@ -5,7 +5,7 @@
  */
 
 import { create, createMany, findOne, findMany, updateOne, count, getDatabase } from '@spfn/core/db';
-import { desc, eq, and, gte, lte, count as drizzleCount } from 'drizzle-orm';
+import { desc, eq, and, gte, lte, inArray, sql, count as drizzleCount } from 'drizzle-orm';
 import {
     notifications,
     type Notification,
@@ -101,6 +101,63 @@ export async function markNotificationFailed(
             errorMessage,
         },
     );
+}
+
+/**
+ * Mark many notifications as sent in a SINGLE UPDATE, preserving each row's
+ * providerMessageId via a CASE (a bulk send used to fan out N concurrent
+ * single-row UPDATEs). drizzle handles column names/escaping; values are bound.
+ */
+export async function markManySent(
+    items: Array<{ id: number; providerMessageId?: string }>,
+): Promise<void>
+{
+    if (items.length === 0)
+    {
+        return;
+    }
+
+    const cases = sql.join(
+        items.map(it => sql`when ${it.id} then ${it.providerMessageId ?? null}`),
+        sql` `,
+    );
+
+    await getDatabase('write')
+        .update(notifications)
+        .set({
+            status: 'sent',
+            sentAt: new Date(),
+            // ELSE keeps the existing value and anchors the CASE result type to text.
+            providerMessageId: sql`case ${notifications.id} ${cases} else ${notifications.providerMessageId} end`,
+        })
+        .where(inArray(notifications.id, items.map(it => it.id)));
+}
+
+/**
+ * Mark many notifications as failed in a SINGLE UPDATE, preserving each row's
+ * errorMessage via a CASE.
+ */
+export async function markManyFailed(
+    items: Array<{ id: number; errorMessage: string }>,
+): Promise<void>
+{
+    if (items.length === 0)
+    {
+        return;
+    }
+
+    const cases = sql.join(
+        items.map(it => sql`when ${it.id} then ${it.errorMessage}`),
+        sql` `,
+    );
+
+    await getDatabase('write')
+        .update(notifications)
+        .set({
+            status: 'failed',
+            errorMessage: sql`case ${notifications.id} ${cases} else ${notifications.errorMessage} end`,
+        })
+        .where(inArray(notifications.id, items.map(it => it.id)));
 }
 
 /**


### PR DESCRIPTION
From the ancillary audit (P-M1) — the item deferred in the perf batch, now done.

## The problem
Bulk send fanned out **N concurrent single-row UPDATEs** to mark each message sent/failed (1000 for a 1000-item bulk), contending for the write pool.

## Why it was deferred, and the fix
A plain `UPDATE ... WHERE id = ANY(ids)` batch would lose the **per-row** `providerMessageId` / `errorMessage`. So `markManySent`/`markManyFailed` carry them in a `CASE <id> WHEN .. THEN .. ELSE <col> END` — one UPDATE per outcome, per-row values preserved, the `ELSE <col>` anchoring the result type and keeping existing values. drizzle handles column names; **every value is bound** (no interpolation).

email/sms/slack bulk paths now collect `{id, messageId}` / `{id, error}` and issue **two** batched UPDATEs.

## Verification
notification type-check + build + madge clean; suite green (32). Also executed against a real Postgres: a mixed sent/failed batch kept each row's distinct `providerMessageId`/`errorMessage` (rows 1 & 3 → their own message ids, row 2 → its own error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)