### PR TITLE
feat(cli): generate SPFN README + split env into .env.local/.env.server on scaffold

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,7 +27,7 @@ Requirements: Node.js 18.18+, Next.js 15+ (App Router, `src/` dir), PostgreSQL (
 npx spfn@beta create my-app
 cd my-app
 docker compose up -d            # Postgres + Redis
-cp .env.local.example .env.local
+# .env.local & .env.server are generated — put server secrets in .env.server
 pnpm spfn:dev                   # Next.js :3790 + SPFN API :8790
 
 # Add SPFN to an existing Next.js project
@@ -241,9 +241,9 @@ spfn.config.js                       # deployment config (subdomain/region/domai
 docker-compose.yml                   # Postgres + Redis (dev)
 docker-compose.production.yml
 Dockerfile, .dockerignore
-.env.example                         # committed, shared non-secret defaults
-.env.local.example                   # gitignored target template (Next.js local overrides)
-.env.server.example                  # → copy to .env.server (gitignored, server secrets)
+.env.example                         # committed reference — every key, placeholder values
+.env.local                           # generated, gitignored (Next.js-facing URLs)
+.env.server                          # generated, gitignored (server secrets: DB, cache)
 ```
 
 `init` also patches `package.json` (scripts: `spfn:dev`, `spfn:server`, `spfn:next`,
@@ -328,8 +328,8 @@ type ships from `spfn` (`@type {import('spfn').SpfnConfig}`).
 
 - **`.env.server` is gitignored and server-only.** Put DB/secret values there, not in
   `.env` (committed) and not in `.env.local` (that's Next.js's local file). There is no
-  `.env.server.local`. Copy `.env.server.example` → `.env.server`. Load order is the
-  standard dotenv chain ending with `.env.server`.
+  `.env.server.local`. `spfn init` generates `.env.server`; put DB/secret values there.
+  Load order is the standard dotenv chain ending with `.env.server`.
 - **Never commit secrets in `spfn.config.js`.** It's checked into Git; its `env` block is
   for non-sensitive values only. Use CI/CD secret management for credentials.
 - **`spfn dev` does not hot-reload by default.** Add `--watch` to restart on `src/server`

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 import { build } from 'tsup';
 
 import { logger } from '../utils/logger.js';
-import { detectPackageManager } from '../utils/package-manager.js';
+import { detectPackageManager, getRunCommand } from '../utils/package-manager.js';
 
 interface BuildOptions
 {
@@ -258,7 +258,7 @@ await startServer({
 
     console.log(chalk.bold('Next steps:\n'));
     console.log('  ' + chalk.cyan('Start production server:'));
-    console.log(`    ${chalk.cyan(pm === 'npm' ? 'npm run' : pm + ' run')} spfn:start  ${chalk.gray('# Start SPFN + Next.js')}\n`);
+    console.log(`    ${chalk.cyan(getRunCommand(pm))} spfn:start  ${chalk.gray('# Start SPFN + Next.js')}\n`);
 
     console.log('  ' + chalk.cyan('Or deploy with Docker:'));
     console.log(`    ${chalk.cyan('docker compose -f docker-compose.production.yml up --build -d')}\n`);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { existsSync } from 'fs';
+import { existsSync, rmSync } from 'fs';
 import { join, resolve, dirname } from 'path';
 import prompts from 'prompts';
 import ora from 'ora';
@@ -136,6 +136,15 @@ async function createProject(projectName: string, options: CreateOptions): Promi
         });
 
         ora().succeed('Next.js project created');
+
+        // Drop the create-next-app README so `spfn init` writes the SPFN one.
+        // init only creates a README when none exists; standalone init keeps any
+        // README the project already has.
+        const cnaReadme = join(projectPath, 'README.md');
+        if (existsSync(cnaReadme))
+        {
+            rmSync(cnaReadme);
+        }
     }
     catch (error: any)
     {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -274,7 +274,7 @@ async function createProject(projectName: string, options: CreateOptions): Promi
     console.log(chalk.bold('Next steps:\n'));
     console.log(`  ${chalk.cyan('cd')} ${projectName}`);
     console.log(`  ${chalk.cyan('docker compose up -d')}  ${chalk.gray('# Start PostgreSQL & Redis')}`);
-    console.log(`  ${chalk.cyan('cp .env.local.example .env.local')}  ${chalk.gray('# Configure environment')}`);
+    console.log(`  ${chalk.gray('# .env.local & .env.server are generated — put server secrets in .env.server')}`);
     console.log(`  ${chalk.cyan(`${pm === 'npm' ? 'npm run' : pm + ' run'} spfn:dev`)}  ${chalk.gray('# Start dev server')}\n`);
 
     console.log(chalk.bold('Your app will be available at:\n'));

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { existsSync, rmSync } from 'fs';
+import { existsSync } from 'fs';
 import { join, resolve, dirname } from 'path';
 import prompts from 'prompts';
 import ora from 'ora';
@@ -7,7 +7,8 @@ import { execa } from 'execa';
 import chalk from 'chalk';
 
 import { logger } from '../utils/logger.js';
-import { detectPackageManager } from '../utils/package-manager.js';
+import { detectPackageManager, getRunCommand } from '../utils/package-manager.js';
+import { ENV_FILES_HINT } from '../utils/messages.js';
 
 interface CreateOptions
 {
@@ -136,15 +137,6 @@ async function createProject(projectName: string, options: CreateOptions): Promi
         });
 
         ora().succeed('Next.js project created');
-
-        // Drop the create-next-app README so `spfn init` writes the SPFN one.
-        // init only creates a README when none exists; standalone init keeps any
-        // README the project already has.
-        const cnaReadme = join(projectPath, 'README.md');
-        if (existsSync(cnaReadme))
-        {
-            rmSync(cnaReadme);
-        }
     }
     catch (error: any)
     {
@@ -257,7 +249,7 @@ async function createProject(projectName: string, options: CreateOptions): Promi
     {
         // Run spfn init programmatically
         const { initializeSpfn } = await import('./init/index.js');
-        await initializeSpfn({ yes: true });
+        await initializeSpfn({ yes: true, overwriteReadme: true });
 
         initSpinner.succeed('SPFN initialized');
     }
@@ -274,8 +266,8 @@ async function createProject(projectName: string, options: CreateOptions): Promi
     console.log(chalk.bold('Next steps:\n'));
     console.log(`  ${chalk.cyan('cd')} ${projectName}`);
     console.log(`  ${chalk.cyan('docker compose up -d')}  ${chalk.gray('# Start PostgreSQL & Redis')}`);
-    console.log(`  ${chalk.gray('# .env.local & .env.server are generated — put server secrets in .env.server')}`);
-    console.log(`  ${chalk.cyan(`${pm === 'npm' ? 'npm run' : pm + ' run'} spfn:dev`)}  ${chalk.gray('# Start dev server')}\n`);
+    console.log(`  ${chalk.gray(`# .env.local & .env.server are generated — ${ENV_FILES_HINT}`)}`);
+    console.log(`  ${chalk.cyan(`${getRunCommand(pm)} spfn:dev`)}  ${chalk.gray('# Start dev server')}\n`);
 
     console.log(chalk.bold('Your app will be available at:\n'));
     console.log(`  ${chalk.cyan('http://localhost:3790')}  ${chalk.gray('(Next.js)')}`);
@@ -284,8 +276,8 @@ async function createProject(projectName: string, options: CreateOptions): Promi
     // Production deployment guidance
     console.log(chalk.bold('🚀 Ready for production?\n'));
     console.log('  ' + chalk.cyan('Build for production:'));
-    console.log(`    ${chalk.cyan(pm === 'npm' ? 'npm run' : pm + ' run')} spfn:build`);
-    console.log(`    ${chalk.cyan(pm === 'npm' ? 'npm run' : pm + ' run')} spfn:start\n`);
+    console.log(`    ${chalk.cyan(getRunCommand(pm))} spfn:build`);
+    console.log(`    ${chalk.cyan(getRunCommand(pm))} spfn:start\n`);
 
     console.log('  ' + chalk.cyan('Or deploy with Docker:'));
     console.log(`    ${chalk.cyan('docker compose -f docker-compose.production.yml up --build -d')}\n`);

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,7 +1,8 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { detectPackageManager } from '../../utils/package-manager.js';
+import { detectPackageManager, getRunCommand } from '../../utils/package-manager.js';
 import { logger } from '../../utils/logger.js';
+import { ENV_FILES_HINT } from '../../utils/messages.js';
 import { validateProject } from './steps/validate.js';
 import { setupServerStructure } from './steps/server-structure.js';
 import { setupApiProxy } from './steps/api-proxy.js';
@@ -14,6 +15,8 @@ import { setupReadme } from './steps/readme.js';
 interface InitOptions
 {
     yes?: boolean;
+    // Set by `spfn create` to replace the create-next-app README with the SPFN one.
+    overwriteReadme?: boolean;
 }
 
 /**
@@ -49,7 +52,7 @@ export async function initializeSpfn(options: InitOptions = {}): Promise<void>
     await setupConfigFiles(cwd);
 
     // Step 9: Create README.md (only when one doesn't already exist)
-    await setupReadme(cwd, { pm, packageJson, includeAuth });
+    await setupReadme(cwd, { pm, packageJson, includeAuth, overwrite: options.overwriteReadme ?? false });
 
     // Done - Show success message and next steps
     console.log('\n' + chalk.green.bold('✓ SPFN initialized successfully!\n'));
@@ -58,13 +61,13 @@ export async function initializeSpfn(options: InitOptions = {}): Promise<void>
     console.log('  1. Start PostgreSQL & Redis (if not installed locally):');
     console.log('     ' + chalk.cyan('docker compose up -d'));
     console.log('  2. Review the generated env files (.env.local, .env.server)');
-    console.log('     ' + chalk.dim('server secrets belong in .env.server — Next.js never loads it'));
-    console.log('  3. Run: ' + chalk.cyan(pm === 'npm' ? 'npm run spfn:dev' : `${pm} run spfn:dev`));
+    console.log('     ' + chalk.dim(ENV_FILES_HINT));
+    console.log('  3. Run: ' + chalk.cyan(`${getRunCommand(pm)} spfn:dev`));
     console.log('  4. Visit:');
     console.log('     - Next.js: ' + chalk.cyan('http://localhost:3790'));
     console.log('     - API:     ' + chalk.cyan('http://localhost:8790/health'));
     console.log('\nAvailable commands:');
-    console.log('  • ' + chalk.cyan(pm === 'npm' ? 'npm run spfn:dev' : `${pm} spfn:dev`) + '       - Start SPFN + Next.js');
+    console.log('  • ' + chalk.cyan(`${getRunCommand(pm)} spfn:dev`) + '       - Start SPFN + Next.js');
     console.log('  • ' + chalk.cyan('spfn env:validate') + '   - Validate environment variables');
     console.log('  • ' + chalk.cyan('spfn env:docs') + '       - Generate env documentation');
     console.log('  • ' + chalk.cyan('spfn env:check') + '      - Check environment status');

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -9,6 +9,7 @@ import { setupDockerFiles } from './steps/docker.js';
 import { setupDeploymentConfig } from './steps/deployment-config.js';
 import { setupPackageJson } from './steps/package.js';
 import { setupConfigFiles } from './steps/config-files.js';
+import { setupReadme } from './steps/readme.js';
 
 interface InitOptions
 {
@@ -46,6 +47,9 @@ export async function initializeSpfn(options: InitOptions = {}): Promise<void>
 
     // Step 8: Setup configuration files (.env, .spfnrc.ts, .gitignore, tsconfig)
     await setupConfigFiles(cwd);
+
+    // Step 9: Create README.md (only when one doesn't already exist)
+    await setupReadme(cwd, { pm, packageJson, includeAuth });
 
     // Done - Show success message and next steps
     console.log('\n' + chalk.green.bold('✓ SPFN initialized successfully!\n'));

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -57,8 +57,8 @@ export async function initializeSpfn(options: InitOptions = {}): Promise<void>
     console.log('Next steps:');
     console.log('  1. Start PostgreSQL & Redis (if not installed locally):');
     console.log('     ' + chalk.cyan('docker compose up -d'));
-    console.log('  2. Copy .env.local.example to .env.local');
-    console.log('     ' + chalk.cyan('cp .env.local.example .env.local'));
+    console.log('  2. Review the generated env files (.env.local, .env.server)');
+    console.log('     ' + chalk.dim('server secrets belong in .env.server — Next.js never loads it'));
     console.log('  3. Run: ' + chalk.cyan(pm === 'npm' ? 'npm run spfn:dev' : `${pm} run spfn:dev`));
     console.log('  4. Visit:');
     console.log('     - Next.js: ' + chalk.cyan('http://localhost:3790'));

--- a/packages/cli/src/commands/init/steps/config-files.ts
+++ b/packages/cli/src/commands/init/steps/config-files.ts
@@ -153,7 +153,9 @@ function mergeMissingEnvKeys(filePath: string, filename: string, template: strin
  */
 function envKeyOf(line: string): string | null
 {
-    const match = line.match(/^([A-Z_][A-Z0-9_]*)=/);
+    // Tolerate dotenv's `export ` prefix and surrounding whitespace, so a key
+    // already present as `export DATABASE_URL=` isn't re-appended with our default.
+    const match = line.match(/^\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)\s*=/);
 
     return match ? match[1] : null;
 }
@@ -192,12 +194,15 @@ function updateGitignore(cwd: string): void
         let updated = content;
         let changed = false;
 
-        // Add .spfn directory
-        if (!hasIgnoreRule(content, '/.spfn/'))
+        // Add .spfn directory. Substring match so an existing `.spfn`, `.spfn/`
+        // or `/.spfn/` rule all count — gitignore line order is irrelevant, so we
+        // just append rather than splicing after a `/build` anchor.
+        if (!content.includes('.spfn'))
         {
-            updated = /# production\r?\n\/build/.test(updated)
-                ? updated.replace(/# production(\r?\n)\/build/, '# production$1/build$1$1# spfn$1/.spfn/')
-                : `${updated.replace(/\n*$/, '\n')}\n# spfn\n/.spfn/\n`;
+            updated += `
+# spfn
+/.spfn/
+`;
             changed = true;
         }
 
@@ -233,7 +238,7 @@ function updateGitignore(cwd: string): void
     }
     catch (error)
     {
-        logger.warn('Could not update .gitignore (you can add patterns manually)');
+        logger.warn('Could not update .gitignore — add .env.local and .env.server manually before committing, so the generated .env.server secrets are not tracked');
     }
 }
 

--- a/packages/cli/src/commands/init/steps/config-files.ts
+++ b/packages/cli/src/commands/init/steps/config-files.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import fse from 'fs-extra';
 import { logger } from '../../../utils/logger.js';
@@ -18,8 +18,7 @@ NEXT_PUBLIC_SPFN_API_URL=http://localhost:8790
 SPFN_APP_URL=http://localhost:3790
 `;
 
-// .env.server template — SPFN backend only; secrets live here, never loaded by
-// Next.js. SERVER_ENV_KEYS is derived from it so the two never drift.
+// .env.server template — SPFN backend only; secrets live here, never loaded by Next.js.
 const ENV_SERVER_TEMPLATE = `# SPFN backend environment
 # Loaded ONLY by the SPFN server, never by Next.js. Keep all server-only config
 # and secrets here so they never reach the Next.js process.
@@ -50,12 +49,21 @@ DB_POOL_IDLE_TIMEOUT=30
 // key list never drifts from what init actually generates. Documentation only:
 // real values go in .env.local / .env.server (gitignored). Because it is committed,
 // concrete DB credentials are replaced with placeholders (AGENTS.md hard rule #4).
-const ENV_EXAMPLE_TEMPLATE = `# Example environment — committed reference for the variables SPFN uses.
+const ENV_EXAMPLE_TEMPLATE = withPlaceholderCreds(`# Example environment — committed reference for the variables SPFN uses.
 # Real values live in .env.local (Next.js) and .env.server (backend secrets),
 # both gitignored. This file documents the keys; it is not loaded by anything.
 
 ${ENV_LOCAL_TEMPLATE}
-${ENV_SERVER_TEMPLATE}`.replace(/(postgresql:\/\/)[^@\s/]+@/g, '$1user:password@');
+${ENV_SERVER_TEMPLATE}`);
+
+/**
+ * Replace concrete DB credentials with a placeholder, for any example file that
+ * may be committed (AGENTS.md hard rule #4: committed *.example carry placeholders).
+ */
+function withPlaceholderCreds(text: string): string
+{
+    return text.replace(/(postgresql:\/\/)[^@\s/]+@/g, '$1user:password@');
+}
 
 /**
  * Setup configuration files:
@@ -114,10 +122,32 @@ export default defineConfig({
  */
 function generateEnvFiles(cwd: string): void
 {
+    // .env.local holds only our Next.js-facing URLs (SPFN_API_URL, NEXT_PUBLIC_*),
+    // safe to add to an existing file — so create it, or merge missing keys.
     writeEnvFile(cwd, '.env.local', ENV_LOCAL_TEMPLATE);
-    writeEnvFile(cwd, '.env.server', ENV_SERVER_TEMPLATE);
+    writeServerEnv(cwd);
     writeExampleEnv(cwd, ENV_EXAMPLE_TEMPLATE);
-    warnOverriddenServerKeys(cwd);
+}
+
+/**
+ * Write .env.server only when absent. If the user already has one it holds their
+ * real secrets, so never touch it — drop SPFN's template beside it as
+ * .env.server.example (credentials placeholdered) and tell them to reconcile.
+ */
+function writeServerEnv(cwd: string): void
+{
+    const filePath = join(cwd, '.env.server');
+
+    if (!existsSync(filePath))
+    {
+        writeFileSync(filePath, ENV_SERVER_TEMPLATE);
+        logger.success('Created .env.server');
+
+        return;
+    }
+
+    writeFileSync(join(cwd, '.env.server.example'), withPlaceholderCreds(ENV_SERVER_TEMPLATE));
+    logger.warn('.env.server already exists — left it untouched; wrote SPFN\'s reference to .env.server.example, add any missing keys manually');
 }
 
 /**
@@ -136,80 +166,9 @@ function writeExampleEnv(cwd: string, content: string): void
     logger.success('Created .env.example (committed reference)');
 }
 
-// Active (uncommented) keys .env.server owns, derived from its template so the
-// two never drift. Used to warn when one is already set in an earlier-loaded file.
-const SERVER_ENV_KEYS = collectEnvKeys(ENV_SERVER_TEMPLATE);
-
-// Matches the dotenv files @spfn/core's loadEnv reads (.env, .env.local,
-// .env.<nodeEnv>[.local]) for ANY NODE_ENV, but NOT non-dotenv names like
-// direnv's .envrc. .env.server (what we generate) is excluded separately.
-const DOTENV_FILE = /^\.env(\.[a-z0-9_-]+)?(\.local)?$/i;
-
 /**
- * Warn when a key .env.server owns is already set in another env file the backend
- * loads earlier. .env.server loads last and wins, so the user's existing value
- * (e.g. a real DATABASE_URL in .env.local) is silently overridden at runtime.
- * Best-effort: an unreadable entry is skipped, never fatal to init.
- */
-function warnOverriddenServerKeys(cwd: string): void
-{
-    for (const file of overridableEnvFiles(cwd))
-    {
-        const content = readEnvFileSafe(join(cwd, file));
-
-        if (content === null)
-        {
-            continue;
-        }
-
-        const keys = collectEnvKeys(content);
-        const clashing = [...SERVER_ENV_KEYS].filter((key) => keys.has(key));
-
-        if (clashing.length > 0)
-        {
-            // .env and .env.local load for every NODE_ENV; the env-specific files
-            // (.env.production etc.) only load when that NODE_ENV is active, so don't
-            // claim an unconditional override for them.
-            const alwaysLoaded = file === '.env' || file === '.env.local';
-            const when = alwaysLoaded ? 'its value wins at runtime' : 'its value wins when that NODE_ENV is active';
-            logger.warn(`${file} also sets ${clashing.join(', ')} — .env.server loads last and ${when}`);
-        }
-    }
-}
-
-/**
- * The dotenv files loadEnv reads before .env.server, excluding .env.server itself
- * and the committed .env.example / *.example references.
- */
-function overridableEnvFiles(cwd: string): string[]
-{
-    return readdirSync(cwd).filter((name) =>
-        DOTENV_FILE.test(name)
-        && name !== '.env.server'
-        && name !== '.env.example'
-        && !name.endsWith('.example'));
-}
-
-/**
- * Read a file as text, or null when it's absent, a directory, or unreadable —
- * so a stray `.env`-named directory never crashes init.
- */
-function readEnvFileSafe(filePath: string): string | null
-{
-    try
-    {
-        return readFileSync(filePath, 'utf-8');
-    }
-    catch
-    {
-        return null;
-    }
-}
-
-/**
- * Write an env file. When it already exists we never overwrite user values —
- * instead we append any SPFN keys the file is missing, so required vars like
- * SPFN_API_URL are added even on a project that already has its own env file.
+ * Write .env.local, or merge any missing SPFN keys into an existing one. Only used
+ * for .env.local, whose values (Next.js-facing URLs) are safe to add.
  */
 function writeEnvFile(cwd: string, filename: string, content: string): void
 {
@@ -268,29 +227,19 @@ function envKeyOf(line: string): string | null
     return match ? match[1] : null;
 }
 
-function collectEnvKeys(content: string): Set<string>
-{
-    return collectKeys(content, false);
-}
-
 /**
- * Like collectEnvKeys but also counts commented `# KEY=` declarations, so a
- * deliberately-disabled key is treated as already present and not re-added.
+ * Keys declared in the file, counting commented `# KEY=` lines too, so a
+ * deliberately-disabled key is treated as present and not re-added by the merge.
  */
 function collectDeclaredKeys(content: string): Set<string>
-{
-    return collectKeys(content, true);
-}
-
-function collectKeys(content: string, includeCommented: boolean): Set<string>
 {
     const keys = new Set<string>();
 
     for (const line of content.split('\n'))
     {
-        // includeCommented strips a leading `# ` first, so `# DATABASE_URL=` and
-        // `DATABASE_URL=` both parse through the same envKeyOf rule.
-        const key = envKeyOf(includeCommented ? line.replace(/^\s*#\s*/, '') : line);
+        // Strip a leading `# ` first so `# DATABASE_URL=` and `DATABASE_URL=` both
+        // parse through the same envKeyOf rule.
+        const key = envKeyOf(line.replace(/^\s*#\s*/, ''));
         if (key !== null)
         {
             keys.add(key);

--- a/packages/cli/src/commands/init/steps/config-files.ts
+++ b/packages/cli/src/commands/init/steps/config-files.ts
@@ -101,51 +101,108 @@ DB_POOL_IDLE_TIMEOUT=30
 }
 
 /**
- * Write an env file (skip if it already exists, to preserve user values)
+ * Write an env file. When it already exists we never overwrite user values —
+ * instead we append any SPFN keys the file is missing, so required vars like
+ * SPFN_API_URL are added even on a project that already has its own env file.
  */
 function writeEnvFile(cwd: string, filename: string, content: string): void
 {
     const filePath = join(cwd, filename);
 
-    if (existsSync(filePath))
+    if (!existsSync(filePath))
+    {
+        writeFileSync(filePath, content);
+        logger.success(`Created ${filename}`);
+
+        return;
+    }
+
+    mergeMissingEnvKeys(filePath, filename, content);
+}
+
+/**
+ * Append the assignment lines from `template` whose keys are absent from the
+ * existing file, preserving everything the user already has.
+ */
+function mergeMissingEnvKeys(filePath: string, filename: string, template: string): void
+{
+    const existing = readFileSync(filePath, 'utf-8');
+    const existingKeys = collectEnvKeys(existing);
+
+    const missing = template
+        .split('\n')
+        .filter((line) =>
+        {
+            const key = envKeyOf(line);
+
+            return key !== null && !existingKeys.has(key);
+        });
+
+    if (missing.length === 0)
     {
         return;
     }
 
-    writeFileSync(filePath, content);
-    logger.success(`Created ${filename}`);
+    const block = `\n# Added by spfn init\n${missing.join('\n')}\n`;
+    writeFileSync(filePath, existing.replace(/\n*$/, '\n') + block);
+    logger.success(`Updated ${filename} (added ${missing.length} SPFN key(s))`);
 }
 
 /**
- * Update .gitignore with SPFN patterns
+ * Extract the variable name from an `KEY=value` line, or null for comments/blanks.
+ */
+function envKeyOf(line: string): string | null
+{
+    const match = line.match(/^([A-Z_][A-Z0-9_]*)=/);
+
+    return match ? match[1] : null;
+}
+
+function collectEnvKeys(content: string): Set<string>
+{
+    const keys = new Set<string>();
+
+    for (const line of content.split('\n'))
+    {
+        const key = envKeyOf(line);
+        if (key !== null)
+        {
+            keys.add(key);
+        }
+    }
+
+    return keys;
+}
+
+/**
+ * Update .gitignore with SPFN patterns, creating the file if it doesn't exist.
+ *
+ * The env files generated above are real, secret-bearing files (.env.server holds
+ * DB/cache credentials), so the ignore rules must be guaranteed even in a project
+ * that ships without a .gitignore.
  */
 function updateGitignore(cwd: string): void
 {
     const gitignorePath = join(cwd, '.gitignore');
-
-    if (!existsSync(gitignorePath))
-    {
-        return;
-    }
+    const existed = existsSync(gitignorePath);
 
     try
     {
-        const content = readFileSync(gitignorePath, 'utf-8');
+        const content = existed ? readFileSync(gitignorePath, 'utf-8') : '';
         let updated = content;
         let changed = false;
 
         // Add .spfn directory
-        if (!content.includes('.spfn'))
+        if (!hasIgnoreRule(content, '/.spfn/'))
         {
-            updated = updated.replace(
-                /# production\n\/build/,
-                '# production\n/build\n\n# spfn\n/.spfn/',
-            );
+            updated = /# production\r?\n\/build/.test(updated)
+                ? updated.replace(/# production(\r?\n)\/build/, '# production$1/build$1$1# spfn$1/.spfn/')
+                : `${updated.replace(/\n*$/, '\n')}\n# spfn\n/.spfn/\n`;
             changed = true;
         }
 
         // Add env local patterns (Next.js)
-        if (!content.includes('.env.local') && !content.includes('.env.*.local'))
+        if (!hasIgnoreRule(content, '.env.local') && !hasIgnoreRule(content, '.env.*.local'))
         {
             updated += `
 # environment secrets (local overrides)
@@ -157,7 +214,7 @@ function updateGitignore(cwd: string): void
 
         // Add .env.server independently — it holds server secrets and must be
         // ignored regardless of whether the .env.local block above was added.
-        if (!content.includes('.env.server'))
+        if (!hasIgnoreRule(content, '.env.server'))
         {
             updated += `
 # spfn server env (secrets)
@@ -169,13 +226,24 @@ function updateGitignore(cwd: string): void
         if (changed)
         {
             writeFileSync(gitignorePath, updated);
-            logger.success('Updated .gitignore with .spfn directory and env patterns');
+            logger.success(existed
+                ? 'Updated .gitignore with .spfn directory and env patterns'
+                : 'Created .gitignore with .spfn directory and env patterns');
         }
     }
     catch (error)
     {
         logger.warn('Could not update .gitignore (you can add patterns manually)');
     }
+}
+
+/**
+ * True when `pattern` is present as its own line (ignoring surrounding
+ * whitespace), so `.env.server` does not match `.env.server.example`.
+ */
+function hasIgnoreRule(content: string, pattern: string): boolean
+{
+    return content.split('\n').some((line) => line.trim() === pattern);
 }
 
 /**

--- a/packages/cli/src/commands/init/steps/config-files.ts
+++ b/packages/cli/src/commands/init/steps/config-files.ts
@@ -48,13 +48,14 @@ DB_POOL_IDLE_TIMEOUT=30
 
 // .env.example — committed reference, derived from the two templates above so its
 // key list never drifts from what init actually generates. Documentation only:
-// real values go in .env.local / .env.server (gitignored).
+// real values go in .env.local / .env.server (gitignored). Because it is committed,
+// concrete DB credentials are replaced with placeholders (AGENTS.md hard rule #4).
 const ENV_EXAMPLE_TEMPLATE = `# Example environment — committed reference for the variables SPFN uses.
 # Real values live in .env.local (Next.js) and .env.server (backend secrets),
 # both gitignored. This file documents the keys; it is not loaded by anything.
 
 ${ENV_LOCAL_TEMPLATE}
-${ENV_SERVER_TEMPLATE}`;
+${ENV_SERVER_TEMPLATE}`.replace(/(postgresql:\/\/)[^@\s/]+@/g, '$1user:password@');
 
 /**
  * Setup configuration files:
@@ -166,7 +167,12 @@ function warnOverriddenServerKeys(cwd: string): void
 
         if (clashing.length > 0)
         {
-            logger.warn(`${file} also sets ${clashing.join(', ')} — .env.server loads last and its value will win at runtime`);
+            // .env and .env.local load for every NODE_ENV; the env-specific files
+            // (.env.production etc.) only load when that NODE_ENV is active, so don't
+            // claim an unconditional override for them.
+            const alwaysLoaded = file === '.env' || file === '.env.local';
+            const when = alwaysLoaded ? 'its value wins at runtime' : 'its value wins when that NODE_ENV is active';
+            logger.warn(`${file} also sets ${clashing.join(', ')} — .env.server loads last and ${when}`);
         }
     }
 }
@@ -264,18 +270,7 @@ function envKeyOf(line: string): string | null
 
 function collectEnvKeys(content: string): Set<string>
 {
-    const keys = new Set<string>();
-
-    for (const line of content.split('\n'))
-    {
-        const key = envKeyOf(line);
-        if (key !== null)
-        {
-            keys.add(key);
-        }
-    }
-
-    return keys;
+    return collectKeys(content, false);
 }
 
 /**
@@ -284,13 +279,18 @@ function collectEnvKeys(content: string): Set<string>
  */
 function collectDeclaredKeys(content: string): Set<string>
 {
+    return collectKeys(content, true);
+}
+
+function collectKeys(content: string, includeCommented: boolean): Set<string>
+{
     const keys = new Set<string>();
 
     for (const line of content.split('\n'))
     {
-        // Strip a leading comment marker, then reuse envKeyOf so `# DATABASE_URL=`
-        // and `DATABASE_URL=` parse through the same rule.
-        const key = envKeyOf(line.replace(/^\s*#\s*/, ''));
+        // includeCommented strips a leading `# ` first, so `# DATABASE_URL=` and
+        // `DATABASE_URL=` both parse through the same envKeyOf rule.
+        const key = envKeyOf(includeCommented ? line.replace(/^\s*#\s*/, '') : line);
         if (key !== null)
         {
             keys.add(key);
@@ -348,7 +348,14 @@ function pendingIgnoreRules(content: string): string[]
 
     if (!gitignoreCovers(lines, '.env.local'))
     {
-        rules.push('\n# environment secrets (local overrides)\n.env.local\n.env.*.local\n');
+        rules.push('\n# environment secrets (local overrides)\n.env.local\n');
+    }
+
+    // Checked independently: a project may already ignore .env.local but not the
+    // .env.*.local glob (e.g. a future .env.production.local with real secrets).
+    if (!gitignoreCovers(lines, '.env.*.local'))
+    {
+        rules.push('\n# environment secrets (env-specific local overrides)\n.env.*.local\n');
     }
 
     if (!gitignoreCovers(lines, '.env.server'))
@@ -389,7 +396,8 @@ function gitignoreCovers(lines: string[], target: string): boolean
 
         if (line.startsWith('!'))
         {
-            if (stripSlashes(line.slice(1)) === normalized)
+            const negated = stripSlashes(line.slice(1));
+            if (negated === normalized || (negated.endsWith('*') && normalized.startsWith(negated.slice(0, -1))))
             {
                 return false;
             }

--- a/packages/cli/src/commands/init/steps/config-files.ts
+++ b/packages/cli/src/commands/init/steps/config-files.ts
@@ -1,9 +1,22 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import fse from 'fs-extra';
 import { logger } from '../../../utils/logger.js';
 
 const { writeFileSync } = fse;
+
+// .env.local template — Next.js-facing values (non-secret URLs).
+const ENV_LOCAL_TEMPLATE = `# Next.js environment
+# Loaded by Next.js (and the SPFN backend). Only non-secret, Next.js-facing
+# values belong here — server secrets go in .env.server.
+
+# SPFN API endpoint — browser + Next.js SSR/proxy target
+SPFN_API_URL=http://localhost:8790
+NEXT_PUBLIC_SPFN_API_URL=http://localhost:8790
+
+# Next.js app URL (used by the SPFN server for CORS/redirects)
+SPFN_APP_URL=http://localhost:3790
+`;
 
 // .env.server template — SPFN backend only; secrets live here, never loaded by
 // Next.js. SERVER_ENV_KEYS is derived from it so the two never drift.
@@ -32,6 +45,16 @@ DB_POOL_IDLE_TIMEOUT=30
 # DATABASE_READ_URL=postgresql://user:password@replica:5432/dbname
 # CACHE_PASSWORD=your-redis-password
 `;
+
+// .env.example — committed reference, derived from the two templates above so its
+// key list never drifts from what init actually generates. Documentation only:
+// real values go in .env.local / .env.server (gitignored).
+const ENV_EXAMPLE_TEMPLATE = `# Example environment — committed reference for the variables SPFN uses.
+# Real values live in .env.local (Next.js) and .env.server (backend secrets),
+# both gitignored. This file documents the keys; it is not loaded by anything.
+
+${ENV_LOCAL_TEMPLATE}
+${ENV_SERVER_TEMPLATE}`;
 
 /**
  * Setup configuration files:
@@ -90,47 +113,9 @@ export default defineConfig({
  */
 function generateEnvFiles(cwd: string): void
 {
-    // .env.local — Next.js-facing values (non-secret URLs)
-    writeEnvFile(cwd, '.env.local', `# Next.js environment
-# Loaded by Next.js (and the SPFN backend). Only non-secret, Next.js-facing
-# values belong here — server secrets go in .env.server.
-
-# SPFN API endpoint — browser + Next.js SSR/proxy target
-SPFN_API_URL=http://localhost:8790
-NEXT_PUBLIC_SPFN_API_URL=http://localhost:8790
-
-# Next.js app URL (used by the SPFN server for CORS/redirects)
-SPFN_APP_URL=http://localhost:3790
-`);
-
-    // .env.server — SPFN backend only; secrets live here, never loaded by Next.js
+    writeEnvFile(cwd, '.env.local', ENV_LOCAL_TEMPLATE);
     writeEnvFile(cwd, '.env.server', ENV_SERVER_TEMPLATE);
-
-    // .env.example — committed, placeholder-only reference for the vars above.
-    // Documentation only: real values go in .env.local / .env.server (gitignored).
-    writeExampleEnv(cwd, `# Example environment — committed reference for the variables SPFN uses.
-# Real values live in .env.local (Next.js) and .env.server (backend secrets),
-# both gitignored. This file documents the keys; it is not loaded by anything.
-
-# --- Next.js-facing (.env.local) ---
-SPFN_API_URL=http://localhost:8790
-NEXT_PUBLIC_SPFN_API_URL=http://localhost:8790
-SPFN_APP_URL=http://localhost:3790
-
-# --- SPFN backend (.env.server) ---
-NODE_ENV=local
-SPFN_LOG_LEVEL=info
-DATABASE_URL=postgresql://user:password@localhost:5432/dbname
-CACHE_URL=redis://localhost:6379
-DB_POOL_MAX=10
-DB_POOL_IDLE_TIMEOUT=30
-
-# --- Optional secrets (uncomment and set as needed) ---
-# DATABASE_WRITE_URL=postgresql://user:password@master:5432/dbname
-# DATABASE_READ_URL=postgresql://user:password@replica:5432/dbname
-# CACHE_PASSWORD=your-redis-password
-`);
-
+    writeExampleEnv(cwd, ENV_EXAMPLE_TEMPLATE);
     warnOverriddenServerKeys(cwd);
 }
 
@@ -154,17 +139,10 @@ function writeExampleEnv(cwd: string, content: string): void
 // two never drift. Used to warn when one is already set in an earlier-loaded file.
 const SERVER_ENV_KEYS = collectEnvKeys(ENV_SERVER_TEMPLATE);
 
-// The env files @spfn/core's loadEnv reads BEFORE .env.server (so an existing value
-// would be overridden). Limited to this known set — never a bare `.env*` glob — so
-// unrelated files like direnv's .envrc are not mistaken for SPFN env sources.
-const LOADER_ENV_FILES = [
-    '.env',
-    '.env.local',
-    '.env.development',
-    '.env.development.local',
-    '.env.production',
-    '.env.production.local',
-];
+// Matches the dotenv files @spfn/core's loadEnv reads (.env, .env.local,
+// .env.<nodeEnv>[.local]) for ANY NODE_ENV, but NOT non-dotenv names like
+// direnv's .envrc. .env.server (what we generate) is excluded separately.
+const DOTENV_FILE = /^\.env(\.[a-z0-9_-]+)?(\.local)?$/i;
 
 /**
  * Warn when a key .env.server owns is already set in another env file the backend
@@ -174,7 +152,7 @@ const LOADER_ENV_FILES = [
  */
 function warnOverriddenServerKeys(cwd: string): void
 {
-    for (const file of LOADER_ENV_FILES)
+    for (const file of overridableEnvFiles(cwd))
     {
         const content = readEnvFileSafe(join(cwd, file));
 
@@ -191,6 +169,19 @@ function warnOverriddenServerKeys(cwd: string): void
             logger.warn(`${file} also sets ${clashing.join(', ')} — .env.server loads last and its value will win at runtime`);
         }
     }
+}
+
+/**
+ * The dotenv files loadEnv reads before .env.server, excluding .env.server itself
+ * and the committed .env.example / *.example references.
+ */
+function overridableEnvFiles(cwd: string): string[]
+{
+    return readdirSync(cwd).filter((name) =>
+        DOTENV_FILE.test(name)
+        && name !== '.env.server'
+        && name !== '.env.example'
+        && !name.endsWith('.example'));
 }
 
 /**
@@ -297,10 +288,12 @@ function collectDeclaredKeys(content: string): Set<string>
 
     for (const line of content.split('\n'))
     {
-        const match = line.match(/^\s*#?\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)\s*=/);
-        if (match)
+        // Strip a leading comment marker, then reuse envKeyOf so `# DATABASE_URL=`
+        // and `DATABASE_URL=` parse through the same rule.
+        const key = envKeyOf(line.replace(/^\s*#\s*/, ''));
+        if (key !== null)
         {
-            keys.add(match[1]);
+            keys.add(key);
         }
     }
 
@@ -345,26 +338,27 @@ function updateGitignore(cwd: string): void
  */
 function pendingIgnoreRules(content: string): string[]
 {
+    const lines = content.split('\n');
     const rules: string[] = [];
 
-    if (!gitignoreCovers(content, '.spfn'))
+    if (!gitignoreCovers(lines, '.spfn'))
     {
         rules.push('\n# spfn\n/.spfn/\n');
     }
 
-    if (!gitignoreCovers(content, '.env.local'))
+    if (!gitignoreCovers(lines, '.env.local'))
     {
         rules.push('\n# environment secrets (local overrides)\n.env.local\n.env.*.local\n');
     }
 
-    if (!gitignoreCovers(content, '.env.server'))
+    if (!gitignoreCovers(lines, '.env.server'))
     {
         rules.push('\n# spfn server env (secrets)\n.env.server\n');
     }
 
     // Keep the committed .env.example reference tracked even when a broad `.env*`
     // glob (create-next-app ships one) would otherwise ignore it.
-    if (!content.split('\n').some((line) => line.trim() === '!.env.example'))
+    if (!lines.some((line) => line.trim() === '!.env.example'))
     {
         rules.push('\n# spfn env reference (committed)\n!.env.example\n');
     }
@@ -375,27 +369,41 @@ function pendingIgnoreRules(content: string): string[]
 /**
  * True when some ignore line already covers `target`. Matches an exact rule
  * (ignoring leading/trailing slashes) or a trailing-`*` glob like `.env*`, but
- * not a comment, a negation, or a longer name such as `.spfnrc.ts` /
- * `.env.server.example`.
+ * not a comment or a longer name such as `.spfnrc.ts` / `.env.server.example`.
+ * An explicit `!target` negation forces "not covered" so we re-add the rule —
+ * otherwise a negated secret file would be left git-tracked.
  */
-function gitignoreCovers(content: string, target: string): boolean
+function gitignoreCovers(lines: string[], target: string): boolean
 {
     const normalized = stripSlashes(target);
+    let covered = false;
 
-    return content.split('\n').some((raw) =>
+    for (const raw of lines)
     {
         const line = raw.trim();
 
-        if (line === '' || line.startsWith('#') || line.startsWith('!'))
+        if (line === '' || line.startsWith('#'))
         {
-            return false;
+            continue;
+        }
+
+        if (line.startsWith('!'))
+        {
+            if (stripSlashes(line.slice(1)) === normalized)
+            {
+                return false;
+            }
+            continue;
         }
 
         const rule = stripSlashes(line);
+        if (rule === normalized || (rule.endsWith('*') && normalized.startsWith(rule.slice(0, -1))))
+        {
+            covered = true;
+        }
+    }
 
-        return rule === normalized
-            || (rule.endsWith('*') && normalized.startsWith(rule.slice(0, -1)));
-    });
+    return covered;
 }
 
 function stripSlashes(value: string): string

--- a/packages/cli/src/commands/init/steps/config-files.ts
+++ b/packages/cli/src/commands/init/steps/config-files.ts
@@ -7,16 +7,15 @@ const { writeFileSync } = fse;
 
 /**
  * Setup configuration files:
- * - .env.example (shared defaults, committed)
- * - .env.local.example (local overrides with secrets, gitignored)
- * - .env.server.example (server-only template incl. secrets; copy to .env.server, gitignored)
+ * - .env.local (Next.js-facing env: API/app URLs — non-secret, gitignored)
+ * - .env.server (SPFN backend env + secrets: DB, cache, pool — never loaded by Next.js, gitignored)
  * - .spfnrc.ts (codegen configuration)
  * - .gitignore (add .spfn directory + env patterns)
  * - tsconfig.json (exclude src/server for Vercel)
  */
 export async function setupConfigFiles(cwd: string): Promise<void>
 {
-    generateEnvExamples(cwd);
+    generateEnvFiles(cwd);
 
     // Create .spfnrc.ts for codegen configuration
     const spfnrcPath = join(cwd, '.spfnrc.ts');
@@ -51,13 +50,32 @@ export default defineConfig({
 }
 
 /**
- * Generate separated .env example files
+ * Generate ready-to-use env files, split by which process loads them.
+ *
+ * .env.local is loaded by Next.js (and also the SPFN backend), so only
+ * non-secret, Next.js-facing values go there. .env.server is loaded ONLY by the
+ * SPFN backend, so every server secret (DB URL, cache, credentials) lives there
+ * and never reaches the Next.js process. Both files are gitignored.
  */
-function generateEnvExamples(cwd: string): void
+function generateEnvFiles(cwd: string): void
 {
-    // .env.example — shared defaults (committed, non-sensitive)
-    writeEnvExample(cwd, '.env.example', `# Shared defaults (committed)
-# These values are shared across all environments.
+    // .env.local — Next.js-facing values (non-secret URLs)
+    writeEnvFile(cwd, '.env.local', `# Next.js environment
+# Loaded by Next.js (and the SPFN backend). Only non-secret, Next.js-facing
+# values belong here — server secrets go in .env.server.
+
+# SPFN API endpoint — browser + Next.js SSR/proxy target
+SPFN_API_URL=http://localhost:8790
+NEXT_PUBLIC_SPFN_API_URL=http://localhost:8790
+
+# Next.js app URL (used by the SPFN server for CORS/redirects)
+SPFN_APP_URL=http://localhost:3790
+`);
+
+    // .env.server — SPFN backend only; secrets live here, never loaded by Next.js
+    writeEnvFile(cwd, '.env.server', `# SPFN backend environment
+# Loaded ONLY by the SPFN server, never by Next.js. Keep all server-only config
+# and secrets here so they never reach the Next.js process.
 
 # Environment
 NODE_ENV=local
@@ -65,56 +83,27 @@ NODE_ENV=local
 # Logging
 SPFN_LOG_LEVEL=info
 
-# Server
-PORT=4000
-
-# SPFN API Server URL (for API Route Proxy and SSR)
-SPFN_API_URL=http://localhost:8790
-NEXT_PUBLIC_SPFN_API_URL=http://localhost:8790
-`);
-
-    // .env.local.example — local overrides (gitignored, sensitive)
-    writeEnvExample(cwd, '.env.local.example', `# Local overrides (gitignored)
-# Developer-specific values that should NOT be committed.
-
-# Database (matches docker-compose.yml)
+# Database (matches docker-compose.yml) — secret, server-only
 DATABASE_URL=postgresql://spfn:spfn@localhost:5432/spfn_dev
 
-# Cache - Redis/Valkey (optional)
+# Cache — Redis/Valkey (optional)
 CACHE_URL=redis://localhost:6379
-
-# SPFN App URL (optional, for CORS and redirects)
-# SPFN_APP_URL=http://localhost:3790
-`);
-
-    // .env.server.example — server-only template (copy to .env.server, gitignored)
-    writeEnvExample(cwd, '.env.server.example', `# Server-only environment (template)
-# Copy to .env.server (gitignored) and fill in real values.
-# These values are only loaded by the SPFN server, not by Next.js.
 
 # Database pool
 DB_POOL_MAX=10
 DB_POOL_IDLE_TIMEOUT=30
 
-# Server timeouts
-SERVER_TIMEOUT=120000
-SHUTDOWN_TIMEOUT=30000
-
-# --- Secrets (never commit .env.server) ---
-
-# Database write/read URLs (master-replica pattern, optional)
+# --- Optional secrets (uncomment and set as needed) ---
 # DATABASE_WRITE_URL=postgresql://user:password@master:5432/dbname
 # DATABASE_READ_URL=postgresql://user:password@replica:5432/dbname
-
-# Cache password (optional)
 # CACHE_PASSWORD=your-redis-password
 `);
 }
 
 /**
- * Write a single .env example file (skip if exists)
+ * Write an env file (skip if it already exists, to preserve user values)
  */
-function writeEnvExample(cwd: string, filename: string, content: string): void
+function writeEnvFile(cwd: string, filename: string, content: string): void
 {
     const filePath = join(cwd, filename);
 

--- a/packages/cli/src/commands/init/steps/config-files.ts
+++ b/packages/cli/src/commands/init/steps/config-files.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import fse from 'fs-extra';
 import { logger } from '../../../utils/logger.js';
@@ -9,6 +9,7 @@ const { writeFileSync } = fse;
  * Setup configuration files:
  * - .env.local (Next.js-facing env: API/app URLs — non-secret, gitignored)
  * - .env.server (SPFN backend env + secrets: DB, cache, pool — never loaded by Next.js, gitignored)
+ * - .env.example (committed, placeholder-only reference for the variables above)
  * - .spfnrc.ts (codegen configuration)
  * - .gitignore (add .spfn directory + env patterns)
  * - tsconfig.json (exclude src/server for Vercel)
@@ -98,6 +99,86 @@ DB_POOL_IDLE_TIMEOUT=30
 # DATABASE_READ_URL=postgresql://user:password@replica:5432/dbname
 # CACHE_PASSWORD=your-redis-password
 `);
+
+    // .env.example — committed, placeholder-only reference for the vars above.
+    // Documentation only: real values go in .env.local / .env.server (gitignored).
+    writeExampleEnv(cwd, `# Example environment — committed reference for the variables SPFN uses.
+# Real values live in .env.local (Next.js) and .env.server (backend secrets),
+# both gitignored. This file documents the keys; it is not loaded by anything.
+
+# --- Next.js-facing (.env.local) ---
+SPFN_API_URL=http://localhost:8790
+NEXT_PUBLIC_SPFN_API_URL=http://localhost:8790
+SPFN_APP_URL=http://localhost:3790
+
+# --- SPFN backend (.env.server) ---
+NODE_ENV=local
+SPFN_LOG_LEVEL=info
+DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+CACHE_URL=redis://localhost:6379
+DB_POOL_MAX=10
+DB_POOL_IDLE_TIMEOUT=30
+
+# --- Optional secrets (uncomment and set as needed) ---
+# DATABASE_WRITE_URL=postgresql://user:password@master:5432/dbname
+# DATABASE_READ_URL=postgresql://user:password@replica:5432/dbname
+# CACHE_PASSWORD=your-redis-password
+`);
+
+    warnOverriddenServerKeys(cwd);
+}
+
+/**
+ * Write the committed .env.example reference, but never clobber a user's own.
+ */
+function writeExampleEnv(cwd: string, content: string): void
+{
+    const filePath = join(cwd, '.env.example');
+
+    if (existsSync(filePath))
+    {
+        return;
+    }
+
+    writeFileSync(filePath, content);
+    logger.success('Created .env.example (committed reference)');
+}
+
+// Active (uncommented) keys .env.server sets — listed so we can warn when one is
+// already defined elsewhere and would be overridden. See loadEnv: .env.server
+// loads last, so its value wins.
+const SERVER_ENV_KEYS = ['NODE_ENV', 'SPFN_LOG_LEVEL', 'DATABASE_URL', 'CACHE_URL', 'DB_POOL_MAX', 'DB_POOL_IDLE_TIMEOUT'];
+
+/**
+ * Warn when a key .env.server owns is already set in another env file the backend
+ * loads earlier. .env.server loads last and wins, so the user's existing value
+ * (e.g. a real DATABASE_URL in .env.local) is silently overridden at runtime.
+ */
+function warnOverriddenServerKeys(cwd: string): void
+{
+    for (const file of otherEnvFiles(cwd))
+    {
+        const keys = collectEnvKeys(readFileSync(join(cwd, file), 'utf-8'));
+        const clashing = SERVER_ENV_KEYS.filter((key) => keys.has(key));
+
+        if (clashing.length > 0)
+        {
+            logger.warn(`${file} also sets ${clashing.join(', ')} — .env.server loads last and its value will win at runtime`);
+        }
+    }
+}
+
+/**
+ * Existing env files the backend loads before .env.server, excluding the
+ * generated reference and any .example templates.
+ */
+function otherEnvFiles(cwd: string): string[]
+{
+    return readdirSync(cwd).filter((name) =>
+        name.startsWith('.env')
+        && name !== '.env.server'
+        && name !== '.env.example'
+        && !name.endsWith('.example'));
 }
 
 /**
@@ -224,6 +305,17 @@ function updateGitignore(cwd: string): void
             updated += `
 # spfn server env (secrets)
 .env.server
+`;
+            changed = true;
+        }
+
+        // Keep the committed .env.example reference tracked even when a broad
+        // `.env*` glob (create-next-app ships one) would otherwise ignore it.
+        if (!hasIgnoreRule(content, '!.env.example'))
+        {
+            updated += `
+# spfn env reference (committed)
+!.env.example
 `;
             changed = true;
         }

--- a/packages/cli/src/commands/init/steps/config-files.ts
+++ b/packages/cli/src/commands/init/steps/config-files.ts
@@ -1,9 +1,37 @@
-import { existsSync, readdirSync, readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import fse from 'fs-extra';
 import { logger } from '../../../utils/logger.js';
 
 const { writeFileSync } = fse;
+
+// .env.server template — SPFN backend only; secrets live here, never loaded by
+// Next.js. SERVER_ENV_KEYS is derived from it so the two never drift.
+const ENV_SERVER_TEMPLATE = `# SPFN backend environment
+# Loaded ONLY by the SPFN server, never by Next.js. Keep all server-only config
+# and secrets here so they never reach the Next.js process.
+
+# Environment
+NODE_ENV=local
+
+# Logging
+SPFN_LOG_LEVEL=info
+
+# Database (matches docker-compose.yml) — secret, server-only
+DATABASE_URL=postgresql://spfn:spfn@localhost:5432/spfn_dev
+
+# Cache — Redis/Valkey (optional)
+CACHE_URL=redis://localhost:6379
+
+# Database pool
+DB_POOL_MAX=10
+DB_POOL_IDLE_TIMEOUT=30
+
+# --- Optional secrets (uncomment and set as needed) ---
+# DATABASE_WRITE_URL=postgresql://user:password@master:5432/dbname
+# DATABASE_READ_URL=postgresql://user:password@replica:5432/dbname
+# CACHE_PASSWORD=your-redis-password
+`;
 
 /**
  * Setup configuration files:
@@ -16,6 +44,9 @@ const { writeFileSync } = fse;
  */
 export async function setupConfigFiles(cwd: string): Promise<void>
 {
+    // Update .gitignore first so the secret-bearing .env.server is written under
+    // an existing ignore rule, never tracked even briefly.
+    updateGitignore(cwd);
     generateEnvFiles(cwd);
 
     // Create .spfnrc.ts for codegen configuration
@@ -46,7 +77,6 @@ export default defineConfig({
         logger.success('Created .spfnrc.ts (codegen configuration)');
     }
 
-    updateGitignore(cwd);
     updateTsconfig(cwd);
 }
 
@@ -74,31 +104,7 @@ SPFN_APP_URL=http://localhost:3790
 `);
 
     // .env.server — SPFN backend only; secrets live here, never loaded by Next.js
-    writeEnvFile(cwd, '.env.server', `# SPFN backend environment
-# Loaded ONLY by the SPFN server, never by Next.js. Keep all server-only config
-# and secrets here so they never reach the Next.js process.
-
-# Environment
-NODE_ENV=local
-
-# Logging
-SPFN_LOG_LEVEL=info
-
-# Database (matches docker-compose.yml) — secret, server-only
-DATABASE_URL=postgresql://spfn:spfn@localhost:5432/spfn_dev
-
-# Cache — Redis/Valkey (optional)
-CACHE_URL=redis://localhost:6379
-
-# Database pool
-DB_POOL_MAX=10
-DB_POOL_IDLE_TIMEOUT=30
-
-# --- Optional secrets (uncomment and set as needed) ---
-# DATABASE_WRITE_URL=postgresql://user:password@master:5432/dbname
-# DATABASE_READ_URL=postgresql://user:password@replica:5432/dbname
-# CACHE_PASSWORD=your-redis-password
-`);
+    writeEnvFile(cwd, '.env.server', ENV_SERVER_TEMPLATE);
 
     // .env.example — committed, placeholder-only reference for the vars above.
     // Documentation only: real values go in .env.local / .env.server (gitignored).
@@ -144,22 +150,41 @@ function writeExampleEnv(cwd: string, content: string): void
     logger.success('Created .env.example (committed reference)');
 }
 
-// Active (uncommented) keys .env.server sets — listed so we can warn when one is
-// already defined elsewhere and would be overridden. See loadEnv: .env.server
-// loads last, so its value wins.
-const SERVER_ENV_KEYS = ['NODE_ENV', 'SPFN_LOG_LEVEL', 'DATABASE_URL', 'CACHE_URL', 'DB_POOL_MAX', 'DB_POOL_IDLE_TIMEOUT'];
+// Active (uncommented) keys .env.server owns, derived from its template so the
+// two never drift. Used to warn when one is already set in an earlier-loaded file.
+const SERVER_ENV_KEYS = collectEnvKeys(ENV_SERVER_TEMPLATE);
+
+// The env files @spfn/core's loadEnv reads BEFORE .env.server (so an existing value
+// would be overridden). Limited to this known set — never a bare `.env*` glob — so
+// unrelated files like direnv's .envrc are not mistaken for SPFN env sources.
+const LOADER_ENV_FILES = [
+    '.env',
+    '.env.local',
+    '.env.development',
+    '.env.development.local',
+    '.env.production',
+    '.env.production.local',
+];
 
 /**
  * Warn when a key .env.server owns is already set in another env file the backend
  * loads earlier. .env.server loads last and wins, so the user's existing value
  * (e.g. a real DATABASE_URL in .env.local) is silently overridden at runtime.
+ * Best-effort: an unreadable entry is skipped, never fatal to init.
  */
 function warnOverriddenServerKeys(cwd: string): void
 {
-    for (const file of otherEnvFiles(cwd))
+    for (const file of LOADER_ENV_FILES)
     {
-        const keys = collectEnvKeys(readFileSync(join(cwd, file), 'utf-8'));
-        const clashing = SERVER_ENV_KEYS.filter((key) => keys.has(key));
+        const content = readEnvFileSafe(join(cwd, file));
+
+        if (content === null)
+        {
+            continue;
+        }
+
+        const keys = collectEnvKeys(content);
+        const clashing = [...SERVER_ENV_KEYS].filter((key) => keys.has(key));
 
         if (clashing.length > 0)
         {
@@ -169,16 +194,19 @@ function warnOverriddenServerKeys(cwd: string): void
 }
 
 /**
- * Existing env files the backend loads before .env.server, excluding the
- * generated reference and any .example templates.
+ * Read a file as text, or null when it's absent, a directory, or unreadable —
+ * so a stray `.env`-named directory never crashes init.
  */
-function otherEnvFiles(cwd: string): string[]
+function readEnvFileSafe(filePath: string): string | null
 {
-    return readdirSync(cwd).filter((name) =>
-        name.startsWith('.env')
-        && name !== '.env.server'
-        && name !== '.env.example'
-        && !name.endsWith('.example'));
+    try
+    {
+        return readFileSync(filePath, 'utf-8');
+    }
+    catch
+    {
+        return null;
+    }
 }
 
 /**
@@ -208,7 +236,9 @@ function writeEnvFile(cwd: string, filename: string, content: string): void
 function mergeMissingEnvKeys(filePath: string, filename: string, template: string): void
 {
     const existing = readFileSync(filePath, 'utf-8');
-    const existingKeys = collectEnvKeys(existing);
+    // Count commented keys as present too: a user who commented out DATABASE_URL
+    // did so deliberately — don't re-append an active default over their choice.
+    const existingKeys = collectDeclaredKeys(existing);
 
     const missing = template
         .split('\n')
@@ -258,6 +288,26 @@ function collectEnvKeys(content: string): Set<string>
 }
 
 /**
+ * Like collectEnvKeys but also counts commented `# KEY=` declarations, so a
+ * deliberately-disabled key is treated as already present and not re-added.
+ */
+function collectDeclaredKeys(content: string): Set<string>
+{
+    const keys = new Set<string>();
+
+    for (const line of content.split('\n'))
+    {
+        const match = line.match(/^\s*#?\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)\s*=/);
+        if (match)
+        {
+            keys.add(match[1]);
+        }
+    }
+
+    return keys;
+}
+
+/**
  * Update .gitignore with SPFN patterns, creating the file if it doesn't exist.
  *
  * The env files generated above are real, secret-bearing files (.env.server holds
@@ -272,75 +322,85 @@ function updateGitignore(cwd: string): void
     try
     {
         const content = existed ? readFileSync(gitignorePath, 'utf-8') : '';
-        let updated = content;
-        let changed = false;
+        const additions = pendingIgnoreRules(content);
 
-        // Add .spfn directory. Substring match so an existing `.spfn`, `.spfn/`
-        // or `/.spfn/` rule all count — gitignore line order is irrelevant, so we
-        // just append rather than splicing after a `/build` anchor.
-        if (!content.includes('.spfn'))
+        if (additions.length === 0)
         {
-            updated += `
-# spfn
-/.spfn/
-`;
-            changed = true;
+            return;
         }
 
-        // Add env local patterns (Next.js)
-        if (!hasIgnoreRule(content, '.env.local') && !hasIgnoreRule(content, '.env.*.local'))
-        {
-            updated += `
-# environment secrets (local overrides)
-.env.local
-.env.*.local
-`;
-            changed = true;
-        }
-
-        // Add .env.server independently — it holds server secrets and must be
-        // ignored regardless of whether the .env.local block above was added.
-        if (!hasIgnoreRule(content, '.env.server'))
-        {
-            updated += `
-# spfn server env (secrets)
-.env.server
-`;
-            changed = true;
-        }
-
-        // Keep the committed .env.example reference tracked even when a broad
-        // `.env*` glob (create-next-app ships one) would otherwise ignore it.
-        if (!hasIgnoreRule(content, '!.env.example'))
-        {
-            updated += `
-# spfn env reference (committed)
-!.env.example
-`;
-            changed = true;
-        }
-
-        if (changed)
-        {
-            writeFileSync(gitignorePath, updated);
-            logger.success(existed
-                ? 'Updated .gitignore with .spfn directory and env patterns'
-                : 'Created .gitignore with .spfn directory and env patterns');
-        }
+        writeFileSync(gitignorePath, content + additions.join(''));
+        logger.success(existed
+            ? 'Updated .gitignore with .spfn directory and env patterns'
+            : 'Created .gitignore with .spfn directory and env patterns');
     }
-    catch (error)
+    catch
     {
         logger.warn('Could not update .gitignore — add .env.local and .env.server manually before committing, so the generated .env.server secrets are not tracked');
     }
 }
 
 /**
- * True when `pattern` is present as its own line (ignoring surrounding
- * whitespace), so `.env.server` does not match `.env.server.example`.
+ * The ignore blocks not already covered by the .gitignore, ready to append.
  */
-function hasIgnoreRule(content: string, pattern: string): boolean
+function pendingIgnoreRules(content: string): string[]
 {
-    return content.split('\n').some((line) => line.trim() === pattern);
+    const rules: string[] = [];
+
+    if (!gitignoreCovers(content, '.spfn'))
+    {
+        rules.push('\n# spfn\n/.spfn/\n');
+    }
+
+    if (!gitignoreCovers(content, '.env.local'))
+    {
+        rules.push('\n# environment secrets (local overrides)\n.env.local\n.env.*.local\n');
+    }
+
+    if (!gitignoreCovers(content, '.env.server'))
+    {
+        rules.push('\n# spfn server env (secrets)\n.env.server\n');
+    }
+
+    // Keep the committed .env.example reference tracked even when a broad `.env*`
+    // glob (create-next-app ships one) would otherwise ignore it.
+    if (!content.split('\n').some((line) => line.trim() === '!.env.example'))
+    {
+        rules.push('\n# spfn env reference (committed)\n!.env.example\n');
+    }
+
+    return rules;
+}
+
+/**
+ * True when some ignore line already covers `target`. Matches an exact rule
+ * (ignoring leading/trailing slashes) or a trailing-`*` glob like `.env*`, but
+ * not a comment, a negation, or a longer name such as `.spfnrc.ts` /
+ * `.env.server.example`.
+ */
+function gitignoreCovers(content: string, target: string): boolean
+{
+    const normalized = stripSlashes(target);
+
+    return content.split('\n').some((raw) =>
+    {
+        const line = raw.trim();
+
+        if (line === '' || line.startsWith('#') || line.startsWith('!'))
+        {
+            return false;
+        }
+
+        const rule = stripSlashes(line);
+
+        return rule === normalized
+            || (rule.endsWith('*') && normalized.startsWith(rule.slice(0, -1)));
+    });
+}
+
+function stripSlashes(value: string): string
+{
+    return value.replace(/^\//, '').replace(/\/$/, '');
 }
 
 /**
@@ -372,7 +432,7 @@ function updateTsconfig(cwd: string): void
             logger.success('Updated tsconfig.json (excluded src/server for Vercel compatibility)');
         }
     }
-    catch (error)
+    catch
     {
         logger.warn('Could not update tsconfig.json (you can add "src/server" to exclude manually)');
     }

--- a/packages/cli/src/commands/init/steps/readme.ts
+++ b/packages/cli/src/commands/init/steps/readme.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { basename, join } from 'path';
 import fse from 'fs-extra';
 import { logger } from '../../../utils/logger.js';
+import { getRunCommand, type PackageManager } from '../../../utils/package-manager.js';
 import { findTemplatesPath } from '../utils/templates.js';
 import type { PackageJson } from './validate.js';
 
@@ -9,9 +10,12 @@ const { writeFileSync } = fse;
 
 interface ReadmeContext
 {
-    pm: string;
+    pm: PackageManager;
     packageJson: PackageJson;
     includeAuth: boolean;
+    // `spfn create` sets this so the SPFN README replaces the create-next-app
+    // default; a standalone `spfn init` leaves it false to keep any existing README.
+    overwrite: boolean;
 }
 
 interface RenderVars
@@ -23,38 +27,42 @@ interface RenderVars
 }
 
 /**
- * Create a SPFN-flavored README.md when the project doesn't already have one.
+ * Create a SPFN-flavored README.md.
  *
- * Policy: if a README.md is present, leave it untouched — we never clobber an
- * existing README. `spfn create` deletes the create-next-app README right after
- * scaffolding, so a fresh `create` lands the SPFN README here, while a standalone
- * `spfn init` preserves whatever README the project already has.
+ * Policy: a standalone `spfn init` never clobbers an existing README. `spfn create`
+ * passes `overwrite: true` so the freshly scaffolded create-next-app README is
+ * replaced with the SPFN one. If the template can't be read, the existing README
+ * (e.g. the create-next-app default) is left in place rather than deleted.
  */
 export async function setupReadme(cwd: string, ctx: ReadmeContext): Promise<void>
 {
     const readmePath = join(cwd, 'README.md');
 
-    if (existsSync(readmePath))
+    if (existsSync(readmePath) && !ctx.overwrite)
     {
         logger.info('README.md already exists — keeping it');
+
         return;
     }
 
     const templatePath = join(findTemplatesPath(), 'README.md');
+    let template: string;
 
-    if (!existsSync(templatePath))
+    try
+    {
+        template = readFileSync(templatePath, 'utf-8');
+    }
+    catch (error)
     {
         logger.warn('README template not found — skipping README generation');
+
         return;
     }
 
-    const projectName = ctx.packageJson.name || cwd.split('/').pop() || 'my-app';
-    const pmRun = ctx.pm === 'npm' ? 'npm run' : `${ctx.pm} run`;
-
-    const content = renderReadme(readFileSync(templatePath, 'utf-8'), {
-        projectName,
+    const content = renderReadme(template, {
+        projectName: ctx.packageJson.name || basename(cwd) || 'my-app',
         pm: ctx.pm,
-        pmRun,
+        pmRun: getRunCommand(ctx.pm),
         includeAuth: ctx.includeAuth,
     });
 
@@ -66,10 +74,12 @@ export async function setupReadme(cwd: string, ctx: ReadmeContext): Promise<void
  * Substitute template placeholders and resolve the optional auth block.
  * The auth block is delimited by `<!-- {{#auth}} -->` / `<!-- {{/auth}} -->`:
  * kept (markers stripped) when auth is included, removed entirely otherwise.
+ * Line terminators are matched as `\r?\n` so a CRLF-checked-out template still
+ * strips the block.
  */
 function renderReadme(template: string, vars: RenderVars): string
 {
-    const authBlock = /\n?<!-- \{\{#auth\}\} -->\n([\s\S]*?)\n<!-- \{\{\/auth\}\} -->\n/;
+    const authBlock = /\r?\n?<!-- \{\{#auth\}\} -->\r?\n([\s\S]*?)\r?\n<!-- \{\{\/auth\}\} -->\r?\n/;
 
     return template
         .replace(authBlock, vars.includeAuth ? '\n$1\n' : '\n')

--- a/packages/cli/src/commands/init/steps/readme.ts
+++ b/packages/cli/src/commands/init/steps/readme.ts
@@ -52,7 +52,7 @@ export async function setupReadme(cwd: string, ctx: ReadmeContext): Promise<void
     {
         template = readFileSync(templatePath, 'utf-8');
     }
-    catch (error)
+    catch
     {
         logger.warn('README template not found — skipping README generation');
 

--- a/packages/cli/src/commands/init/steps/readme.ts
+++ b/packages/cli/src/commands/init/steps/readme.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import fse from 'fs-extra';
+import { logger } from '../../../utils/logger.js';
+import { findTemplatesPath } from '../utils/templates.js';
+import type { PackageJson } from './validate.js';
+
+const { writeFileSync } = fse;
+
+interface ReadmeContext
+{
+    pm: string;
+    packageJson: PackageJson;
+    includeAuth: boolean;
+}
+
+interface RenderVars
+{
+    projectName: string;
+    pm: string;
+    pmRun: string;
+    includeAuth: boolean;
+}
+
+/**
+ * Create a SPFN-flavored README.md when the project doesn't already have one.
+ *
+ * Policy: if a README.md is present, leave it untouched — we never clobber an
+ * existing README. `spfn create` deletes the create-next-app README right after
+ * scaffolding, so a fresh `create` lands the SPFN README here, while a standalone
+ * `spfn init` preserves whatever README the project already has.
+ */
+export async function setupReadme(cwd: string, ctx: ReadmeContext): Promise<void>
+{
+    const readmePath = join(cwd, 'README.md');
+
+    if (existsSync(readmePath))
+    {
+        logger.info('README.md already exists — keeping it');
+        return;
+    }
+
+    const templatePath = join(findTemplatesPath(), 'README.md');
+
+    if (!existsSync(templatePath))
+    {
+        logger.warn('README template not found — skipping README generation');
+        return;
+    }
+
+    const projectName = ctx.packageJson.name || cwd.split('/').pop() || 'my-app';
+    const pmRun = ctx.pm === 'npm' ? 'npm run' : `${ctx.pm} run`;
+
+    const content = renderReadme(readFileSync(templatePath, 'utf-8'), {
+        projectName,
+        pm: ctx.pm,
+        pmRun,
+        includeAuth: ctx.includeAuth,
+    });
+
+    writeFileSync(readmePath, content);
+    logger.success('Created README.md');
+}
+
+/**
+ * Substitute template placeholders and resolve the optional auth block.
+ * The auth block is delimited by `<!-- {{#auth}} -->` / `<!-- {{/auth}} -->`:
+ * kept (markers stripped) when auth is included, removed entirely otherwise.
+ */
+function renderReadme(template: string, vars: RenderVars): string
+{
+    const authBlock = /\n?<!-- \{\{#auth\}\} -->\n([\s\S]*?)\n<!-- \{\{\/auth\}\} -->\n/;
+
+    return template
+        .replace(authBlock, vars.includeAuth ? '\n$1\n' : '\n')
+        .replaceAll('{{projectName}}', vars.projectName)
+        .replaceAll('{{pmRun}}', vars.pmRun)
+        .replaceAll('{{pm}}', vars.pm);
+}

--- a/packages/cli/src/commands/init/steps/readme.ts
+++ b/packages/cli/src/commands/init/steps/readme.ts
@@ -81,9 +81,11 @@ function renderReadme(template: string, vars: RenderVars): string
 {
     const authBlock = /\r?\n?<!-- \{\{#auth\}\} -->\r?\n([\s\S]*?)\r?\n<!-- \{\{\/auth\}\} -->\r?\n/;
 
+    // Function replacers so a value containing `$` (e.g. a directory name used as
+    // projectName) is inserted literally, not read as a $1/$& replacement pattern.
     return template
         .replace(authBlock, vars.includeAuth ? '\n$1\n' : '\n')
-        .replaceAll('{{projectName}}', vars.projectName)
-        .replaceAll('{{pmRun}}', vars.pmRun)
-        .replaceAll('{{pm}}', vars.pm);
+        .replaceAll('{{projectName}}', () => vars.projectName)
+        .replaceAll('{{pmRun}}', () => vars.pmRun)
+        .replaceAll('{{pm}}', () => vars.pm);
 }

--- a/packages/cli/src/utils/messages.ts
+++ b/packages/cli/src/utils/messages.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared CLI guidance strings, kept in one place so the same fact isn't worded
+ * differently across `spfn create` and `spfn init` next-steps output.
+ */
+
+// The generated env split. `spfn create` and `spfn init` both surface this.
+export const ENV_FILES_HINT = 'server secrets belong in .env.server — Next.js never loads it';

--- a/packages/cli/src/utils/package-manager.ts
+++ b/packages/cli/src/utils/package-manager.ts
@@ -73,6 +73,11 @@ export function getInstallCommand(pm: PackageManager): string
     }
 }
 
+export function getRunCommand(pm: PackageManager): string
+{
+    return pm === 'npm' ? 'npm run' : `${pm} run`;
+}
+
 export function getAddCommand(pm: PackageManager, packages: string[]): string
 {
     const pkgs = packages.join(' ');

--- a/packages/cli/templates/README.md
+++ b/packages/cli/templates/README.md
@@ -17,11 +17,10 @@ A full-stack app built with [SPFN](https://github.com/spfn/spfn) — a
    docker compose up -d
    ```
 
-2. Configure environment variables:
-
-   ```bash
-   cp .env.local.example .env.local
-   ```
+2. Environment files are already generated — `.env.local` for Next.js and
+   `.env.server` for backend secrets (database, cache). The defaults match the
+   bundled `docker compose`, so no copying is needed. Edit them as your app grows;
+   keep server secrets in `.env.server` (Next.js never loads it).
 
 3. Start the dev server (Next.js + SPFN backend together):
 

--- a/packages/cli/templates/README.md
+++ b/packages/cli/templates/README.md
@@ -1,0 +1,95 @@
+# {{projectName}}
+
+A full-stack app built with [SPFN](https://github.com/spfn/spfn) — a
+[Next.js](https://nextjs.org) frontend with a typed SPFN backend.
+
+## Prerequisites
+
+- Node.js ≥ 18.18
+- [Docker](https://www.docker.com/) — runs PostgreSQL & Redis locally
+- `{{pm}}` (package manager)
+
+## Getting Started
+
+1. Start PostgreSQL & Redis:
+
+   ```bash
+   docker compose up -d
+   ```
+
+2. Configure environment variables:
+
+   ```bash
+   cp .env.local.example .env.local
+   ```
+
+3. Start the dev server (Next.js + SPFN backend together):
+
+   ```bash
+   {{pmRun}} spfn:dev
+   ```
+
+Your app will be available at:
+
+- **Next.js** — http://localhost:3790
+- **SPFN API** — http://localhost:8790
+
+## Project structure
+
+```
+src/
+├── app/              # Next.js App Router (frontend)
+├── server/           # SPFN backend
+│   ├── entities/     # Drizzle tables
+│   ├── repositories/ # Data access (extends BaseRepository)
+│   ├── routes/       # route.get/post/... with TypeBox validation
+│   ├── router.ts     # defineRouter — registers routes
+│   └── config/       # env.config.ts, server.config.ts
+├── generated/        # Generated route map — do not edit by hand
+└── lib/              # Shared contracts and the typed API client
+```
+
+A feature is built as a vertical slice:
+**Entity → Repository → Route → Router → codegen → typed client**.
+
+## Common commands
+
+| Command | Description |
+| --- | --- |
+| `{{pmRun}} spfn:dev` | Start Next.js + the SPFN backend |
+| `{{pmRun}} spfn:build` | Build for production |
+| `{{pmRun}} spfn:start` | Run the production build |
+| `spfn codegen run` | Regenerate the route map after changing routes |
+| `spfn db:generate` | Create a migration from entity changes |
+| `spfn env:validate` | Validate environment variables |
+| `spfn env:docs` | Generate environment documentation |
+
+> After editing routes or routers, run `spfn codegen run` and commit the
+> regenerated `src/generated/`. After changing an entity, run `spfn db:generate`
+> to create a migration — don't write SQL by hand.
+
+<!-- {{#auth}} -->
+## Authentication
+
+This project includes [`@spfn/auth`](https://github.com/spfn/spfn/tree/main/packages/auth).
+Auth routes are mounted under the main router and exposed through the typed
+`authApi` client. See the package README for the full flow — signup, login,
+OAuth, and RBAC.
+<!-- {{/auth}} -->
+
+## Deployment
+
+Build and run the whole stack with Docker:
+
+```bash
+docker compose -f docker-compose.production.yml up --build -d
+```
+
+The SPFN backend (`src/server`) runs as its own service and is excluded from the
+Next.js/Vercel build. If you deploy the frontend to a managed host, deploy the
+backend separately.
+
+## Learn more
+
+- [SPFN documentation](https://github.com/spfn/spfn)
+- [Next.js documentation](https://nextjs.org/docs)


### PR DESCRIPTION
## What

Reworks what `spfn create` / `spfn init` lay down for a new SPFN app:

- **Generates a SPFN-flavored `README.md`** instead of leaving the create-next-app
  default. `spfn create` replaces the CNA README; a standalone `init` keeps any
  existing README. Optional auth section is templated in/out.
- **Splits env into two real files** instead of `*.example` templates you must copy:
  - `.env.local` — Next.js-facing, non-secret URLs (`SPFN_API_URL`, `NEXT_PUBLIC_*`, `SPFN_APP_URL`)
  - `.env.server` — backend-only secrets (DB, cache, pool); never loaded by Next.js
  - `.env.example` — committed, **placeholder-only** reference derived from the two
    templates (so its key list can't drift), kept tracked via a `!.env.example` rule
- **`.gitignore` is ensured first** (created if absent) so the secret-bearing
  `.env.server` is never tracked, with a matcher that understands `.env*` globs and
  `!` negations and won't false-match `.spfnrc.ts`.

## Behavior on existing projects

- `.env.local`: created, or missing SPFN keys merged in (its values are safe to add;
  commented-out keys are respected and not re-added).
- `.env.server`: if the user already has one, it is **left untouched** (it holds their
  real secrets) — SPFN's template is written beside it as `.env.server.example`
  (credentials placeholdered) with a warning to reconcile by hand.

## Misc

- Adds `getRunCommand(pm)` and routes the hand-rolled `<pm> run` branches through it
  (create/build/init/readme), fixing a missing `run` in one init message.
- `README.md` replacements are `$`-safe (directory names containing `$`).
- `packages/cli/README.md` updated to describe the generated files (no stale
  `cp *.example` guidance).

Hardened over several review passes (env-merge edge cases, gitignore coverage,
CRLF/Windows paths, placeholder compliance with AGENTS.md rule #4). Verified with
`pnpm type-check`, `pnpm lint`, `pnpm build`, and temp-dir integration tests of the
generate/merge/sidecar paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)