### PR TITLE
perf(monitor): pg_trgm GIN indexes for error-group search (P-M8)

### DIFF
--- a/packages/monitor/migrations/0002_magenta_proudstar.sql
+++ b/packages/monitor/migrations/0002_magenta_proudstar.sql
@@ -1,0 +1,7 @@
+-- pg_trgm provides the gin_trgm_ops operator class used by the trigram GIN
+-- indexes below (makes leading-wildcard ILIKE searches sargable). drizzle-kit
+-- cannot generate CREATE EXTENSION, so it is added here by hand. Idempotent.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
+CREATE INDEX "monitor_eg_name_trgm_idx" ON "spfn_monitor"."error_groups" USING gin ("name" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "monitor_eg_message_trgm_idx" ON "spfn_monitor"."error_groups" USING gin ("message" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "monitor_eg_path_trgm_idx" ON "spfn_monitor"."error_groups" USING gin ("path" gin_trgm_ops);

--- a/packages/monitor/migrations/meta/0002_snapshot.json
+++ b/packages/monitor/migrations/meta/0002_snapshot.json
@@ -1,0 +1,493 @@
+{
+  "id": "c220e177-67d7-4ab6-99f3-b64f5ba7dcfc",
+  "prevId": "f36888a8-929e-41ba-ac25-e3ce942cba67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "spfn_monitor.error_events": {
+      "name": "error_events",
+      "schema": "spfn_monitor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stack_trace": {
+          "name": "stack_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "monitor_ee_group_id_idx": {
+          "name": "monitor_ee_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_ee_created_at_idx": {
+          "name": "monitor_ee_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_ee_user_id_idx": {
+          "name": "monitor_ee_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "error_events_group_id_error_groups_id_fk": {
+          "name": "error_events_group_id_error_groups_id_fk",
+          "tableFrom": "error_events",
+          "tableTo": "error_groups",
+          "schemaTo": "spfn_monitor",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "spfn_monitor.error_groups": {
+      "name": "error_groups",
+      "schema": "spfn_monitor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "monitor_eg_fingerprint_idx": {
+          "name": "monitor_eg_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_eg_status_idx": {
+          "name": "monitor_eg_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_eg_last_seen_at_idx": {
+          "name": "monitor_eg_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_eg_path_idx": {
+          "name": "monitor_eg_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_eg_name_trgm_idx": {
+          "name": "monitor_eg_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "monitor_eg_message_trgm_idx": {
+          "name": "monitor_eg_message_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"message\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "monitor_eg_path_trgm_idx": {
+          "name": "monitor_eg_path_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"path\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "error_groups_fingerprint_unique": {
+          "name": "error_groups_fingerprint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "fingerprint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "spfn_monitor.logs": {
+      "name": "logs",
+      "schema": "spfn_monitor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "monitor_log_level_idx": {
+          "name": "monitor_log_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_log_source_idx": {
+          "name": "monitor_log_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_log_created_at_idx": {
+          "name": "monitor_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "spfn_monitor": "spfn_monitor"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/monitor/migrations/meta/_journal.json
+++ b/packages/monitor/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1774403094404,
       "tag": "0001_bumpy_dark_beast",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1782573013559,
+      "tag": "0002_magenta_proudstar",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/monitor/src/server/entities/error-groups.ts
+++ b/packages/monitor/src/server/entities/error-groups.ts
@@ -6,6 +6,7 @@
  */
 
 import { text, integer, index } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import { id, timestamps, enumText, utcTimestamp } from '@spfn/core/db';
 import { monitorSchema } from './schema';
 
@@ -51,6 +52,14 @@ export const errorGroups = monitorSchema.table('error_groups',
         index('monitor_eg_status_idx').on(table.status),
         index('monitor_eg_last_seen_at_idx').on(table.lastSeenAt),
         index('monitor_eg_path_idx').on(table.path),
+        // pg_trgm GIN indexes make the admin search's leading-wildcard ILIKE
+        // (%term%) on name/message/path sargable instead of a seq scan. Error
+        // groups are fingerprint-deduped, so insert volume is low — the write cost
+        // of these GIN indexes is acceptable here (NOT applied to the high-volume
+        // logs table). Requires the pg_trgm extension (see the migration).
+        index('monitor_eg_name_trgm_idx').using('gin', sql`${table.name} gin_trgm_ops`),
+        index('monitor_eg_message_trgm_idx').using('gin', sql`${table.message} gin_trgm_ops`),
+        index('monitor_eg_path_trgm_idx').using('gin', sql`${table.path} gin_trgm_ops`),
     ],
 );
 


### PR DESCRIPTION
From the ancillary audit (P-M8) — the second deferred perf item, now done.

## The problem
The admin error-group search uses leading-wildcard `ILIKE ('%term%')` on `name`/`message`/`path` — **unsargable**, so btree indexes are unused and it falls to a full seq scan.

## The fix
`pg_trgm` GIN indexes (`gin_trgm_ops`) on those three columns make the **existing** `ILIKE` sargable — no query change needed.

**Only `error_groups`** gets these — it's fingerprint-deduped (low insert volume), so the GIN write cost is acceptable. The **high-volume `logs`** table is intentionally left out: a trgm index on every log line would be too costly for an infrequent admin search.

## How the extension migration is installed
- The GIN indexes live in the **entity schema** (`.using('gin', sql\`<col> gin_trgm_ops\`)`), so `drizzle-kit generate` emits the `CREATE INDEX`.
- `pg_trgm` provides `gin_trgm_ops`, but drizzle-kit **can't generate `CREATE EXTENSION`** — so `CREATE EXTENSION IF NOT EXISTS pg_trgm;` is **prepended by hand** to the generated migration (the documented exception to "don't hand-edit migrations"). It's idempotent; the migration role needs privilege to create the extension (pre-available on most managed Postgres).

## Verification
Applied against a real Postgres; `EXPLAIN` shows the `ILIKE` OR-search resolved via **BitmapOr over the three `*_trgm_idx` GIN indexes** (`Index Cond: (name ~~* '%failed%')` …) instead of a seq scan. monitor type-check + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)