### PR TITLE
perf(core): exponential retry backoff for jobs by default (P-L2)

### DIFF
--- a/packages/core/src/job/register-jobs.ts
+++ b/packages/core/src/job/register-jobs.ts
@@ -30,6 +30,9 @@ function getDefaultJobOptions(options?: JobOptions): PgBoss.SendOptions
     return {
         retryLimit: options?.retryLimit ?? 3,
         retryDelay: options?.retryDelay ?? 1000,
+        // Exponential backoff by default — a failed cohort (e.g. a provider 429)
+        // would otherwise all retry at the same fixed offset (thundering herd).
+        retryBackoff: options?.retryBackoff ?? true,
         expireInSeconds: options?.expireInSeconds ?? 300,
     };
 }

--- a/packages/core/src/job/types.ts
+++ b/packages/core/src/job/types.ts
@@ -24,6 +24,14 @@ export interface JobOptions
     retryDelay?: number;
 
     /**
+     * Exponential backoff between retries (retryDelay * 2^attempt). Defaults to
+     * true so a failed cohort (e.g. on a provider 429) doesn't all retry at the
+     * same fixed offset — a thundering herd. Set false for fixed retryDelay.
+     * @default true
+     */
+    retryBackoff?: boolean;
+
+    /**
      * Job expiration in seconds
      * @default 300 (5 minutes)
      */


### PR DESCRIPTION
From the ancillary audit (P-L2).

Job retries used a fixed `retryDelay` (1000ms) with no backoff, so a whole failed cohort — e.g. every item of a bulk send that hit a provider 429 — retried at the **same offset**, a thundering herd. Default pg-boss `retryBackoff` to `true` (exponential: `retryDelay * 2^attempt`); add `JobOptions.retryBackoff` to override.

> Jitter and honouring `Retry-After` are further refinements left for a focused pass.

## Verification
core type-check + build + madge clean; job suite green (18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)