### PR TITLE
feat(core): rate-limit named policies + SSRF-safe fetch

### DIFF
--- a/packages/auth/src/server/lib/rate-limit-keys.ts
+++ b/packages/auth/src/server/lib/rate-limit-keys.ts
@@ -1,0 +1,99 @@
+/**
+ * @spfn/auth - Rate-limit key builders
+ *
+ * `by` functions for rateLimitPolicy that add an account/target dimension on top
+ * of the client IP, so brute force and abuse are limited by the thing being
+ * attacked — not only by source IP (which an attacker rotates).
+ *
+ * The body is read via `c.req.json()`, which Hono caches: reading it here does
+ * not consume the stream, so the route handler's own validation still sees it.
+ * The IP dimension is given its own (looser) limit so a shared NAT isn't
+ * throttled as one user, while the per-account/target limit stays tight.
+ */
+
+import type { Context } from 'hono';
+import { getClientIp, type RateLimitDimension } from '@spfn/core/middleware';
+
+interface KeyOptions
+{
+    /** Limit for the per-IP dimension. Omit to use the policy's top-level limit. */
+    ipLimit?: number;
+}
+
+async function readJsonBody(c: Context): Promise<Record<string, unknown>>
+{
+    try
+    {
+        return await c.req.json();
+    }
+    catch
+    {
+        return {};
+    }
+}
+
+function accountKey(body: Record<string, unknown>): string | undefined
+{
+    if (typeof body.email === 'string' && body.email.trim())
+    {
+        return `email:${body.email.trim().toLowerCase()}`;
+    }
+    if (typeof body.phone === 'string' && body.phone.trim())
+    {
+        return `phone:${body.phone.trim()}`;
+    }
+
+    return undefined;
+}
+
+function targetKey(body: Record<string, unknown>): string | undefined
+{
+    if (typeof body.target !== 'string' || !body.target.trim())
+    {
+        return undefined;
+    }
+
+    const type = typeof body.targetType === 'string' ? body.targetType : 'target';
+    const value = type === 'email' ? body.target.trim().toLowerCase() : body.target.trim();
+
+    return `${type}:${value}`;
+}
+
+/**
+ * Limit by client IP (loose) AND the account in the request body — `email` or
+ * `phone` (tight, uses the policy limit). Use on login/register so a distributed
+ * attacker can't brute-force one account by rotating IPs.
+ */
+export function byIpAndAccount(options: KeyOptions = {})
+{
+    return async (c: Context): Promise<(RateLimitDimension | undefined)[]> =>
+    {
+        const body = await readJsonBody(c);
+        const account = accountKey(body);
+
+        return [
+            { key: `ip:${getClientIp(c)}`, limit: options.ipLimit },
+            account ? `acct:${account}` : undefined,
+        ];
+    };
+}
+
+/**
+ * Limit by client IP (loose) AND the verification target in the body —
+ * `targetType:target` (tight, uses the policy limit). Use on code send/verify so
+ * a victim's phone/email can't be flooded (SMS-bombing) or an OTP brute-forced
+ * regardless of how many source IPs the attacker uses.
+ */
+export function byIpAndTarget(options: KeyOptions = {})
+{
+    return async (c: Context): Promise<(RateLimitDimension | undefined)[]> =>
+    {
+        const body = await readJsonBody(c);
+        const target = targetKey(body);
+
+        return [
+            { key: `ip:${getClientIp(c)}`, limit: options.ipLimit },
+            target ? `tgt:${target}` : undefined,
+        ];
+    };
+}

--- a/packages/auth/src/server/routes/auth/index.ts
+++ b/packages/auth/src/server/routes/auth/index.ts
@@ -21,6 +21,7 @@ import {
 import { Type } from '@sinclair/typebox';
 import { Transactional } from '@spfn/core/db';
 import { rateLimitPolicy } from '@spfn/core/middleware';
+import { byIpAndAccount, byIpAndTarget } from '../../lib/rate-limit-keys';
 import { defineRouter, route } from '@spfn/core/route';
 
 // NOTE: a POST /_auth/exists endpoint was removed deliberately — it answered
@@ -42,7 +43,7 @@ export const sendVerificationCode = route.post('/_auth/codes')
             purpose: VerificationPurposeSchema,
         }),
     })
-    .use([rateLimitPolicy('auth-code-send', { limit: 5, windowMs: 60_000 })])
+    .use([rateLimitPolicy('auth-code-send', { limit: 5, windowMs: 60_000, by: byIpAndTarget({ ipLimit: 20 }) })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -71,7 +72,7 @@ export const verifyCode = route.post('/_auth/codes/verify')
             purpose: VerificationPurposeSchema,
         }),
     })
-    .use([rateLimitPolicy('auth-code-verify', { limit: 10, windowMs: 60_000 })])
+    .use([rateLimitPolicy('auth-code-verify', { limit: 10, windowMs: 60_000, by: byIpAndTarget({ ipLimit: 50 }) })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -109,7 +110,7 @@ export const register = route.post('/_auth/register')
             algorithm: Type.Union(KEY_ALGORITHM.map(algo => Type.Literal(algo)), { description: 'Signature algorithm' }),
         }),
     })
-    .use([rateLimitPolicy('auth-register', { limit: 10, windowMs: 60_000 }), Transactional()])
+    .use([rateLimitPolicy('auth-register', { limit: 10, windowMs: 60_000, by: byIpAndAccount({ ipLimit: 100 }) }), Transactional()])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -146,7 +147,7 @@ export const login = route.post('/_auth/login')
             oldKeyId: Type.Optional(Type.String({ description: 'Previous key ID for rotation' })),
         }),
     })
-    .use([rateLimitPolicy('auth-login', { limit: 10, windowMs: 60_000 }), Transactional()])
+    .use([rateLimitPolicy('auth-login', { limit: 10, windowMs: 60_000, by: byIpAndAccount({ ipLimit: 100 }) }), Transactional()])
     .skip(['auth'])
     .handler(async (c) =>
     {

--- a/packages/auth/src/server/routes/auth/index.ts
+++ b/packages/auth/src/server/routes/auth/index.ts
@@ -20,7 +20,7 @@ import {
 } from '../../services';
 import { Type } from '@sinclair/typebox';
 import { Transactional } from '@spfn/core/db';
-import { rateLimit } from '@spfn/core/middleware';
+import { rateLimitPolicy } from '@spfn/core/middleware';
 import { defineRouter, route } from '@spfn/core/route';
 
 // NOTE: a POST /_auth/exists endpoint was removed deliberately — it answered
@@ -42,7 +42,7 @@ export const sendVerificationCode = route.post('/_auth/codes')
             purpose: VerificationPurposeSchema,
         }),
     })
-    .use([rateLimit({ limit: 5, windowMs: 60_000 })])
+    .use([rateLimitPolicy('auth-code-send', { limit: 5, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -71,7 +71,7 @@ export const verifyCode = route.post('/_auth/codes/verify')
             purpose: VerificationPurposeSchema,
         }),
     })
-    .use([rateLimit({ limit: 10, windowMs: 60_000 })])
+    .use([rateLimitPolicy('auth-code-verify', { limit: 10, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -109,7 +109,7 @@ export const register = route.post('/_auth/register')
             algorithm: Type.Union(KEY_ALGORITHM.map(algo => Type.Literal(algo)), { description: 'Signature algorithm' }),
         }),
     })
-    .use([Transactional()])
+    .use([rateLimitPolicy('auth-register', { limit: 10, windowMs: 60_000 }), Transactional()])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -146,7 +146,7 @@ export const login = route.post('/_auth/login')
             oldKeyId: Type.Optional(Type.String({ description: 'Previous key ID for rotation' })),
         }),
     })
-    .use([rateLimit({ limit: 10, windowMs: 60_000 }), Transactional()])
+    .use([rateLimitPolicy('auth-login', { limit: 10, windowMs: 60_000 }), Transactional()])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -222,6 +222,7 @@ export const changePassword = route.put('/_auth/password')
             newPassword: PasswordSchema,
         }),
     })
+    .use([rateLimitPolicy('auth-password-change', { limit: 10, windowMs: 60_000 })])
     .handler(async (c) =>
     {
         const { body } = await c.data();

--- a/packages/auth/src/server/routes/invitations/index.ts
+++ b/packages/auth/src/server/routes/invitations/index.ts
@@ -21,6 +21,7 @@ import {
 } from '../../services';
 import { Type } from '@sinclair/typebox';
 import { Transactional } from '@spfn/core/db';
+import { rateLimitPolicy } from '@spfn/core/middleware';
 import { defineRouter, route } from '@spfn/core/route';
 
 /**
@@ -45,6 +46,7 @@ export const getInvitation = route.get('/_auth/invitations/:token')
             }),
         }),
     })
+    .use([rateLimitPolicy('auth-invitation-lookup', { limit: 30, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -102,7 +104,7 @@ export const acceptInvitation = route.post('/_auth/invitations/accept')
             algorithm: Type.Union(KEY_ALGORITHM.map(algo => Type.Literal(algo)), { description: 'Signature algorithm' }),
         }),
     })
-    .use([Transactional()])
+    .use([rateLimitPolicy('auth-invitation-accept', { limit: 10, windowMs: 60_000 }), Transactional()])
     .skip(['auth'])
     .handler(async (c) =>
     {

--- a/packages/auth/src/server/routes/oauth/index.ts
+++ b/packages/auth/src/server/routes/oauth/index.ts
@@ -11,7 +11,7 @@ import { Type } from '@sinclair/typebox';
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import { Transactional } from '@spfn/core/db';
 import { ValidationError } from '@spfn/core/errors';
-import { rateLimit } from '@spfn/core/middleware';
+import { rateLimitPolicy } from '@spfn/core/middleware';
 import { defineRouter, route } from '@spfn/core/route';
 
 import { KEY_ALGORITHM, SOCIAL_PROVIDERS } from '../../types';
@@ -50,7 +50,7 @@ export const oauthGoogleStart = route.get('/_auth/oauth/google')
             }),
         }),
     })
-    .use([rateLimit({ limit: 20, windowMs: 60_000 })])
+    .use([rateLimitPolicy('oauth-start', { limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -89,7 +89,7 @@ export const oauthGoogleCallback = route.get('/_auth/oauth/google/callback')
             })),
         }),
     })
-    .use([Transactional()])
+    .use([rateLimitPolicy('oauth-callback', { limit: 30, windowMs: 60_000 }), Transactional()])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -163,7 +163,7 @@ export const oauthStart = route.post('/_auth/oauth/start')
             })),
         }),
     })
-    .use([rateLimit({ limit: 20, windowMs: 60_000 })])
+    .use([rateLimitPolicy('oauth-start', { limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -220,6 +220,7 @@ export const getGoogleOAuthUrl = route.post('/_auth/oauth/google/url')
             })),
         }),
     })
+    .use([rateLimitPolicy('oauth-start', { limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -254,6 +255,7 @@ export const oauthFinalize = route.post('/_auth/oauth/finalize')
             returnUrl: Type.Optional(Type.String({ description: 'URL to redirect after login' })),
         }),
     })
+    .use([rateLimitPolicy('oauth-start', { limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -300,7 +302,7 @@ export const oauthProviderStart = route.get('/_auth/oauth/:provider')
             }),
         }),
     })
-    .use([rateLimit({ limit: 20, windowMs: 60_000 })])
+    .use([rateLimitPolicy('oauth-start', { limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -340,7 +342,7 @@ export const oauthProviderCallback = route.get('/_auth/oauth/:provider/callback'
             })),
         }),
     })
-    .use([Transactional()])
+    .use([rateLimitPolicy('oauth-callback', { limit: 30, windowMs: 60_000 }), Transactional()])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -408,6 +410,7 @@ export const getProviderOAuthUrl = route.post('/_auth/oauth/:provider/url')
             })),
         }),
     })
+    .use([rateLimitPolicy('oauth-start', { limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {
@@ -460,6 +463,7 @@ export const oauthNative = route.post('/_auth/oauth/:provider/native')
     })
     // Transactional 미들웨어를 쓰지 않는다. id_token 검증(외부 JWKS 조회)을 트랜잭션 밖에서
     // 먼저 하고, DB 쓰기만 oauthNativeService 내부의 runInTransaction으로 감싼다.
+    .use([rateLimitPolicy('oauth-native', { limit: 20, windowMs: 60_000 })])
     .skip(['auth'])
     .handler(async (c) =>
     {

--- a/packages/auth/src/server/routes/users/index.ts
+++ b/packages/auth/src/server/routes/users/index.ts
@@ -4,6 +4,7 @@
 
 import { getAuth } from '../../helpers';
 import { getUserProfileService, updateUserProfileService, checkUsernameAvailableService, updateUsernameService, updateLocaleService } from '../../services';
+import { rateLimitPolicy } from '@spfn/core/middleware';
 import { defineRouter, route } from '@spfn/core/route';
 import { Type } from '@sinclair/typebox';
 
@@ -78,6 +79,7 @@ export const checkUsername = route.get('/_auth/users/username/check')
             username: Type.String({ minLength: 1 }),
         }),
     })
+    .use([rateLimitPolicy('auth-username-check', { limit: 30, windowMs: 60_000 })])
     .handler(async (c) =>
     {
         const { query } = await c.data();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,11 @@
             "import": "./dist/middleware/index.js",
             "require": "./dist/middleware/index.js"
         },
+        "./security": {
+            "types": "./dist/security/index.d.ts",
+            "import": "./dist/security/index.js",
+            "require": "./dist/security/index.js"
+        },
         "./cache": {
             "types": "./dist/cache/index.d.ts",
             "import": "./dist/cache/index.js",

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -476,4 +476,13 @@ export const coreEnvSchema = defineEnvSchema({
         description: 'When the cache (Redis/Valkey) backing the limiter is unavailable, reject with 429 instead of allowing requests through. Default false (fail open) so development without a cache still works.',
         default: false,
     }),
+
+    // ========================================================================
+    // Outbound request safety (SSRF)
+    // ========================================================================
+
+    SAFE_FETCH_BLOCK_PRIVATE_IPS: envBoolean({
+        description: 'Default for safeFetch (@spfn/core/security): block outbound requests that resolve to private/reserved IP ranges, including the cloud metadata address. Keep true in production; set false only for trusted internal-network calls in development. Overridden by defineServerConfig().outboundFetch({ blockPrivateIps }).',
+        default: true,
+    }),
 });

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -450,4 +450,30 @@ export const coreEnvSchema = defineEnvSchema({
         nextjs: true,
         examples: [1, 2, 3],
     }),
+
+    // ========================================================================
+    // Rate limiting (global default limiter)
+    // ========================================================================
+
+    RATE_LIMIT_MODE: envEnum(['off', 'on'] as const, {
+        description: 'Global default rate limiter. "off": only routes tagged with rateLimitPolicy() are limited. "on": every named-middleware route gets the default limit too (opt out per route with .skip([\'rateLimit\'])). Health/SSE/WebSocket endpoints are always exempt. Overridden by defineServerConfig().rateLimit({ mode }).',
+        default: 'off',
+    }),
+
+    RATE_LIMIT_DEFAULT_LIMIT: envNumber({
+        description: 'Max requests per window for the global default limiter (RATE_LIMIT_MODE=on), counted per route and per client IP.',
+        default: 100,
+        examples: [60, 100, 300],
+    }),
+
+    RATE_LIMIT_DEFAULT_WINDOW_MS: envNumber({
+        description: 'Window length in milliseconds for the global default limiter.',
+        default: 60000,
+        examples: [1000, 60000],
+    }),
+
+    RATE_LIMIT_FAIL_CLOSED: envBoolean({
+        description: 'When the cache (Redis/Valkey) backing the limiter is unavailable, reject with 429 instead of allowing requests through. Default false (fail open) so development without a cache still works.',
+        default: false,
+    }),
 });

--- a/packages/core/src/middleware/README.md
+++ b/packages/core/src/middleware/README.md
@@ -469,9 +469,10 @@ Read these before relying on rate limiting as a security control:
   login/register/code routes already do this via `byIpAndAccount()` / `byIpAndTarget()`.
 - **`getClientIp` trusts forwarded headers.** Behind a verified proxy (proxy-guard) it uses
   the real client IP; otherwise it reads `X-Forwarded-For`/`X-Real-IP`, which a direct client
-  can spoof (rotate to bypass, or pin to a victim to DoS them). If neither header is present
-  it falls back to the literal `'unknown'` — i.e. **all clients share one bucket**. Only
-  enable the global default behind a proxy that sets a trustworthy client IP.
+  can spoof (rotate to bypass, or pin to a victim to DoS them). With no forwarding header it
+  falls back to the TCP peer address (Node adapter), and only to the literal `'unknown'` when
+  even that is unavailable (non-Node runtime). Still: enable the global default behind a proxy
+  that sets a trustworthy client IP, since the header — when present — is taken on trust.
 - **Fail-open by default.** When the cache (Redis) is down, limiters pass requests through.
   Set `RATE_LIMIT_FAIL_CLOSED=true` to reject instead — this now applies to **both** the
   global default and named policy tags (a tag may still opt back to fail-open with

--- a/packages/core/src/middleware/README.md
+++ b/packages/core/src/middleware/README.md
@@ -334,9 +334,11 @@ Replacement token is the literal string `'***MASKED***'`.
 
 ## rateLimit
 
-Redis-backed **fixed-window** rate limiter. Registered under the named `'rateLimit'`
-middleware so a route can opt out with `.skip(['rateLimit'])`. Attach per-route with
-`.use([rateLimit({...})])`.
+Redis-backed **fixed-window** rate limiter. Three ways to apply it: attach per-route with
+`.use([rateLimit({...})])`; enable a [global default](#global-default-limiter) for every route;
+or tag a route with a [named policy](#named-policies--ratelimitpolicyname-fallback) the
+consuming app tunes centrally. The global default and policy tags use the named `'rateLimit'`
+middleware, so routes opt out with `.skip(['rateLimit'])`.
 
 ```typescript
 import { rateLimit, getClientIp } from '@spfn/core/middleware';
@@ -381,6 +383,54 @@ route.post('/_auth/codes')
 > **IP trust caveat**: `getClientIp` reads the leftmost `X-Forwarded-For` hop, which a client
 > can spoof unless a trusted proxy overwrites it. For security-sensitive limits, pair the IP
 > dimension with an account/target dimension rather than relying on IP alone.
+
+### Global default limiter
+
+Turn on a default limiter for **every** route from one place — no per-route `.use()`. It is
+registered as the named `'rateLimit'` middleware, so a route opts out with `.skip(['rateLimit'])`.
+Disabled by default (`mode: 'off'`).
+
+```typescript
+export default defineServerConfig()
+    .rateLimit({
+        mode: 'on',
+        default: { limit: 100, windowMs: 60_000 },
+    })
+    .routes(appRouter)
+    .build();
+```
+
+Or via env: `RATE_LIMIT_MODE=on`, `RATE_LIMIT_DEFAULT_LIMIT`, `RATE_LIMIT_DEFAULT_WINDOW_MS`,
+`RATE_LIMIT_FAIL_CLOSED`. Health, SSE and WebSocket endpoints register outside the
+named-middleware pipeline, so they are always exempt.
+
+### Named policies — `rateLimitPolicy(name, fallback)`
+
+Lets a **package** tag a sensitive route while the **consuming app** tunes the numbers
+centrally. The package ships the tag with a safe fallback; the app overrides it by name.
+
+```typescript
+// in a package (e.g. @spfn/auth)
+route.post('/_auth/login')
+    .use([rateLimitPolicy('auth-login', { limit: 5, windowMs: 60_000 })])
+    .handler(/* ... */);
+
+// in the consuming app — tune every policy in one place
+export default defineServerConfig()
+    .rateLimit({
+        policies: {
+            'auth-login': { limit: 10, windowMs: 60_000 },
+        },
+    })
+    .routes(appRouter)
+    .build();
+```
+
+- **Resolution**: configured policy (by name) wins, shallow-merged over the fallback; with no
+  config the fallback applies, so the route is protected out of the box.
+- **Override**: the tag carries `skips: ['rateLimit']`, so on a route that would also get the
+  global default, the tag replaces it — no double counting.
+- Policies are registered at server boot whether or not the global default is enabled.
 
 ---
 

--- a/packages/core/src/middleware/README.md
+++ b/packages/core/src/middleware/README.md
@@ -365,7 +365,26 @@ route.post('/_auth/codes')
 | `limit` | `number` | — | Max requests per window, applied to **each** dimension. |
 | `windowMs` | `number` | — | Window length in milliseconds. |
 | `scope` | `string` | `` `${method} ${routePath}` `` | Counter-key namespace; defaults to per-route. |
-| `by` | `(c) => (string \| null \| undefined)[]` | `[getClientIp(c)]` | Identity dimensions; each non-empty value is counted separately. |
+| `by` | `(c) => (Dimension \| null \| undefined)[]` | `[getClientIp(c)]` | Identity dimensions; each non-empty value is counted separately, strictest wins. A `Dimension` is a `string` (uses `limit`) or `{ key, limit? }` to give that dimension its own limit. |
+
+Per-dimension limits let one limiter be loose on IP and tight on account/target — so a
+shared NAT isn't throttled as one user while a single account stays protected:
+
+```typescript
+rateLimit({
+    limit: 5,                 // default for dimensions without their own limit
+    windowMs: 60_000,
+    by: (c) => [
+        { key: `ip:${getClientIp(c)}`, limit: 100 }, // loose per-IP floor
+        accountKey(c),                               // tight per-account (uses limit: 5)
+    ],
+});
+```
+
+`@spfn/auth` ships `byIpAndAccount()` / `byIpAndTarget()` builders for exactly this on its
+login, register, and verification-code routes (per-account / per-target tight, per-IP loose),
+so distributed brute force and SMS-bombing are limited by the thing being attacked, not only
+by source IP.
 | `failClosed` | `boolean` | `false` | Reject with 429 when the cache is unavailable instead of allowing through. |
 | `message` | `string` | generic | 429 response message. |
 
@@ -442,13 +461,12 @@ export default defineServerConfig()
 
 Read these before relying on rate limiting as a security control:
 
-- **Keyed by client IP only (unless you set `by`).** Default identity is `getClientIp(c)`.
-  Consequences: a distributed attacker (many source IPs) is **not** stopped per-account —
-  each IP gets its own bucket; and a shared NAT/CGNAT can throttle many real users as one.
-  For account/target protection (credential stuffing, OTP/SMS-bombing) add a `by` dimension
-  that returns a stable account or target key in addition to the IP. The bundled `@spfn/auth`
-  policies are **IP-keyed** — they raise the bar for single-source brute force, not for
-  distributed attacks.
+- **Default identity is the client IP.** A limiter with no `by` keys only on `getClientIp(c)`,
+  so a distributed attacker (many source IPs) isn't stopped per-account and a shared NAT/CGNAT
+  can be throttled as one user. For account/target protection (credential stuffing,
+  OTP/SMS-bombing) add a `by` dimension returning a stable account/target key alongside the IP
+  — ideally with a per-dimension limit (loose IP, tight account). The bundled `@spfn/auth`
+  login/register/code routes already do this via `byIpAndAccount()` / `byIpAndTarget()`.
 - **`getClientIp` trusts forwarded headers.** Behind a verified proxy (proxy-guard) it uses
   the real client IP; otherwise it reads `X-Forwarded-For`/`X-Real-IP`, which a direct client
   can spoof (rotate to bypass, or pin to a victim to DoS them). If neither header is present

--- a/packages/core/src/middleware/README.md
+++ b/packages/core/src/middleware/README.md
@@ -428,8 +428,14 @@ export default defineServerConfig()
 
 - **Resolution**: configured policy (by name) wins, shallow-merged over the fallback; with no
   config the fallback applies, so the route is protected out of the box.
-- **Override**: the tag carries `skips: ['rateLimit']`, so on a route that would also get the
-  global default, the tag replaces it — no double counting.
+- **Layered**: the tag registers under a distinct name (`rateLimit:<name>`) and does **not**
+  skip the global default, so a tagged route gets both — the global per-IP floor (when
+  enabled) *and* this policy's own bucket; whichever is stricter trips first. Opt out of the
+  floor on a route with `.skip(['rateLimit'])`.
+- **Shared bucket**: a policy's counter scope defaults to its name, so every route sharing a
+  policy shares one bucket (e.g. all OAuth start routes share `oauth-start`). It also keeps
+  the key from colliding with the global default's per-route scope. Pass an explicit `scope`
+  to override.
 - Policies are registered at server boot whether or not the global default is enabled.
 
 ### Limitations & operational notes
@@ -452,9 +458,9 @@ Read these before relying on rate limiting as a security control:
   Set `RATE_LIMIT_FAIL_CLOSED=true` to reject instead — this now applies to **both** the
   global default and named policy tags (a tag may still opt back to fail-open with
   `failClosed: false`).
-- **Counters are per-route.** `scope` defaults to `${method} ${routePath}`, so several routes
-  sharing one policy name (e.g. the OAuth start routes) each get their **own** bucket — the
-  name tunes the numbers, it does not pool the counter. Set an explicit `scope` to share one.
+- **Counter scopes differ by layer.** The global default is keyed per-route
+  (`${method} ${routePath}`); a named policy is keyed by its **name**, so routes sharing a
+  policy share one bucket. Pass an explicit `scope` to change either.
 - **The SSE token endpoint is not exempt.** Only the SSE *stream*, WebSocket, and health
   endpoints (registered outside the named-middleware pipeline) bypass the global default;
   `POST /events/token` runs `config.middlewares`, so it receives the limiter too.

--- a/packages/core/src/middleware/README.md
+++ b/packages/core/src/middleware/README.md
@@ -432,6 +432,33 @@ export default defineServerConfig()
   global default, the tag replaces it — no double counting.
 - Policies are registered at server boot whether or not the global default is enabled.
 
+### Limitations & operational notes
+
+Read these before relying on rate limiting as a security control:
+
+- **Keyed by client IP only (unless you set `by`).** Default identity is `getClientIp(c)`.
+  Consequences: a distributed attacker (many source IPs) is **not** stopped per-account —
+  each IP gets its own bucket; and a shared NAT/CGNAT can throttle many real users as one.
+  For account/target protection (credential stuffing, OTP/SMS-bombing) add a `by` dimension
+  that returns a stable account or target key in addition to the IP. The bundled `@spfn/auth`
+  policies are **IP-keyed** — they raise the bar for single-source brute force, not for
+  distributed attacks.
+- **`getClientIp` trusts forwarded headers.** Behind a verified proxy (proxy-guard) it uses
+  the real client IP; otherwise it reads `X-Forwarded-For`/`X-Real-IP`, which a direct client
+  can spoof (rotate to bypass, or pin to a victim to DoS them). If neither header is present
+  it falls back to the literal `'unknown'` — i.e. **all clients share one bucket**. Only
+  enable the global default behind a proxy that sets a trustworthy client IP.
+- **Fail-open by default.** When the cache (Redis) is down, limiters pass requests through.
+  Set `RATE_LIMIT_FAIL_CLOSED=true` to reject instead — this now applies to **both** the
+  global default and named policy tags (a tag may still opt back to fail-open with
+  `failClosed: false`).
+- **Counters are per-route.** `scope` defaults to `${method} ${routePath}`, so several routes
+  sharing one policy name (e.g. the OAuth start routes) each get their **own** bucket — the
+  name tunes the numbers, it does not pool the counter. Set an explicit `scope` to share one.
+- **The SSE token endpoint is not exempt.** Only the SSE *stream*, WebSocket, and health
+  endpoints (registered outside the named-middleware pipeline) bypass the global default;
+  `POST /events/token` runs `config.middlewares`, so it receives the limiter too.
+
 ---
 
 ## Pitfalls & anti-patterns

--- a/packages/core/src/middleware/__tests__/rate-limit.test.ts
+++ b/packages/core/src/middleware/__tests__/rate-limit.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../cache', () => ({
     isCacheDisabled: () => cacheDisabled,
 }));
 
-import { rateLimit } from '../rate-limit';
+import { rateLimit, rateLimitPolicy, setRateLimitPolicies, getRateLimitPolicy } from '../rate-limit';
 import { TooManyRequestsError } from '../../errors';
 
 function makeCtx(headers: Record<string, string> = {})
@@ -99,5 +99,66 @@ describe('rateLimit middleware', () =>
         ).rejects.toBeInstanceOf(TooManyRequestsError);
         expect(next).not.toHaveBeenCalled();
         expect(evalMock).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('rateLimitPolicy named policies', () =>
+{
+    beforeEach(() =>
+    {
+        evalMock.mockReset();
+        cacheClient = { eval: evalMock };
+        cacheDisabled = false;
+        setRateLimitPolicies(undefined);
+    });
+
+    it('registers as a named "rateLimit" middleware that auto-skips the global default', () =>
+    {
+        const tag = rateLimitPolicy('p', { limit: 5, windowMs: 60_000 });
+
+        expect(tag.name).toBe('rateLimit');
+        expect(tag.skips).toEqual(['rateLimit']);
+        expect(typeof tag.handler).toBe('function');
+    });
+
+    it('uses the fallback when the app configured no policy', async () =>
+    {
+        // fallback limit 1, count 2 → over → reject
+        evalMock.mockResolvedValue([2, 60_000]);
+        const next = vi.fn();
+
+        await expect(
+            rateLimitPolicy('p', { limit: 1, windowMs: 60_000 }).handler(makeCtx(), next),
+        ).rejects.toBeInstanceOf(TooManyRequestsError);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('lets a configured policy override the fallback', async () =>
+    {
+        // app raises the limit to 10; count 2 is now under → allowed
+        setRateLimitPolicies({ p: { limit: 10, windowMs: 60_000 } });
+        evalMock.mockResolvedValue([2, 60_000]);
+        const next = vi.fn().mockResolvedValue(undefined);
+
+        await rateLimitPolicy('p', { limit: 1, windowMs: 60_000 }).handler(makeCtx(), next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('shallow-merges configured fields over the fallback', () =>
+    {
+        setRateLimitPolicies({ p: { limit: 50 } as never });
+
+        expect(getRateLimitPolicy('p')).toEqual({ limit: 50 });
+        expect(getRateLimitPolicy('missing')).toBeUndefined();
+    });
+
+    it('setRateLimitPolicies(undefined) clears the registry', () =>
+    {
+        setRateLimitPolicies({ p: { limit: 1, windowMs: 1000 } });
+        expect(getRateLimitPolicy('p')).toBeDefined();
+
+        setRateLimitPolicies(undefined);
+        expect(getRateLimitPolicy('p')).toBeUndefined();
     });
 });

--- a/packages/core/src/middleware/__tests__/rate-limit.test.ts
+++ b/packages/core/src/middleware/__tests__/rate-limit.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../cache', () => ({
     isCacheDisabled: () => cacheDisabled,
 }));
 
-import { rateLimit, rateLimitPolicy, setRateLimitPolicies, getRateLimitPolicy } from '../rate-limit';
+import { rateLimit, rateLimitPolicy, setRateLimitPolicies, getRateLimitPolicy, setRateLimitFailClosedDefault } from '../rate-limit';
 import { TooManyRequestsError } from '../../errors';
 
 function makeCtx(headers: Record<string, string> = {})
@@ -110,6 +110,7 @@ describe('rateLimitPolicy named policies', () =>
         cacheClient = { eval: evalMock };
         cacheDisabled = false;
         setRateLimitPolicies(undefined);
+        setRateLimitFailClosedDefault(false);
     });
 
     it('registers as a named "rateLimit" middleware that auto-skips the global default', () =>
@@ -151,6 +152,26 @@ describe('rateLimitPolicy named policies', () =>
 
         expect(getRateLimitPolicy('p')).toEqual({ limit: 50 });
         expect(getRateLimitPolicy('missing')).toBeUndefined();
+    });
+
+    it('applies the app-wide fail-closed default to a tag (reaches named policies)', async () =>
+    {
+        setRateLimitFailClosedDefault(true);
+        cacheClient = undefined; // cache unavailable
+
+        await expect(rateLimitPolicy('p', { limit: 5, windowMs: 60_000 }).handler(makeCtx(), vi.fn()))
+            .rejects.toBeInstanceOf(TooManyRequestsError);
+    });
+
+    it('a tag/policy may still opt to fail open despite the default', async () =>
+    {
+        setRateLimitFailClosedDefault(true);
+        cacheClient = undefined;
+        const next = vi.fn().mockResolvedValue(undefined);
+
+        await rateLimitPolicy('p', { limit: 5, windowMs: 60_000, failClosed: false }).handler(makeCtx(), next);
+
+        expect(next).toHaveBeenCalledTimes(1);
     });
 
     it('setRateLimitPolicies(undefined) clears the registry', () =>

--- a/packages/core/src/middleware/__tests__/rate-limit.test.ts
+++ b/packages/core/src/middleware/__tests__/rate-limit.test.ts
@@ -100,6 +100,38 @@ describe('rateLimit middleware', () =>
         expect(next).not.toHaveBeenCalled();
         expect(evalMock).toHaveBeenCalledTimes(2);
     });
+
+    it('honors a per-dimension limit — loose IP passes, tight account trips', async () =>
+    {
+        evalMock.mockResolvedValue([6, 30_000]);
+        const next = vi.fn();
+
+        await expect(
+            rateLimit({
+                limit: 5,
+                windowMs: 60_000,
+                by: () => [{ key: 'ip:1.2.3.4', limit: 100 }, 'acct:a@b.com'],
+            })(makeCtx(), next),
+        ).rejects.toBeInstanceOf(TooManyRequestsError);
+
+        // IP dim (limit 100) allowed at count 6; account dim (top-level limit 5) tripped.
+        expect(evalMock).toHaveBeenCalledTimes(2);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('a loose per-dimension limit lets through what the top-level limit would reject', async () =>
+    {
+        evalMock.mockResolvedValue([6, 30_000]);
+        const next = vi.fn().mockResolvedValue(undefined);
+
+        await rateLimit({
+            limit: 5,
+            windowMs: 60_000,
+            by: () => [{ key: 'ip:1.2.3.4', limit: 100 }],
+        })(makeCtx(), next);
+
+        expect(next).toHaveBeenCalledTimes(1); // 6 <= 100
+    });
 });
 
 describe('rateLimitPolicy named policies', () =>

--- a/packages/core/src/middleware/__tests__/rate-limit.test.ts
+++ b/packages/core/src/middleware/__tests__/rate-limit.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../cache', () => ({
     isCacheDisabled: () => cacheDisabled,
 }));
 
-import { rateLimit, rateLimitPolicy, setRateLimitPolicies, getRateLimitPolicy, setRateLimitFailClosedDefault } from '../rate-limit';
+import { rateLimit, rateLimitPolicy, getClientIp, setRateLimitPolicies, getRateLimitPolicy, setRateLimitFailClosedDefault } from '../rate-limit';
 import { TooManyRequestsError } from '../../errors';
 
 function makeCtx(headers: Record<string, string> = {})
@@ -224,5 +224,44 @@ describe('rateLimitPolicy named policies', () =>
 
         setRateLimitPolicies(undefined);
         expect(getRateLimitPolicy('p')).toBeUndefined();
+    });
+});
+
+describe('getClientIp socket fallback', () =>
+{
+    function ipCtx(opts: { headers?: Record<string, string>; env?: unknown; clientType?: string } = {})
+    {
+        const headers = opts.headers ?? {};
+
+        return {
+            req: { header: (name: string) => headers[name.toLowerCase()] },
+            get: (key: string) => (key === 'clientType' ? opts.clientType : undefined),
+            env: opts.env,
+        } as never;
+    }
+
+    it('uses the TCP peer address when no forwarding header is present', () =>
+    {
+        expect(getClientIp(ipCtx({ env: { incoming: { socket: { remoteAddress: '203.0.113.9' } } } }))).toBe('203.0.113.9');
+    });
+
+    it('reads the socket via env.server when the adapter nests bindings', () =>
+    {
+        expect(getClientIp(ipCtx({ env: { server: { incoming: { socket: { remoteAddress: '203.0.113.9' } } } } }))).toBe('203.0.113.9');
+    });
+
+    it('prefers X-Forwarded-For over the socket address', () =>
+    {
+        const c = ipCtx({
+            headers: { 'x-forwarded-for': '198.51.100.1' },
+            env: { incoming: { socket: { remoteAddress: '203.0.113.9' } } },
+        });
+
+        expect(getClientIp(c)).toBe('198.51.100.1');
+    });
+
+    it('returns "unknown" only when nothing identifies the client', () =>
+    {
+        expect(getClientIp(ipCtx())).toBe('unknown');
     });
 });

--- a/packages/core/src/middleware/__tests__/rate-limit.test.ts
+++ b/packages/core/src/middleware/__tests__/rate-limit.test.ts
@@ -113,13 +113,24 @@ describe('rateLimitPolicy named policies', () =>
         setRateLimitFailClosedDefault(false);
     });
 
-    it('registers as a named "rateLimit" middleware that auto-skips the global default', () =>
+    it('registers under a distinct name and layers over (does not skip) the global default', () =>
     {
         const tag = rateLimitPolicy('p', { limit: 5, windowMs: 60_000 });
 
-        expect(tag.name).toBe('rateLimit');
-        expect(tag.skips).toEqual(['rateLimit']);
+        expect(tag.name).toBe('rateLimit:p');
+        expect(tag.skips).toBeUndefined();
         expect(typeof tag.handler).toBe('function');
+    });
+
+    it('defaults the counter scope to the policy name (shared bucket, no collision with global)', async () =>
+    {
+        evalMock.mockResolvedValue([1, 60_000]);
+
+        await rateLimitPolicy('auth-login', { limit: 5, windowMs: 60_000 })
+            .handler(makeCtx({ 'x-forwarded-for': '1.2.3.4' }), vi.fn());
+
+        // key is `ratelimit:${scope}:${dimension}` — scope defaults to the policy name
+        expect(evalMock.mock.calls[0][2]).toBe('ratelimit:auth-login:1.2.3.4');
     });
 
     it('uses the fallback when the app configured no policy', async () =>

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -8,5 +8,5 @@ export { RequestLogger, maskSensitiveData } from './request-logger';
 export type { RequestLoggerOptions, RequestLoggerConfig } from './request-logger';
 export { createProxyGuard, createCacheNonceStore, createInMemoryNonceStore } from './proxy-guard';
 export type { ProxyGuardConfig, ProxyGuardMode, ClientType, NonceStore } from './proxy-guard';
-export { rateLimit, rateLimitPolicy, getClientIp, setRateLimitPolicies, getRateLimitPolicy } from './rate-limit';
+export { rateLimit, rateLimitPolicy, getClientIp, setRateLimitPolicies, getRateLimitPolicy, setRateLimitFailClosedDefault } from './rate-limit';
 export type { RateLimitOptions } from './rate-limit';

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -9,4 +9,4 @@ export type { RequestLoggerOptions, RequestLoggerConfig } from './request-logger
 export { createProxyGuard, createCacheNonceStore, createInMemoryNonceStore } from './proxy-guard';
 export type { ProxyGuardConfig, ProxyGuardMode, ClientType, NonceStore } from './proxy-guard';
 export { rateLimit, rateLimitPolicy, getClientIp, setRateLimitPolicies, getRateLimitPolicy, setRateLimitFailClosedDefault } from './rate-limit';
-export type { RateLimitOptions } from './rate-limit';
+export type { RateLimitOptions, RateLimitDimension } from './rate-limit';

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -8,5 +8,5 @@ export { RequestLogger, maskSensitiveData } from './request-logger';
 export type { RequestLoggerOptions, RequestLoggerConfig } from './request-logger';
 export { createProxyGuard, createCacheNonceStore, createInMemoryNonceStore } from './proxy-guard';
 export type { ProxyGuardConfig, ProxyGuardMode, ClientType, NonceStore } from './proxy-guard';
-export { rateLimit, getClientIp } from './rate-limit';
+export { rateLimit, rateLimitPolicy, getClientIp, setRateLimitPolicies, getRateLimitPolicy } from './rate-limit';
 export type { RateLimitOptions } from './rate-limit';

--- a/packages/core/src/middleware/rate-limit.ts
+++ b/packages/core/src/middleware/rate-limit.ts
@@ -167,6 +167,20 @@ export const rateLimit = defineMiddlewareFactory(
 const policyRegistry = new Map<string, RateLimitOptions>();
 
 /**
+ * App-wide fail-closed default applied to policy tags that don't set `failClosed`
+ * themselves. Set at boot from RATE_LIMIT_FAIL_CLOSED so operators can make ALL
+ * limiters (including named policies on auth routes) reject on cache outage — the
+ * env flag would otherwise only reach the global default limiter.
+ */
+let policyFailClosedDefault = false;
+
+/** Set the fail-closed default for named policies. Called by the server at boot. */
+export function setRateLimitFailClosedDefault(failClosed: boolean): void
+{
+    policyFailClosedDefault = failClosed;
+}
+
+/**
  * Replace the named-policy registry. Called by the server at boot; passing
  * undefined clears it (so a restart without policies doesn't keep stale ones).
  */
@@ -223,7 +237,14 @@ export function rateLimitPolicy(name: string, fallback: RateLimitOptions): Named
         if (!resolved)
         {
             const configured = getRateLimitPolicy(name);
-            resolved = rateLimit(configured ? { ...fallback, ...configured } : fallback);
+            const merged: RateLimitOptions = configured ? { ...fallback, ...configured } : { ...fallback };
+
+            if (merged.failClosed === undefined)
+            {
+                merged.failClosed = policyFailClosedDefault;
+            }
+
+            resolved = rateLimit(merged);
         }
 
         return resolved(c, next);

--- a/packages/core/src/middleware/rate-limit.ts
+++ b/packages/core/src/middleware/rate-limit.ts
@@ -35,9 +35,16 @@ end
 return { count, redis.call('PTTL', KEYS[1]) }
 `;
 
+/**
+ * One identity dimension to limit on. A bare string uses the top-level `limit`;
+ * an object can carry its own `limit` so dimensions can differ (e.g. a loose
+ * per-IP cap alongside a tight per-account cap).
+ */
+export type RateLimitDimension = string | { key: string; limit?: number };
+
 export interface RateLimitOptions
 {
-    /** Max requests allowed per window, applied to each identity dimension. */
+    /** Max requests allowed per window, applied to each dimension without its own `limit`. */
     limit: number;
 
     /** Window length in milliseconds. */
@@ -51,10 +58,11 @@ export interface RateLimitOptions
 
     /**
      * Identity dimensions to limit on. Each non-empty value is counted
-     * separately and the strictest wins (e.g. by IP and by account). Defaults
-     * to the client IP only.
+     * separately and the strictest wins (e.g. by IP and by account). A dimension
+     * may override the top-level `limit` via `{ key, limit }`. Defaults to the
+     * client IP only.
      */
-    by?: (c: Context) => (string | null | undefined)[] | Promise<(string | null | undefined)[]>;
+    by?: (c: Context) => (RateLimitDimension | null | undefined)[] | Promise<(RateLimitDimension | null | undefined)[]>;
 
     /** Reject with 429 instead of allowing through when the cache is unavailable. */
     failClosed?: boolean;
@@ -128,20 +136,28 @@ export const rateLimit = defineMiddlewareFactory(
             }
 
             const dimensions = (by ? await by(c) : [getClientIp(c)])
-                .filter((d): d is string => Boolean(d));
+                .filter((d): d is RateLimitDimension => Boolean(d));
 
             const ns = scope || `${c.req.method} ${c.req.routePath || c.req.path}`;
 
             for (const dimension of dimensions)
             {
+                const key = typeof dimension === 'string' ? dimension : dimension.key;
+                if (!key)
+                {
+                    continue;
+                }
+
+                const dimLimit = typeof dimension === 'string' ? limit : (dimension.limit ?? limit);
+
                 const [count, pttl] = await cache.eval(
                     FIXED_WINDOW_LUA,
                     1,
-                    `ratelimit:${ns}:${dimension}`,
+                    `ratelimit:${ns}:${key}`,
                     String(windowMs),
                 ) as [number, number];
 
-                if (count > limit)
+                if (count > dimLimit)
                 {
                     const retryAfter = Math.max(1, Math.ceil((pttl > 0 ? pttl : windowMs) / 1000));
                     c.header('Retry-After', String(retryAfter));

--- a/packages/core/src/middleware/rate-limit.ts
+++ b/packages/core/src/middleware/rate-limit.ts
@@ -81,6 +81,10 @@ export interface RateLimitOptions
  * the forwarded header is attacker-settable, so fall back to the raw chain — whose
  * leftmost hop is itself spoofable, so still pair with an account/target dimension
  * for anything security-sensitive.
+ *
+ * Last resort before giving up is the TCP peer address from the Node adapter
+ * socket. Without it, a deployment that sets no forwarding header would collapse
+ * every client onto a single `'unknown'` bucket.
  */
 export function getClientIp(c: Context): string
 {
@@ -98,7 +102,24 @@ export function getClientIp(c: Context): string
 
     return forwardedFor?.split(',')[0]?.trim()
         || c.req.header('x-real-ip')
+        || socketRemoteAddress(c)
         || 'unknown';
+}
+
+/**
+ * TCP peer address from the @hono/node-server adapter, when present. Mirrors the
+ * adapter's own getConnInfo access path and degrades to undefined on other
+ * runtimes (Bun/edge) so callers fall through to 'unknown'.
+ */
+function socketRemoteAddress(c: Context): string | undefined
+{
+    const env = c.env as {
+        server?: { incoming?: { socket?: { remoteAddress?: string } } };
+        incoming?: { socket?: { remoteAddress?: string } };
+    } | undefined;
+    const bindings = env?.server ?? env;
+
+    return bindings?.incoming?.socket?.remoteAddress;
 }
 
 /**

--- a/packages/core/src/middleware/rate-limit.ts
+++ b/packages/core/src/middleware/rate-limit.ts
@@ -14,7 +14,8 @@
 
 import type { Context, MiddlewareHandler } from 'hono';
 import { PROXY_CLIENT_IP_HEADER } from '../security/proxy-signature';
-import { defineMiddlewareFactory } from '../route/define-middleware';
+import { defineMiddleware, defineMiddlewareFactory } from '../route/define-middleware';
+import type { NamedMiddleware } from '../route/define-middleware';
 import { getCache, isCacheDisabled } from '../cache';
 import { TooManyRequestsError } from '../errors';
 import { logger } from '../logger';
@@ -156,3 +157,77 @@ export const rateLimit = defineMiddlewareFactory(
         };
     },
 );
+
+/**
+ * Named rate-limit policies, populated once at boot from
+ * `defineServerConfig().rateLimit({ policies })`. A package tags a route with
+ * rateLimitPolicy() and the consuming app supplies the numbers here, so policy
+ * tuning lives in one place rather than being hard-coded in each package.
+ */
+const policyRegistry = new Map<string, RateLimitOptions>();
+
+/**
+ * Replace the named-policy registry. Called by the server at boot; passing
+ * undefined clears it (so a restart without policies doesn't keep stale ones).
+ */
+export function setRateLimitPolicies(policies?: Record<string, RateLimitOptions>): void
+{
+    policyRegistry.clear();
+
+    if (!policies)
+    {
+        return;
+    }
+
+    for (const [name, options] of Object.entries(policies))
+    {
+        policyRegistry.set(name, options);
+    }
+}
+
+/** Look up a configured policy by name — undefined when the app didn't set it. */
+export function getRateLimitPolicy(name: string): RateLimitOptions | undefined
+{
+    return policyRegistry.get(name);
+}
+
+/**
+ * Rate-limit a route under a named policy.
+ *
+ * A package author tags a sensitive route with a policy name plus a safe
+ * fallback; the consuming app tunes the numbers centrally via
+ * `defineServerConfig().rateLimit({ policies: { [name]: {...} } })`. When the
+ * app configures the policy, its fields override the fallback (shallow merge);
+ * otherwise the fallback applies, so the route is protected out of the box.
+ *
+ * Carries `skips: ['rateLimit']` so that on a route which would also receive the
+ * global default limiter, this tag replaces it rather than stacking — no double
+ * counting.
+ *
+ * @example
+ * ```typescript
+ * route.post('/_auth/login')
+ *     .use([rateLimitPolicy('auth-login', { limit: 5, windowMs: 60_000 })])
+ *     .handler(...);
+ * ```
+ */
+export function rateLimitPolicy(name: string, fallback: RateLimitOptions): NamedMiddleware<'rateLimit'>
+{
+    // Resolution is deferred to the first request: the registry is populated at
+    // server boot, which runs after route modules are imported. Cached after the
+    // first hit since the registry is static once the server is up.
+    let resolved: MiddlewareHandler | undefined;
+
+    const handler: MiddlewareHandler = (c, next) =>
+    {
+        if (!resolved)
+        {
+            const configured = getRateLimitPolicy(name);
+            resolved = rateLimit(configured ? { ...fallback, ...configured } : fallback);
+        }
+
+        return resolved(c, next);
+    };
+
+    return defineMiddleware('rateLimit', handler, { skips: ['rateLimit'] });
+}

--- a/packages/core/src/middleware/rate-limit.ts
+++ b/packages/core/src/middleware/rate-limit.ts
@@ -214,9 +214,15 @@ export function getRateLimitPolicy(name: string): RateLimitOptions | undefined
  * app configures the policy, its fields override the fallback (shallow merge);
  * otherwise the fallback applies, so the route is protected out of the box.
  *
- * Carries `skips: ['rateLimit']` so that on a route which would also receive the
- * global default limiter, this tag replaces it rather than stacking — no double
- * counting.
+ * LAYERS on top of the global default limiter rather than replacing it: the tag
+ * has a distinct name (`rateLimit:<name>`) and does not skip the global, so a
+ * route gets both the global per-IP floor (when enabled) and this policy's own
+ * bucket — whichever is stricter trips first. Opt out of the global floor on a
+ * route with `.skip(['rateLimit'])`.
+ *
+ * The counter scope defaults to the policy name, so (a) every route sharing a
+ * policy shares one bucket, and (b) the key never collides with the global
+ * default's per-route `${method} ${path}` scope.
  *
  * @example
  * ```typescript
@@ -225,7 +231,7 @@ export function getRateLimitPolicy(name: string): RateLimitOptions | undefined
  *     .handler(...);
  * ```
  */
-export function rateLimitPolicy(name: string, fallback: RateLimitOptions): NamedMiddleware<'rateLimit'>
+export function rateLimitPolicy(name: string, fallback: RateLimitOptions): NamedMiddleware<string>
 {
     // Resolution is deferred to the first request: the registry is populated at
     // server boot, which runs after route modules are imported. Cached after the
@@ -239,6 +245,11 @@ export function rateLimitPolicy(name: string, fallback: RateLimitOptions): Named
             const configured = getRateLimitPolicy(name);
             const merged: RateLimitOptions = configured ? { ...fallback, ...configured } : { ...fallback };
 
+            if (merged.scope === undefined)
+            {
+                merged.scope = name;
+            }
+
             if (merged.failClosed === undefined)
             {
                 merged.failClosed = policyFailClosedDefault;
@@ -250,5 +261,5 @@ export function rateLimitPolicy(name: string, fallback: RateLimitOptions): Named
         return resolved(c, next);
     };
 
-    return defineMiddleware('rateLimit', handler, { skips: ['rateLimit'] });
+    return defineMiddleware(`rateLimit:${name}`, handler);
 }

--- a/packages/core/src/security/README.md
+++ b/packages/core/src/security/README.md
@@ -1,0 +1,86 @@
+# @spfn/core/security
+
+Helpers for making outbound requests safely. The headline export is **`safeFetch`**,
+an SSRF-hardened drop-in for `fetch`.
+
+## Why
+
+Any time the backend fetches a URL that a user can influence — a webhook target, an
+image URL, an OAuth callback, a `$ref` in stored data — an attacker can point it at an
+internal address (`http://169.254.169.254/…` for cloud credentials, `http://127.0.0.1:…`
+for internal services). That is **SSRF** (Server-Side Request Forgery).
+
+A string allowlist or a "block these hostnames" check does **not** stop it: the attacker
+controls DNS, so `evil.com` can resolve to `169.254.169.254` *after* your check passes
+(**DNS rebinding**). The only robust defense is to resolve the host, validate the
+resolved IP, and **pin the connection to that validated IP**.
+
+## `safeFetch(input, init?)`
+
+Same signature as `fetch`. It:
+
+1. checks the protocol (default `http:`/`https:`) and any host allowlist;
+2. resolves the hostname and rejects if it points at a private/reserved range;
+3. **pins** the connection to a validated IP via a custom undici `lookup`, closing the
+   rebinding window between check and connect;
+4. re-validates every redirect hop (they go through the same dispatcher).
+
+Blocked targets throw `SsrfBlockedError`.
+
+```typescript
+import { safeFetch } from '@spfn/core/security';
+
+const res = await safeFetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+});
+```
+
+## Policy
+
+Private/reserved IPs are blocked by default. Configure the process-wide default once at
+boot, or build a scoped fetch with `createSafeFetch(policy)`:
+
+```typescript
+// server.config.ts — sets the default safeFetch() policy
+export default defineServerConfig()
+    .outboundFetch({ allowHosts: ['hooks.slack.com'] })
+    .build();
+
+// or a one-off, scoped instance (reuse it — it owns a pooled dispatcher)
+import { createSafeFetch } from '@spfn/core/security';
+const fetchSlack = createSafeFetch({ allowHosts: ['hooks.slack.com'] });
+```
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `allowedProtocols` | `string[]` | `['http:','https:']` | Permitted URL schemes. |
+| `blockPrivateIps` | `boolean` | `true` | Block private/reserved ranges (loopback, link-local/metadata, RFC1918, ULA, multicast). |
+| `allowHosts` | `string[]` | — | Exact hostname allowlist (case-insensitive). Strongest control for a known upstream set. |
+
+Env: `SAFE_FETCH_BLOCK_PRIVATE_IPS` sets the boot default for `blockPrivateIps`
+(keep `true` in production; `false` only for trusted internal-network calls in dev).
+
+## `assertSafeUrl(url, policy?)`
+
+When the actual request is made by code you **don't** control (e.g. an app-provided
+storage `download(url)`), you can't pin the connection. Validate the URL first:
+
+```typescript
+import { assertSafeUrl } from '@spfn/core/security';
+
+if (/^https?:\/\//i.test(ref)) await assertSafeUrl(ref); // throws SsrfBlockedError if internal
+return storage.download(ref);
+```
+
+This runs the same protocol/allowlist/DNS-resolution checks but **cannot** prevent
+rebinding between the check and that code's own connection — it raises the bar (blocks
+the obvious metadata/loopback injection) rather than fully closing SSRF. Prefer
+`safeFetch` whenever you own the request.
+
+## Also here
+
+- `isPrivateOrReservedIp(ip)` — the IP classifier, exported for reuse/testing.
+- `proxy-signature` — HMAC signing/verification for the proxy→backend trust path
+  (see `@spfn/core/middleware` proxy-guard).

--- a/packages/core/src/security/README.md
+++ b/packages/core/src/security/README.md
@@ -23,7 +23,13 @@ Same signature as `fetch`. It:
 2. resolves the hostname and rejects if it points at a private/reserved range;
 3. **pins** the connection to a validated IP via a custom undici `lookup`, closing the
    rebinding window between check and connect;
-4. re-validates every redirect hop (they go through the same dispatcher).
+4. follows redirects **manually** and re-validates **every hop** — including a hop whose
+   target is a bare IP literal (which undici would otherwise connect to directly, skipping
+   the pinning lookup). Capped at `maxRedirects` (default 5).
+
+The original method, body, and headers are **not** replayed across a redirect: the next
+hop may be attacker-chosen, so forwarding the payload or auth headers would leak them — the
+redirected request is issued as a header-less `GET`.
 
 Blocked targets throw `SsrfBlockedError`.
 
@@ -56,11 +62,19 @@ const fetchSlack = createSafeFetch({ allowHosts: ['hooks.slack.com'] });
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `allowedProtocols` | `string[]` | `['http:','https:']` | Permitted URL schemes. |
-| `blockPrivateIps` | `boolean` | `true` | Block private/reserved ranges (loopback, link-local/metadata, RFC1918, ULA, multicast). |
-| `allowHosts` | `string[]` | — | Exact hostname allowlist (case-insensitive). Strongest control for a known upstream set. |
+| `blockPrivateIps` | `boolean` | `true` | Block private/reserved ranges (loopback, link-local/metadata, RFC1918, CGNAT, ULA, multicast, NAT64/6to4). |
+| `allowHosts` | `string[]` | — | Exact hostname allowlist (case-insensitive), enforced on every redirect hop. Strongest control for a known upstream set. |
+| `maxRedirects` | `number` | `5` | Redirects to follow, each re-validated. |
 
 Env: `SAFE_FETCH_BLOCK_PRIVATE_IPS` sets the boot default for `blockPrivateIps`
 (keep `true` in production; `false` only for trusted internal-network calls in dev).
+
+> **Compatibility note.** The Slack webhook sender (`@spfn/notification`) now routes
+> through `safeFetch`, so a webhook pointed at a **private/internal address** (self-hosted
+> Mattermost, an internal Slack-compatible endpoint on `10.x`/`192.168.x`, etc.) will now
+> fail to send. Allow it explicitly with `outboundFetch({ allowHosts: ['your.host'] })`, or
+> — if the target is a raw private IP — `outboundFetch({ blockPrivateIps: false })` (which
+> relaxes the check for *all* outbound calls, so prefer `allowHosts`).
 
 ## `assertSafeUrl(url, policy?)`
 

--- a/packages/core/src/security/__tests__/safe-fetch-redirect.test.ts
+++ b/packages/core/src/security/__tests__/safe-fetch-redirect.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @spfn/core - safeFetch redirect validation tests
+ *
+ * Regression guard for the SSRF redirect bypass: undici does not invoke the
+ * pinning lookup for IP-literal targets, and the first-hop URL check doesn't
+ * run on redirects — so a public first hop returning `302 → http://10.x` could
+ * reach an internal address. createSafeFetch must re-validate every hop.
+ *
+ * undici is mocked: we assert which URLs reach dispatch and which are blocked
+ * before dispatch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchMock = vi.fn();
+
+vi.mock('undici', () => ({
+    fetch: (...args: unknown[]) => fetchMock(...args),
+    Agent: class
+    {
+        close(): Promise<void> 
+        {
+            return Promise.resolve(); 
+        }
+    },
+}));
+
+import { createSafeFetch, SsrfBlockedError } from '../safe-fetch';
+
+function mockResponse(status: number, location: string | null)
+{
+    return {
+        status,
+        headers: { get: (k: string) => (k.toLowerCase() === 'location' ? location : null) },
+        body: { cancel: () => Promise.resolve() },
+    };
+}
+
+describe('createSafeFetch redirect validation', () =>
+{
+    beforeEach(() => fetchMock.mockReset());
+
+    it('blocks a redirect to a private IP literal (the headline bypass)', async () =>
+    {
+        fetchMock.mockResolvedValueOnce(mockResponse(302, 'http://169.254.169.254/latest/meta-data'));
+
+        const safe = createSafeFetch();
+
+        await expect(safe('https://public.example.com')).rejects.toBeInstanceOf(SsrfBlockedError);
+        // First hop dispatched; the private redirect target is rejected BEFORE a second dispatch.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('blocks a redirect to loopback', async () =>
+    {
+        fetchMock.mockResolvedValueOnce(mockResponse(301, 'http://127.0.0.1:8080/admin'));
+
+        await expect(createSafeFetch()('https://public.example.com')).rejects.toBeInstanceOf(SsrfBlockedError);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('follows a redirect to a public host, without replaying method/body', async () =>
+    {
+        fetchMock
+            .mockResolvedValueOnce(mockResponse(302, 'https://other-public.example.com/'))
+            .mockResolvedValueOnce(mockResponse(200, null));
+
+        const res = await createSafeFetch()('https://public.example.com', { method: 'POST', body: 'secret' });
+
+        expect(res.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        // Redirect hop must not forward the original POST body/headers to the new host.
+        expect(fetchMock.mock.calls[1][1].method).toBe('GET');
+        expect(fetchMock.mock.calls[1][1].body).toBeUndefined();
+        expect(fetchMock.mock.calls[1][1].redirect).toBe('manual');
+    });
+
+    it('enforces allowHosts on the redirect target, not just the first hop', async () =>
+    {
+        fetchMock.mockResolvedValueOnce(mockResponse(302, 'https://evil.example.com/'));
+
+        const safe = createSafeFetch({ allowHosts: ['hooks.slack.com'] });
+
+        await expect(safe('https://hooks.slack.com/services/x')).rejects.toBeInstanceOf(SsrfBlockedError);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('caps redirect chains', async () =>
+    {
+        fetchMock.mockResolvedValue(mockResponse(302, 'https://loop.example.com/'));
+
+        await expect(createSafeFetch({ maxRedirects: 3 })('https://public.example.com'))
+            .rejects.toBeInstanceOf(SsrfBlockedError);
+        expect(fetchMock).toHaveBeenCalledTimes(4); // hops 0..3, then capped
+    });
+});

--- a/packages/core/src/security/__tests__/safe-fetch.test.ts
+++ b/packages/core/src/security/__tests__/safe-fetch.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @spfn/core - safeFetch / SSRF guard tests
+ *
+ * DNS is mocked so hostname resolution is deterministic without a network.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const lookupMock = vi.fn();
+
+vi.mock('node:dns', () => ({
+    promises: { lookup: (...args: unknown[]) => lookupMock(...args) },
+}));
+
+import {
+    isPrivateOrReservedIp,
+    assertSafeUrl,
+    SsrfBlockedError,
+    setDefaultSafeFetchPolicy,
+} from '../safe-fetch';
+
+describe('isPrivateOrReservedIp', () =>
+{
+    it('flags private and reserved IPv4', () =>
+    {
+        for (const ip of ['127.0.0.1', '10.1.2.3', '172.16.0.1', '192.168.1.1', '169.254.169.254', '0.0.0.0', '100.64.0.1'])
+        {
+            expect(isPrivateOrReservedIp(ip)).toBe(true);
+        }
+    });
+
+    it('allows public IPv4', () =>
+    {
+        for (const ip of ['8.8.8.8', '1.1.1.1', '93.184.216.34'])
+        {
+            expect(isPrivateOrReservedIp(ip)).toBe(false);
+        }
+    });
+
+    it('handles IPv6 loopback / ULA / link-local and IPv4-mapped', () =>
+    {
+        expect(isPrivateOrReservedIp('::1')).toBe(true);
+        expect(isPrivateOrReservedIp('fc00::1')).toBe(true);
+        expect(isPrivateOrReservedIp('fe80::1')).toBe(true);
+        expect(isPrivateOrReservedIp('::ffff:127.0.0.1')).toBe(true);
+        expect(isPrivateOrReservedIp('2606:4700:4700::1111')).toBe(false);
+        expect(isPrivateOrReservedIp('::ffff:8.8.8.8')).toBe(false);
+    });
+
+    it('treats a non-IP string as unsafe', () =>
+    {
+        expect(isPrivateOrReservedIp('not-an-ip')).toBe(true);
+    });
+});
+
+describe('assertSafeUrl', () =>
+{
+    beforeEach(() =>
+    {
+        lookupMock.mockReset();
+        setDefaultSafeFetchPolicy(undefined);
+    });
+
+    it('rejects non-http(s) protocols', async () =>
+    {
+        await expect(assertSafeUrl('file:///etc/passwd')).rejects.toBeInstanceOf(SsrfBlockedError);
+        await expect(assertSafeUrl('ftp://example.com')).rejects.toBeInstanceOf(SsrfBlockedError);
+        expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a private IP literal without any DNS lookup', async () =>
+    {
+        await expect(assertSafeUrl('http://169.254.169.254/latest/meta-data')).rejects.toBeInstanceOf(SsrfBlockedError);
+        await expect(assertSafeUrl('http://127.0.0.1:8080')).rejects.toBeInstanceOf(SsrfBlockedError);
+        expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a hostname that resolves to a private address', async () =>
+    {
+        lookupMock.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+
+        await expect(assertSafeUrl('http://evil.example.com')).rejects.toBeInstanceOf(SsrfBlockedError);
+        expect(lookupMock).toHaveBeenCalledOnce();
+    });
+
+    it('allows a hostname that resolves to a public address', async () =>
+    {
+        lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+
+        await expect(assertSafeUrl('https://example.com')).resolves.toBeUndefined();
+    });
+
+    it('rejects when any resolved address is private (rebinding-style multi-answer)', async () =>
+    {
+        lookupMock.mockResolvedValue([
+            { address: '93.184.216.34', family: 4 },
+            { address: '10.0.0.5', family: 4 },
+        ]);
+
+        await expect(assertSafeUrl('https://example.com')).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    it('enforces an explicit host allowlist', async () =>
+    {
+        lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+
+        await expect(assertSafeUrl('https://hooks.slack.com/x', { allowHosts: ['hooks.slack.com'] }))
+            .resolves.toBeUndefined();
+        await expect(assertSafeUrl('https://example.com', { allowHosts: ['hooks.slack.com'] }))
+            .rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    it('skips private-IP checks when blockPrivateIps is false', async () =>
+    {
+        await expect(assertSafeUrl('http://127.0.0.1:5432', { blockPrivateIps: false }))
+            .resolves.toBeUndefined();
+    });
+});

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @spfn/core/security - Outbound request safety helpers
+ */
+
+export {
+    safeFetch,
+    createSafeFetch,
+    assertSafeUrl,
+    isPrivateOrReservedIp,
+    setDefaultSafeFetchPolicy,
+    getDefaultSafeFetchPolicy,
+    SsrfBlockedError,
+} from './safe-fetch';
+export type { SafeFetchPolicy } from './safe-fetch';

--- a/packages/core/src/security/safe-fetch.ts
+++ b/packages/core/src/security/safe-fetch.ts
@@ -40,9 +40,15 @@ export interface SafeFetchPolicy
     /**
      * Exact hostname allowlist (case-insensitive). When set, only these hosts
      * are reachable — the strongest control for a known set of upstreams.
+     * Enforced on every redirect hop, not just the first URL.
      */
     allowHosts?: string[];
+
+    /** Max redirects to follow, each re-validated. @default 5 */
+    maxRedirects?: number;
 }
+
+const DEFAULT_MAX_REDIRECTS = 5;
 
 const DEFAULTS: Required<Pick<SafeFetchPolicy, 'allowedProtocols' | 'blockPrivateIps'>> = {
     allowedProtocols: ['http:', 'https:'],
@@ -81,6 +87,9 @@ const blockedRanges = (() =>
     list.addSubnet('fe80::', 10, 'ipv6');       // link-local
     list.addSubnet('ff00::', 8, 'ipv6');        // multicast
     list.addSubnet('2001:db8::', 32, 'ipv6');   // documentation
+    list.addSubnet('64:ff9b::', 96, 'ipv6');    // NAT64 well-known prefix (can wrap private v4)
+    list.addSubnet('2002::', 16, 'ipv6');       // 6to4 (can wrap private v4)
+    list.addSubnet('192.88.99.0', 24, 'ipv4');  // 6to4 anycast relay
 
     return list;
 })();
@@ -249,21 +258,58 @@ function urlOf(input: FetchInput): string
     return (input as { url: string }).url;
 }
 
+type SafeFetchFn = ((input: FetchInput, init?: FetchInit) => FetchReturn) & { _dispatcher: Agent };
+
 /**
  * Build an SSRF-safe fetch bound to a policy. Reuse the returned function (it
  * owns a pooled dispatcher) rather than calling this per request.
+ *
+ * Redirects are followed manually so EVERY hop is validated — including a hop
+ * whose target is a bare IP literal, which undici would otherwise connect to
+ * directly without invoking the pinning lookup. The original method/body and
+ * headers are NOT replayed across a redirect: the next hop may be attacker-
+ * chosen, so forwarding the payload or auth headers would leak them.
  */
-export function createSafeFetch(policy: SafeFetchPolicy = {})
+export function createSafeFetch(policy: SafeFetchPolicy = {}): SafeFetchFn
 {
     const merged = { ...DEFAULTS, ...policy };
+    const maxRedirects = merged.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
     const dispatcher = new Agent({ connect: { lookup: pinnedLookup(merged) } });
 
-    return (input: FetchInput, init?: FetchInit): FetchReturn =>
+    const run = async (input: FetchInput, init?: FetchInit): Promise<Awaited<FetchReturn>> =>
     {
-        assertUrlAllowed(urlOf(input), merged);
+        let url = urlOf(input);
+        let hopInit: FetchInit = init;
 
-        return undiciFetch(input, { ...init, dispatcher });
+        for (let hop = 0; ; hop++)
+        {
+            assertUrlAllowed(url, merged);
+
+            const res = await undiciFetch(url, { ...hopInit, dispatcher, redirect: 'manual' });
+
+            const location = res.status >= 300 && res.status < 400 ? res.headers.get('location') : null;
+            if (!location)
+            {
+                return res;
+            }
+
+            await res.body?.cancel().catch(() => 
+            {});
+
+            if (hop >= maxRedirects)
+            {
+                throw new SsrfBlockedError(`Too many redirects (> ${maxRedirects})`);
+            }
+
+            url = new URL(location, url).href;
+            hopInit = { method: 'GET' };
+        }
     };
+
+    const fn = ((input: FetchInput, init?: FetchInit) => run(input, init)) as SafeFetchFn;
+    fn._dispatcher = dispatcher;
+
+    return fn;
 }
 
 // ---------------------------------------------------------------------------
@@ -271,7 +317,7 @@ export function createSafeFetch(policy: SafeFetchPolicy = {})
 // ---------------------------------------------------------------------------
 
 let configuredPolicy: SafeFetchPolicy = {};
-let cachedDefaultFetch: ReturnType<typeof createSafeFetch> | undefined;
+let cachedDefaultFetch: SafeFetchFn | undefined;
 
 /**
  * Replace the default policy used by {@link safeFetch}. Called by the server at
@@ -280,6 +326,10 @@ let cachedDefaultFetch: ReturnType<typeof createSafeFetch> | undefined;
  */
 export function setDefaultSafeFetchPolicy(policy?: SafeFetchPolicy): void
 {
+    // Close the previous dispatcher's connection pool so repeated boots
+    // (tests, multi-app processes) don't leak Agents.
+    cachedDefaultFetch?._dispatcher.close().catch(() => 
+    {});
     configuredPolicy = policy ?? {};
     cachedDefaultFetch = undefined;
 }

--- a/packages/core/src/security/safe-fetch.ts
+++ b/packages/core/src/security/safe-fetch.ts
@@ -1,0 +1,302 @@
+/**
+ * @spfn/core - SSRF-safe outbound fetch
+ *
+ * A drop-in `fetch` for calling URLs that may be influenced by user input
+ * (webhooks, image fetchers, callback URLs). It blocks requests to private and
+ * reserved IP ranges — including the cloud metadata address (169.254.169.254) —
+ * and defeats DNS rebinding by resolving the hostname, validating every returned
+ * address, and pinning the connection to a validated IP via a custom undici
+ * `lookup`. Redirects go through the same dispatcher, so each hop is re-validated.
+ *
+ * A plain string allowlist cannot stop SSRF on its own: an attacker-controlled
+ * hostname can resolve to a private IP (DNS rebinding). The pinning is the point.
+ */
+
+import { promises as dnsPromises } from 'node:dns';
+import { isIP, BlockList, type LookupFunction } from 'node:net';
+import { fetch as undiciFetch, Agent } from 'undici';
+
+/** Thrown when a request target is blocked by the SSRF policy. */
+export class SsrfBlockedError extends Error
+{
+    constructor(message: string)
+    {
+        super(message);
+        this.name = 'SsrfBlockedError';
+    }
+}
+
+export interface SafeFetchPolicy
+{
+    /** URL schemes allowed. @default ['http:', 'https:'] */
+    allowedProtocols?: string[];
+
+    /**
+     * Reject targets that resolve to a private or reserved IP range (loopback,
+     * link-local/metadata, RFC1918, ULA, multicast, …). @default true
+     */
+    blockPrivateIps?: boolean;
+
+    /**
+     * Exact hostname allowlist (case-insensitive). When set, only these hosts
+     * are reachable — the strongest control for a known set of upstreams.
+     */
+    allowHosts?: string[];
+}
+
+const DEFAULTS: Required<Pick<SafeFetchPolicy, 'allowedProtocols' | 'blockPrivateIps'>> = {
+    allowedProtocols: ['http:', 'https:'],
+    blockPrivateIps: true,
+};
+
+/**
+ * Private/reserved IP ranges. Built once. `BlockList` handles CIDR membership
+ * for both families; IPv4-mapped IPv6 is unwrapped and checked as IPv4 so a
+ * mapped public address still resolves.
+ */
+const blockedRanges = (() =>
+{
+    const list = new BlockList();
+
+    // IPv4 — RFC 1918 + special-purpose / reserved
+    list.addSubnet('0.0.0.0', 8, 'ipv4');
+    list.addSubnet('10.0.0.0', 8, 'ipv4');
+    list.addSubnet('100.64.0.0', 10, 'ipv4');   // CGNAT
+    list.addSubnet('127.0.0.0', 8, 'ipv4');     // loopback
+    list.addSubnet('169.254.0.0', 16, 'ipv4');  // link-local incl. cloud metadata
+    list.addSubnet('172.16.0.0', 12, 'ipv4');
+    list.addSubnet('192.0.0.0', 24, 'ipv4');
+    list.addSubnet('192.0.2.0', 24, 'ipv4');    // TEST-NET-1
+    list.addSubnet('192.168.0.0', 16, 'ipv4');
+    list.addSubnet('198.18.0.0', 15, 'ipv4');   // benchmarking
+    list.addSubnet('198.51.100.0', 24, 'ipv4'); // TEST-NET-2
+    list.addSubnet('203.0.113.0', 24, 'ipv4');  // TEST-NET-3
+    list.addSubnet('224.0.0.0', 4, 'ipv4');     // multicast
+    list.addSubnet('240.0.0.0', 4, 'ipv4');     // reserved + broadcast
+
+    // IPv6
+    list.addAddress('::1', 'ipv6');             // loopback
+    list.addAddress('::', 'ipv6');              // unspecified
+    list.addSubnet('fc00::', 7, 'ipv6');        // unique local
+    list.addSubnet('fe80::', 10, 'ipv6');       // link-local
+    list.addSubnet('ff00::', 8, 'ipv6');        // multicast
+    list.addSubnet('2001:db8::', 32, 'ipv6');   // documentation
+
+    return list;
+})();
+
+/**
+ * Whether an IP literal falls in a private or reserved range. A non-IP input is
+ * treated as unsafe (`true`) — callers pass resolved addresses, never hostnames.
+ */
+export function isPrivateOrReservedIp(ip: string): boolean
+{
+    const family = isIP(ip);
+
+    if (family === 4)
+    {
+        return blockedRanges.check(ip, 'ipv4');
+    }
+
+    if (family === 6)
+    {
+        // IPv4-mapped (::ffff:a.b.c.d): judge by the embedded IPv4.
+        const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
+        if (mapped)
+        {
+            return blockedRanges.check(mapped[1], 'ipv4');
+        }
+
+        return blockedRanges.check(ip, 'ipv6');
+    }
+
+    return true;
+}
+
+function stripBrackets(hostname: string): string
+{
+    return hostname.replace(/^\[/, '').replace(/\]$/, '');
+}
+
+/**
+ * Synchronous, no-DNS checks: protocol, host allowlist, and — when the host is
+ * an IP literal — the private-range check. Throws SsrfBlockedError on violation.
+ */
+function assertUrlAllowed(rawUrl: string, policy: SafeFetchPolicy): URL
+{
+    let url: URL;
+    try
+    {
+        url = new URL(rawUrl);
+    }
+    catch
+    {
+        throw new SsrfBlockedError(`Invalid URL: ${rawUrl}`);
+    }
+
+    const protocols = policy.allowedProtocols ?? DEFAULTS.allowedProtocols;
+    if (!protocols.includes(url.protocol))
+    {
+        throw new SsrfBlockedError(`Protocol not allowed: ${url.protocol}`);
+    }
+
+    const host = stripBrackets(url.hostname);
+
+    if (policy.allowHosts)
+    {
+        const allowed = policy.allowHosts.some(h => h.toLowerCase() === host.toLowerCase());
+        if (!allowed)
+        {
+            throw new SsrfBlockedError(`Host not in allowlist: ${host}`);
+        }
+    }
+
+    if (policy.blockPrivateIps !== false && isIP(host) && isPrivateOrReservedIp(host))
+    {
+        throw new SsrfBlockedError(`Blocked address: ${host}`);
+    }
+
+    return url;
+}
+
+/**
+ * Validate a URL for SSRF without making the request: runs the sync checks and,
+ * for hostnames, resolves DNS and rejects if any address is private/reserved.
+ *
+ * Use this to guard a URL handed to code you do not control (so you cannot pin
+ * the connection). It cannot prevent rebinding between this check and that
+ * code's own connection — for requests you make yourself, use {@link safeFetch}.
+ */
+export async function assertSafeUrl(rawUrl: string, policy?: SafeFetchPolicy): Promise<void>
+{
+    const merged = { ...getDefaultSafeFetchPolicy(), ...policy };
+    const url = assertUrlAllowed(rawUrl, merged);
+    const host = stripBrackets(url.hostname);
+
+    // IP literals are fully judged by assertUrlAllowed; only hostnames need DNS.
+    if (isIP(host) || merged.blockPrivateIps === false)
+    {
+        return;
+    }
+
+    const addresses = await dnsPromises.lookup(host, { all: true });
+    for (const { address } of addresses)
+    {
+        if (isPrivateOrReservedIp(address))
+        {
+            throw new SsrfBlockedError(`Host resolves to a blocked address: ${host} → ${address}`);
+        }
+    }
+}
+
+/**
+ * Custom DNS lookup for undici: resolve, drop private/reserved addresses, and
+ * return only validated ones — so the connection is pinned to an address we
+ * already checked (no rebinding window between check and connect).
+ */
+function pinnedLookup(policy: SafeFetchPolicy): LookupFunction
+{
+    return (hostname, options, callback) =>
+    {
+        const family = typeof options === 'object' && typeof options.family === 'number' ? options.family : 0;
+        const wantsAll = typeof options === 'object' && options.all === true;
+
+        dnsPromises.lookup(hostname, { all: true, verbatim: true, family }).then(
+            (addresses) =>
+            {
+                const safe = policy.blockPrivateIps === false
+                    ? addresses
+                    : addresses.filter(a => !isPrivateOrReservedIp(a.address));
+
+                if (safe.length === 0)
+                {
+                    callback(new SsrfBlockedError(`Host resolves only to blocked addresses: ${hostname}`), '', 0);
+
+                    return;
+                }
+
+                if (wantsAll)
+                {
+                    (callback as unknown as (err: null, addresses: typeof safe) => void)(null, safe);
+
+                    return;
+                }
+
+                callback(null, safe[0].address, safe[0].family);
+            },
+            (err: NodeJS.ErrnoException) => callback(err, '', 0),
+        );
+    };
+}
+
+type FetchInput = Parameters<typeof undiciFetch>[0];
+
+type FetchInit = Parameters<typeof undiciFetch>[1];
+
+type FetchReturn = ReturnType<typeof undiciFetch>;
+
+function urlOf(input: FetchInput): string
+{
+    if (typeof input === 'string')
+    {
+        return input;
+    }
+    if (input instanceof URL)
+    {
+        return input.href;
+    }
+
+    return (input as { url: string }).url;
+}
+
+/**
+ * Build an SSRF-safe fetch bound to a policy. Reuse the returned function (it
+ * owns a pooled dispatcher) rather than calling this per request.
+ */
+export function createSafeFetch(policy: SafeFetchPolicy = {})
+{
+    const merged = { ...DEFAULTS, ...policy };
+    const dispatcher = new Agent({ connect: { lookup: pinnedLookup(merged) } });
+
+    return (input: FetchInput, init?: FetchInit): FetchReturn =>
+    {
+        assertUrlAllowed(urlOf(input), merged);
+
+        return undiciFetch(input, { ...init, dispatcher });
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Default policy registry — set once at server boot, read by safeFetch().
+// ---------------------------------------------------------------------------
+
+let configuredPolicy: SafeFetchPolicy = {};
+let cachedDefaultFetch: ReturnType<typeof createSafeFetch> | undefined;
+
+/**
+ * Replace the default policy used by {@link safeFetch}. Called by the server at
+ * boot from `defineServerConfig().outboundFetch(...)`. Passing undefined resets
+ * to the secure defaults (private IPs blocked, http/https only).
+ */
+export function setDefaultSafeFetchPolicy(policy?: SafeFetchPolicy): void
+{
+    configuredPolicy = policy ?? {};
+    cachedDefaultFetch = undefined;
+}
+
+/** The effective default policy (secure defaults merged with any configured overrides). */
+export function getDefaultSafeFetchPolicy(): SafeFetchPolicy
+{
+    return { ...DEFAULTS, ...configuredPolicy };
+}
+
+/**
+ * SSRF-safe `fetch` using the configured default policy. Drop-in replacement for
+ * `fetch` when the URL may be influenced by user input.
+ */
+export function safeFetch(input: FetchInput, init?: FetchInit): FetchReturn
+{
+    cachedDefaultFetch ??= createSafeFetch(getDefaultSafeFetchPolicy());
+
+    return cachedDefaultFetch(input, init);
+}

--- a/packages/core/src/server/config-builder.ts
+++ b/packages/core/src/server/config-builder.ts
@@ -149,6 +149,22 @@ export class ServerConfigBuilder
     }
 
     /**
+     * Configure the SSRF policy for outbound `safeFetch` calls (webhooks,
+     * callbacks). Private/reserved IPs are blocked by default.
+     *
+     * @example
+     * ```typescript
+     * .outboundFetch({ allowHosts: ['hooks.slack.com'] })
+     * ```
+     */
+    outboundFetch(outboundFetch: ServerConfig['outboundFetch']): this
+    {
+        this.config.outboundFetch = outboundFetch;
+
+        return this;
+    }
+
+    /**
      * Register define-route based router
      *
      * Automatically applies:

--- a/packages/core/src/server/config-builder.ts
+++ b/packages/core/src/server/config-builder.ts
@@ -129,6 +129,26 @@ export class ServerConfigBuilder
     }
 
     /**
+     * Configure rate limiting: an optional global default limiter plus the named
+     * policies that `rateLimitPolicy(name, fallback)` tags resolve against.
+     *
+     * @example
+     * ```typescript
+     * .rateLimit({
+     *     mode: 'on',
+     *     default: { limit: 100, windowMs: 60_000 },
+     *     policies: { 'auth-login': { limit: 5, windowMs: 60_000 } },
+     * })
+     * ```
+     */
+    rateLimit(rateLimit: ServerConfig['rateLimit']): this
+    {
+        this.config.rateLimit = rateLimit;
+
+        return this;
+    }
+
+    /**
      * Register define-route based router
      *
      * Automatically applies:

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -9,8 +9,9 @@ import { cors } from 'hono/cors';
 import { existsSync } from 'fs';
 import { join } from 'path';
 
-import { registerRoutes, type RegisteredRoute } from '@spfn/core/route';
-import { ErrorHandler, RequestLogger } from '@spfn/core/middleware';
+import { registerRoutes, defineMiddleware, type RegisteredRoute } from '@spfn/core/route';
+import { ErrorHandler, RequestLogger, rateLimit, setRateLimitPolicies } from '@spfn/core/middleware';
+import { env } from '@spfn/core/config';
 import { createSSEHandler } from '../event/sse/handler';
 import { SSETokenManager, CacheTokenStore } from '../event/sse/token-manager';
 import { wireEventRouterCache } from '../event/cache-transport';
@@ -18,7 +19,7 @@ import { createHealthCheckHandler } from './helpers';
 import { serverLogger } from './logger';
 
 import type { ServerConfig, AppFactory } from './types';
-import type { NonceStore } from '@spfn/core/middleware';
+import type { NonceStore, RateLimitOptions } from '@spfn/core/middleware';
 
 // Extend Hono context with error handler flag
 declare module 'hono'
@@ -74,6 +75,10 @@ async function loadCustomApp(
     // Register routes (if provided via config)
     if (config?.routes)
     {
+        // Populate rate-limit policies and (optionally) the global default limiter
+        // before routes are registered, so policy tags resolve and skip works.
+        applyRateLimit(config);
+
         const routes = registerRoutes(app, config.routes, config.middlewares);
         logRegisteredRoutes(routes, config?.debug ?? false);
     }
@@ -105,6 +110,9 @@ async function createAutoConfiguredApp(config?: ServerConfig): Promise<Hono>
 
     // 2.5 Proxy-guard (trusted-proxy signature + origin verification)
     await applyProxyGuard(app, config);
+
+    // 2.6 Rate limit: register named policies + optional global default limiter
+    applyRateLimit(config);
 
     // 3. Custom middleware
     if (Array.isArray(config?.use))
@@ -224,6 +232,41 @@ async function applyProxyGuard(app: Hono, config?: ServerConfig): Promise<void>
     }));
 
     serverLogger.info(`✓ Proxy-guard enabled (mode: ${mode})`);
+}
+
+/**
+ * Wire rate limiting before routes register.
+ *
+ * Always publishes the named-policy registry (so `rateLimitPolicy()` tags resolve
+ * even when the global default is off). When enabled, prepends a named 'rateLimit'
+ * middleware carrying the default policy — routes opt out with `.skip(['rateLimit'])`
+ * and policy tags override it via their `skips: ['rateLimit']`. Health, SSE and
+ * WebSocket endpoints register outside the named-middleware pipeline, so they are
+ * naturally exempt from the global default.
+ */
+function applyRateLimit(config?: ServerConfig): void
+{
+    const rl = config?.rateLimit;
+
+    setRateLimitPolicies(rl?.policies);
+
+    const enabled = (rl?.mode ?? env.RATE_LIMIT_MODE) === 'on';
+    if (!enabled || !config)
+    {
+        return;
+    }
+
+    const defaultPolicy: RateLimitOptions = rl?.default ?? {
+        limit: env.RATE_LIMIT_DEFAULT_LIMIT,
+        windowMs: env.RATE_LIMIT_DEFAULT_WINDOW_MS,
+        failClosed: env.RATE_LIMIT_FAIL_CLOSED,
+    };
+
+    const globalRateLimit = defineMiddleware('rateLimit', rateLimit(defaultPolicy));
+
+    config.middlewares = [globalRateLimit, ...(config.middlewares ?? [])];
+
+    serverLogger.info(`✓ Rate limit default enabled (${defaultPolicy.limit} per ${defaultPolicy.windowMs}ms)`);
 }
 
 function registerHealthCheckEndpoint(app: Hono, config?: ServerConfig): void

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -11,6 +11,7 @@ import { join } from 'path';
 
 import { registerRoutes, defineMiddleware, type RegisteredRoute } from '@spfn/core/route';
 import { ErrorHandler, RequestLogger, rateLimit, setRateLimitPolicies } from '@spfn/core/middleware';
+import { setDefaultSafeFetchPolicy } from '@spfn/core/security';
 import { env } from '@spfn/core/config';
 import { createSSEHandler } from '../event/sse/handler';
 import { SSETokenManager, CacheTokenStore } from '../event/sse/token-manager';
@@ -40,6 +41,9 @@ declare module 'hono'
  */
 export async function createServer(config?: ServerConfig): Promise<Hono>
 {
+    // Publish the outbound SSRF policy before any route or handler can call safeFetch.
+    applyOutboundFetch(config);
+
     const cwd = process.cwd();
     const appPath = join(cwd, 'src', 'server', 'app.ts');
     const appJsPath = join(cwd, 'src', 'server', 'app');
@@ -267,6 +271,17 @@ function applyRateLimit(config?: ServerConfig): void
     config.middlewares = [globalRateLimit, ...(config.middlewares ?? [])];
 
     serverLogger.info(`✓ Rate limit default enabled (${defaultPolicy.limit} per ${defaultPolicy.windowMs}ms)`);
+}
+
+/**
+ * Publish the process-wide SSRF policy used by `safeFetch` (`@spfn/core/security`).
+ * App config wins; otherwise the `SAFE_FETCH_BLOCK_PRIVATE_IPS` env sets the default.
+ */
+function applyOutboundFetch(config?: ServerConfig): void
+{
+    const policy = config?.outboundFetch ?? { blockPrivateIps: env.SAFE_FETCH_BLOCK_PRIVATE_IPS };
+
+    setDefaultSafeFetchPolicy(policy);
 }
 
 function registerHealthCheckEndpoint(app: Hono, config?: ServerConfig): void

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -10,7 +10,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 
 import { registerRoutes, defineMiddleware, type RegisteredRoute } from '@spfn/core/route';
-import { ErrorHandler, RequestLogger, rateLimit, setRateLimitPolicies } from '@spfn/core/middleware';
+import { ErrorHandler, RequestLogger, rateLimit, setRateLimitPolicies, setRateLimitFailClosedDefault } from '@spfn/core/middleware';
 import { setDefaultSafeFetchPolicy } from '@spfn/core/security';
 import { env } from '@spfn/core/config';
 import { createSSEHandler } from '../event/sse/handler';
@@ -21,6 +21,10 @@ import { serverLogger } from './logger';
 
 import type { ServerConfig, AppFactory } from './types';
 import type { NonceStore, RateLimitOptions } from '@spfn/core/middleware';
+
+// Tracks configs whose global rate-limit middleware has already been injected,
+// so a repeated createServer on the same config doesn't prepend it twice.
+const rateLimitApplied = new WeakSet<object>();
 
 // Extend Hono context with error handler flag
 declare module 'hono'
@@ -76,13 +80,14 @@ async function loadCustomApp(
 
     const app = await appFactory();
 
+    // Always run: registers policies + fail-closed default even for a custom app
+    // that wires its own routes (so rateLimitPolicy tags still resolve). Injection
+    // of the global default only takes effect when routes are registered below.
+    applyRateLimit(config);
+
     // Register routes (if provided via config)
     if (config?.routes)
     {
-        // Populate rate-limit policies and (optionally) the global default limiter
-        // before routes are registered, so policy tags resolve and skip works.
-        applyRateLimit(config);
-
         const routes = registerRoutes(app, config.routes, config.middlewares);
         logRegisteredRoutes(routes, config?.debug ?? false);
     }
@@ -252,18 +257,27 @@ function applyRateLimit(config?: ServerConfig): void
 {
     const rl = config?.rateLimit;
 
+    // These are idempotent (plain reassignment) and must run on every path —
+    // including a Level-3 custom app — so policy tags resolve and fail-closed
+    // reaches them whether or not the global default limiter is enabled.
     setRateLimitPolicies(rl?.policies);
+    setRateLimitFailClosedDefault(env.RATE_LIMIT_FAIL_CLOSED);
 
     const enabled = (rl?.mode ?? env.RATE_LIMIT_MODE) === 'on';
-    if (!enabled || !config)
+    if (!enabled || !config || rateLimitApplied.has(config))
     {
         return;
     }
 
-    const defaultPolicy: RateLimitOptions = rl?.default ?? {
-        limit: env.RATE_LIMIT_DEFAULT_LIMIT,
-        windowMs: env.RATE_LIMIT_DEFAULT_WINDOW_MS,
-        failClosed: env.RATE_LIMIT_FAIL_CLOSED,
+    // Guard against a second prepend if createServer runs twice on the same config
+    // (register-routes does not dedup server-level middlewares against each other,
+    // so two 'rateLimit' entries would silently halve the effective limit).
+    rateLimitApplied.add(config);
+
+    const defaultPolicy: RateLimitOptions = {
+        limit: rl?.default?.limit ?? env.RATE_LIMIT_DEFAULT_LIMIT,
+        windowMs: rl?.default?.windowMs ?? env.RATE_LIMIT_DEFAULT_WINDOW_MS,
+        failClosed: rl?.default?.failClosed ?? env.RATE_LIMIT_FAIL_CLOSED,
     };
 
     const globalRateLimit = defineMiddleware('rateLimit', rateLimit(defaultPolicy));

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -2,7 +2,7 @@ import type { Hono, MiddlewareHandler } from 'hono';
 import { cors } from 'hono/cors';
 import type { serve } from '@hono/node-server';
 import type { Router, NamedMiddleware } from '@spfn/core/route';
-import type { OnErrorContext, ProxyGuardConfig } from '@spfn/core/middleware';
+import type { OnErrorContext, ProxyGuardConfig, RateLimitOptions } from '@spfn/core/middleware';
 import type { JobRouter, BossOptions } from '../job';
 import type { EventRouterDef } from '../event/router';
 import type { SSEHandlerConfig } from '../event/sse/types';
@@ -120,6 +120,35 @@ export interface ServerConfig
          * is briefly unavailable. @default false
          */
         nonce?: boolean;
+    };
+
+    /**
+     * Rate limiting: an optional global default limiter plus named policies.
+     *
+     * `mode: 'on'` applies `default` to every named-middleware route (opt out
+     * with `.skip(['rateLimit'])`); `policies` lets packages tag sensitive routes
+     * via `rateLimitPolicy(name, fallback)` while this app tunes the numbers in
+     * one place. Backed by the shared cache (CACHE_URL); without a cache it fails
+     * open unless `default.failClosed` is set. Disabled by default (`mode: 'off'`).
+     *
+     * @example
+     * ```typescript
+     * .rateLimit({
+     *     mode: 'on',
+     *     default: { limit: 100, windowMs: 60_000 },
+     *     policies: { 'auth-login': { limit: 5, windowMs: 60_000 } },
+     * })
+     * ```
+     */
+    rateLimit?: {
+        /** 'on' applies the default limiter to every route. @default 'off' */
+        mode?: 'off' | 'on';
+
+        /** Default policy applied to all routes when `mode` is 'on'. */
+        default?: RateLimitOptions;
+
+        /** Named policies referenced by `rateLimitPolicy(name, fallback)` tags. */
+        policies?: Record<string, RateLimitOptions>;
     };
 
     /**

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -3,6 +3,7 @@ import { cors } from 'hono/cors';
 import type { serve } from '@hono/node-server';
 import type { Router, NamedMiddleware } from '@spfn/core/route';
 import type { OnErrorContext, ProxyGuardConfig, RateLimitOptions } from '@spfn/core/middleware';
+import type { SafeFetchPolicy } from '@spfn/core/security';
 import type { JobRouter, BossOptions } from '../job';
 import type { EventRouterDef } from '../event/router';
 import type { SSEHandlerConfig } from '../event/sse/types';
@@ -150,6 +151,19 @@ export interface ServerConfig
         /** Named policies referenced by `rateLimitPolicy(name, fallback)` tags. */
         policies?: Record<string, RateLimitOptions>;
     };
+
+    /**
+     * SSRF policy for outbound requests made via `safeFetch` (`@spfn/core/security`).
+     * Sets the process-wide default used by webhook/callback senders. Private and
+     * reserved IPs are blocked by default; set `allowHosts` to restrict to a known
+     * set of upstreams, or `blockPrivateIps: false` for trusted internal calls.
+     *
+     * @example
+     * ```typescript
+     * .outboundFetch({ allowHosts: ['hooks.slack.com'] })
+     * ```
+     */
+    outboundFetch?: SafeFetchPolicy;
 
     /**
      * Global middlewares with names for route-level skip control

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -18,6 +18,7 @@
             "@spfn/core/server": ["./src/server/index.ts"],
             "@spfn/core/errors": ["./src/errors/index.ts"],
             "@spfn/core/middleware": ["./src/middleware/index.ts"],
+            "@spfn/core/security": ["./src/security/index.ts"],
             "@spfn/core/cache": ["./src/cache/index.ts"],
             "@spfn/core/codegen": ["./src/codegen/index.ts"],
             "@spfn/core/env": ["./src/env/index.ts"],

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
         'server/index': 'src/server/index.ts',
         'errors/index': 'src/errors/index.ts',
         'middleware/index': 'src/middleware/index.ts',
+        'security/index': 'src/security/index.ts',
         'cache/index': 'src/cache/index.ts',
         'codegen/index': 'src/codegen/index.ts',
         'env/index': 'src/env/index.ts',

--- a/packages/notification/src/channels/slack/providers/webhook.ts
+++ b/packages/notification/src/channels/slack/providers/webhook.ts
@@ -5,6 +5,7 @@
 import type { SlackProvider, InternalSendSlackParams } from '../types';
 import type { SendResult } from '../../types';
 import { logger } from '@spfn/core/logger';
+import { safeFetch } from '@spfn/core/security';
 
 const log = logger.child('@spfn/notification:slack-webhook');
 
@@ -20,7 +21,10 @@ export const webhookProvider: SlackProvider = {
     {
         try
         {
-            const res = await fetch(params.webhookUrl, {
+            // safeFetch: webhookUrl can be operator- or dynamically-supplied, so
+            // guard against SSRF to private/metadata addresses. Blocked targets
+            // throw and are reported as a failed send by the catch below.
+            const res = await safeFetch(params.webhookUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/packages/workflow/src/engine/workflow-engine.ts
+++ b/packages/workflow/src/engine/workflow-engine.ts
@@ -6,6 +6,7 @@
 
 import { eq, and, desc, inArray } from 'drizzle-orm';
 import { Value } from '@sinclair/typebox/value';
+import { assertSafeUrl } from '@spfn/core/security';
 import type { WorkflowDef, WorkflowEvent, WorkflowStepDef } from '../builder';
 import type { WorkflowStatus, WorkflowStepStatus } from '../types';
 import {
@@ -598,6 +599,17 @@ implements WorkflowEngine<TWorkflows>
         const ref = output as { $ref?: string };
         if (ref.$ref && this.config.storage)
         {
+            // A $ref normally comes from our own storage.upload(), but step output
+            // is data — a malicious step could shape it as { $ref: 'http://169.254...' }
+            // to make download() fetch an internal address (SSRF). storage.download
+            // is app-provided so we can't pin its connection; validate http(s) refs
+            // against the SSRF policy before handing them over. Non-HTTP refs
+            // (storage keys, s3://, …) are left to the backend's own scheme.
+            if (/^https?:\/\//i.test(ref.$ref))
+            {
+                await assertSafeUrl(ref.$ref);
+            }
+
             return await this.config.storage.download(ref.$ref);
         }
 

--- a/packages/workflow/src/engine/workflow-engine.ts
+++ b/packages/workflow/src/engine/workflow-engine.ts
@@ -6,7 +6,10 @@
 
 import { eq, and, desc, inArray } from 'drizzle-orm';
 import { Value } from '@sinclair/typebox/value';
-import { assertSafeUrl } from '@spfn/core/security';
+import { assertSafeUrl, SsrfBlockedError } from '@spfn/core/security';
+
+/** URL schemes never legitimate for a storage $ref — classic SSRF/LFI vectors. */
+const DANGEROUS_REF_SCHEMES = new Set(['file', 'gopher', 'data', 'ftp', 'ftps', 'dict', 'tftp', 'ldap', 'jar', 'netdoc']);
 import type { WorkflowDef, WorkflowEvent, WorkflowStepDef } from '../builder';
 import type { WorkflowStatus, WorkflowStepStatus } from '../types';
 import {
@@ -601,13 +604,21 @@ implements WorkflowEngine<TWorkflows>
         {
             // A $ref normally comes from our own storage.upload(), but step output
             // is data — a malicious step could shape it as { $ref: 'http://169.254...' }
-            // to make download() fetch an internal address (SSRF). storage.download
-            // is app-provided so we can't pin its connection; validate http(s) refs
-            // against the SSRF policy before handing them over. Non-HTTP refs
-            // (storage keys, s3://, …) are left to the backend's own scheme.
-            if (/^https?:\/\//i.test(ref.$ref))
+            // (SSRF) or { $ref: 'file:///etc/passwd' } (LFI) to abuse download().
+            // storage.download is app-provided so we can't pin its connection; instead
+            // validate the ref's scheme before handing it over:
+            //   - http(s): full SSRF check (still TOCTOU vs download's own resolve)
+            //   - known dangerous schemes (file/gopher/…): reject outright
+            //   - plain keys ('uploads/x') and other schemes (s3://, gs://): left to
+            //     the backend, which owns its scheme.
+            const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(ref.$ref)?.[1]?.toLowerCase();
+            if (scheme === 'http' || scheme === 'https')
             {
                 await assertSafeUrl(ref.$ref);
+            }
+            else if (scheme && DANGEROUS_REF_SCHEMES.has(scheme))
+            {
+                throw new SsrfBlockedError(`Refusing to resolve output $ref with scheme "${scheme}:"`);
             }
 
             return await this.config.storage.download(ref.$ref);


### PR DESCRIPTION
Reusable rate limiting and SSRF protection that attach with one config, so the
two concerns don't have to be hand-wired into every package and consumer app.
Built, then hardened against an adversarial review (which found — and this PR
fixes — a real SSRF redirect bypass and rate-limit fail-open traps).

## Rate limiting (`@spfn/core/middleware`)

- **Named policies** — `rateLimitPolicy(name, fallback)`: a package tags a route
  with a policy name + safe fallback; the consuming app tunes numbers centrally
  via `defineServerConfig().rateLimit({ policies })`. Protected out of the box
  even with no app config.
- **Global default limiter** — opt-in per-IP floor for every route
  (`rateLimit({ mode:'on', default })` or `RATE_LIMIT_*` env), opt out per route
  with `.skip(['rateLimit'])`.
- **Layered, not replacing** — a tagged route gets both the global IP floor and
  its own policy bucket; whichever is stricter trips first. Distinct counter
  scopes avoid key collision.
- **Per-dimension limits** — `by` may return `{ key, limit }`, so a limiter can
  be loose on IP and tight on account/target.
- **`getClientIp`** now falls back to the socket peer address instead of
  collapsing all clients onto one `'unknown'` bucket.

## SSRF-safe fetch (`@spfn/core/security`)

- **`safeFetch`** — drop-in `fetch` that blocks private/reserved ranges (incl.
  `169.254.169.254`, NAT64/6to4) and defeats DNS rebinding by resolving +
  validating + **pinning** the connection to a checked IP via a custom undici
  lookup. **Redirects are followed manually and re-validated per hop** (incl.
  IP-literal targets undici would otherwise connect to directly) — closing the
  bypass the review caught. Method/body/headers are not replayed across hops.
- **`assertSafeUrl`** for URLs handed to code we don't control.
- Policy via `defineServerConfig().outboundFetch()` / `SAFE_FETCH_BLOCK_PRIVATE_IPS`.

## Adoption

- `@spfn/auth`: login/register/code-send/code-verify limited by **account/target
  + IP** (distributed brute force, SMS-bombing, OTP cracking); other sensitive
  routes (invitations, OAuth start/callback/native, username check, password
  change) tagged.
- `@spfn/notification`: Slack webhook sends go through `safeFetch`.
- `@spfn/workflow`: `resolveOutput` validates http(s) `$ref` and rejects
  dangerous schemes before `storage.download`.

## Verification

- `pnpm build` + `pnpm type-check` pass for core/auth/notification/workflow.
- 140 core security+middleware tests pass, incl. regression tests for the
  redirect-to-private bypass, per-dimension limits, policy fail-closed, and the
  `getClientIp` socket fallback. `pnpm codegen` produces no diff.

## Known follow-up

- Per-dimension *windows* (only per-dimension *limits* land here).
- A present forwarding header is still trusted behind a proxy — enable the
  global default only behind a proxy that sets a trustworthy client IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)