### PR TITLE
perf(monitor): parallel recurring-error writes + default findMany cap (P-L8/P-L12)

### DIFF
--- a/packages/monitor/src/server/repositories/error-groups.repository.ts
+++ b/packages/monitor/src/server/repositories/error-groups.repository.ts
@@ -24,6 +24,9 @@ export interface ErrorGroupFilters
     offset?: number;
 }
 
+// Default cap so a caller that omits `limit` can't pull the whole table.
+const DEFAULT_FIND_LIMIT = 100;
+
 export class ErrorGroupsRepository extends BaseRepository
 {
     async findById(id: number): Promise<ErrorGroup | null>
@@ -96,10 +99,7 @@ export class ErrorGroupsRepository extends BaseRepository
             query = query.where(where);
         }
 
-        if (filters.limit)
-        {
-            query = query.limit(filters.limit);
-        }
+        query = query.limit(filters.limit ?? DEFAULT_FIND_LIMIT);
 
         if (filters.offset)
         {

--- a/packages/monitor/src/server/repositories/logs.repository.ts
+++ b/packages/monitor/src/server/repositories/logs.repository.ts
@@ -21,6 +21,9 @@ export interface LogFilters
     offset?: number;
 }
 
+// Default cap so a caller that omits `limit` can't pull the whole table.
+const DEFAULT_FIND_LIMIT = 100;
+
 export class LogsRepository extends BaseRepository
 {
     async create(data: NewLog): Promise<Log>
@@ -89,10 +92,7 @@ export class LogsRepository extends BaseRepository
             query = query.where(where);
         }
 
-        if (filters.limit)
-        {
-            query = query.limit(filters.limit);
-        }
+        query = query.limit(filters.limit ?? DEFAULT_FIND_LIMIT);
 
         if (filters.offset)
         {

--- a/packages/monitor/src/server/services/error-tracking.service.ts
+++ b/packages/monitor/src/server/services/error-tracking.service.ts
@@ -118,9 +118,13 @@ export async function trackError(
         return;
     }
 
-    // Active or ignored — just increment count + create event (no notification)
-    await errorGroupsRepository.incrementCount(existing.id);
-    await safeCreateEvent(existing.id, err, ctx, metadata);
+    // Active or ignored — just increment count + create event (no notification).
+    // No data dependency between the two writes (the event insert is isolated),
+    // so fire them together instead of serially.
+    await Promise.all([
+        errorGroupsRepository.incrementCount(existing.id),
+        safeCreateEvent(existing.id, err, ctx, metadata),
+    ]);
 }
 
 /**


### PR DESCRIPTION
From the ancillary audit (perf lows).

- **P-L8**: the recurring-error hot path awaited `incrementCount` **then** `safeCreateEvent` sequentially — two writes to different tables with no data dependency. Fire them with `Promise.all`.
- **P-L12**: `findMany` applied `limit` only when truthy, so a caller omitting it would pull the whole table. Default to a 100-row cap (current routes always pass a limit → latent protection).

> P-L9 (offset cap) intentionally skipped — silently bounding `OFFSET` breaks legitimate deep pagination; keyset paging would be the real fix.

## Verification
monitor type-check + build + madge clean; unit suite green (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)