### PR TITLE
fix(cli)!: ops CLI 표면 전체 리뷰의 결과 — https 강제, 앱 기준 패키지 해석, 매니페스트 신뢰 경계

### DIFF
--- a/packages/auth/src/server/entities/ops-tokens.ts
+++ b/packages/auth/src/server/entities/ops-tokens.ts
@@ -6,9 +6,10 @@
  * list, and the row stores only the SHA-256 hash of the secret — the secret
  * itself is shown once at issuance and never persisted.
  *
- * Issuance is an operator act performed where database access already exists
- * (`spfn ops token issue`); there is no HTTP surface for creating tokens, so
- * a deployed app exposes verification only.
+ * Issuance is an operator act, and it goes over HTTP like everything else on
+ * this surface: `POST /_auth/ops-tokens`, behind `authenticate` plus
+ * `requireRole('admin', 'superadmin')`. `spfn ops token issue` signs in as an
+ * administrator and calls it, so the CLI needs no database access of its own.
  */
 
 import { text } from 'drizzle-orm/pg-core';

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -411,8 +411,14 @@ listSignups  GET /_ops/signups
 Add `--json` for the raw JSON Schema. The server still validates every call — `--describe`
 reports what it will accept, and the app's answer decides.
 
-The app URL comes from `--app` or `SPFN_OPS_APP`. The ops token resolves `--token` →
-`SPFN_OPS_TOKEN` → macOS keychain, and its lifecycle is managed with:
+The app URL comes from `--app` or `SPFN_OPS_APP`, and it must be **https** — every one of
+these commands carries a secret, and `token issue` carries an administrator's password.
+`http` is accepted only against `localhost`, `127.0.0.1` and `::1`, where there is no
+network to listen on. A URL with a base path (`https://example.com/api`) is kept whole:
+both the ops calls and the administrator sign-in go through it.
+
+The ops token resolves `--token` → `SPFN_OPS_TOKEN` → macOS keychain, and its lifecycle is
+managed with:
 
 ```bash
 spfn ops token issue --name laptop --scopes 'waitlist:read' --app <url>
@@ -441,6 +447,10 @@ ops token lives in its schema, and the signing comes from its `@spfn/auth/crypto
 point, which that release added. The CLI does not depend on the package in any form — it
 loads it from the app at run time, and tells a missing package apart from one too old to
 carry the entry point, so the message names the thing to do.
+
+Because the package is the app's, it is resolved **from the directory the command runs in**.
+Run `spfn ops token` from the app's root; running it elsewhere reports the package as
+missing, and the message names the directory it looked in.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spfn",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "Scaffold a full-stack TypeScript backend onto a Next.js app built with an AI coding agent: auth, database, typed routes and codegen, one fixed vertical slice per feature",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/ops/__tests__/resolve.test.ts
+++ b/packages/cli/src/commands/ops/__tests__/resolve.test.ts
@@ -1,0 +1,135 @@
+/**
+ * `spfn ops` target resolution — which app the CLI talks to.
+ *
+ * Every command here sends a secret: `token issue` posts an administrator's
+ * password, `list` and `call` present an ops token. The scheme of the URL that
+ * carries them is therefore part of the command's contract, not a formatting
+ * detail, which is what these tests pin.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveAppUrl, resolveToken } from '../resolve.js';
+
+const keychain = vi.hoisted(() => ({
+    keychainSupported: vi.fn(() => false),
+    loadOpsToken: vi.fn(async () => null as string | null),
+}));
+
+vi.mock('../../../utils/ops/keychain.js', () => keychain);
+
+/** `process.exit` is typed `never`, so a refusal has to be caught as a throw. */
+class Exited extends Error
+{
+    constructor(public readonly code: number | undefined)
+    {
+        super(`process.exit(${code})`);
+    }
+}
+
+beforeEach(() =>
+{
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) =>
+    {
+        throw new Exited(code);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => 
+    {});
+    delete process.env.SPFN_OPS_APP;
+    delete process.env.SPFN_OPS_TOKEN;
+    keychain.keychainSupported.mockReturnValue(false);
+    keychain.loadOpsToken.mockResolvedValue(null);
+});
+
+afterEach(() =>
+{
+    vi.restoreAllMocks();
+});
+
+describe('resolveAppUrl', () =>
+{
+    it('accepts https', () =>
+    {
+        expect(resolveAppUrl({ app: 'https://api.example.com' })).toBe('https://api.example.com');
+    });
+
+    it('keeps a base path untouched', () =>
+    {
+        expect(resolveAppUrl({ app: 'https://example.com/api' })).toBe('https://example.com/api');
+    });
+
+    it.each([
+        'http://localhost:8790',
+        'http://127.0.0.1:8790',
+        'http://[::1]:8790',
+        'http://app.localhost:8790',
+    ])('allows http against a loopback host (%s)', (url) =>
+    {
+        expect(resolveAppUrl({ app: url })).toBe(url);
+    });
+
+    it('refuses http to a remote host, so an administrator password is never sent in the clear', () =>
+    {
+        expect(() => resolveAppUrl({ app: 'http://api.example.com' })).toThrow(Exited);
+        expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/over http/);
+    });
+
+    it('refuses http coming from a stale SPFN_OPS_APP just as it refuses the flag', () =>
+    {
+        process.env.SPFN_OPS_APP = 'http://api.example.com';
+        expect(() => resolveAppUrl({})).toThrow(Exited);
+    });
+
+    it.each(['file:///etc/passwd', 'ftp://files.example.com', 'javascript:alert(1)'])(
+        'refuses a non-HTTP scheme (%s)',
+        (url) =>
+        {
+            expect(() => resolveAppUrl({ app: url })).toThrow(Exited);
+        },
+    );
+
+    it('refuses a URL that does not parse', () =>
+    {
+        expect(() => resolveAppUrl({ app: 'not a url' })).toThrow(Exited);
+    });
+
+    it('refuses when no app was named at all', () =>
+    {
+        expect(() => resolveAppUrl({})).toThrow(Exited);
+    });
+});
+
+describe('resolveToken', () =>
+{
+    it('prefers the flag over the environment', async () =>
+    {
+        process.env.SPFN_OPS_TOKEN = 'spfn_ops_env';
+        await expect(resolveToken({ token: 'spfn_ops_flag' }, 'https://api.example.com'))
+            .resolves.toBe('spfn_ops_flag');
+    });
+
+    it('falls back to the environment', async () =>
+    {
+        process.env.SPFN_OPS_TOKEN = 'spfn_ops_env';
+        await expect(resolveToken({}, 'https://api.example.com')).resolves.toBe('spfn_ops_env');
+    });
+
+    it('reads the keychain when nothing else named a token', async () =>
+    {
+        keychain.keychainSupported.mockReturnValue(true);
+        keychain.loadOpsToken.mockResolvedValue('spfn_ops_stored');
+
+        await expect(resolveToken({}, 'https://api.example.com')).resolves.toBe('spfn_ops_stored');
+        expect(keychain.loadOpsToken).toHaveBeenCalledWith('api.example.com');
+    });
+
+    it('advises instead of crashing when the keychain cannot be read', async () =>
+    {
+        keychain.keychainSupported.mockReturnValue(true);
+        keychain.loadOpsToken.mockRejectedValue(new Error('The user name or passphrase you entered is not correct.'));
+
+        // A locked keychain must reach the "no token" refusal, not surface as
+        // an unhandled rejection the top-level handler dumps as a stack trace.
+        await expect(resolveToken({}, 'https://api.example.com')).rejects.toThrow(Exited);
+        expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/Could not read the keychain/);
+    });
+});

--- a/packages/cli/src/commands/ops/__tests__/token.test.ts
+++ b/packages/cli/src/commands/ops/__tests__/token.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `spfn ops token issue` — what happens to the secret.
+ *
+ * The secret exists in the clear exactly once, in the issuance answer. Whatever
+ * the command does after that decides whether the operator ends up holding a
+ * usable token or a row nobody can present and nobody knows to revoke, so both
+ * ways of delivering it are pinned here.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const keychain = vi.hoisted(() => ({
+    keychainSupported: vi.fn(() => true),
+    storeOpsToken: vi.fn(async () => 
+    {}),
+    deleteOpsToken: vi.fn(async () => 
+    {}),
+    loadOpsToken: vi.fn(async () => null as string | null),
+}));
+
+const session = vi.hoisted(() => ({
+    adminRequest: vi.fn(),
+    assertInteractive: vi.fn(),
+    withAdminSession: vi.fn(async (_appUrl: string, run: (s: unknown) => Promise<unknown>) =>
+        await run({ authorization: 'Bearer x', keyId: 'k' })),
+}));
+
+vi.mock('../../../utils/ops/keychain.js', () => keychain);
+vi.mock('../../../utils/ops/admin-session.js', () => session);
+
+const SECRET = 'spfn_ops_0123456789abcdef';
+
+/** Drive the `issue` subcommand the way commander would. */
+async function issue(extra: string[] = []): Promise<void>
+{
+    const { buildTokenCommand } = await import('../token.js');
+
+    await buildTokenCommand().parseAsync(
+        ['issue', '--name', 'laptop', '--scopes', 'waitlist:read', '--app', 'https://api.example.com', ...extra],
+        { from: 'user' },
+    );
+}
+
+beforeEach(() =>
+{
+    vi.spyOn(console, 'log').mockImplementation(() => 
+    {});
+    vi.spyOn(console, 'error').mockImplementation(() => 
+    {});
+    keychain.keychainSupported.mockReturnValue(true);
+    keychain.storeOpsToken.mockResolvedValue(undefined);
+    session.adminRequest.mockResolvedValue({
+        token: SECRET,
+        opsToken: { id: 1, name: 'laptop', scopes: ['waitlist:read'], expiresAt: null, revokedAt: null, lastUsedAt: null },
+    });
+});
+
+afterEach(() =>
+{
+    vi.restoreAllMocks();
+});
+
+function printed(): string
+{
+    return [
+        ...vi.mocked(console.log).mock.calls.flat(),
+        ...vi.mocked(console.error).mock.calls.flat(),
+    ].join('\n');
+}
+
+describe('spfn ops token issue', () =>
+{
+    it('prints the secret when no keychain was asked for', async () =>
+    {
+        await issue();
+
+        expect(printed()).toContain(SECRET);
+    });
+
+    it('stores the secret without printing it, given --to-keychain', async () =>
+    {
+        await issue(['--to-keychain']);
+
+        expect(keychain.storeOpsToken).toHaveBeenCalledWith('api.example.com', SECRET);
+        expect(printed()).not.toContain(SECRET);
+    });
+
+    it('falls back to printing when the keychain refuses, so an issued token is never lost', async () =>
+    {
+        // The row already exists at this point. A locked keychain that swallowed
+        // the secret would leave a token nobody can present and nobody knows to
+        // revoke.
+        keychain.storeOpsToken.mockRejectedValue(new Error('User interaction is not allowed.'));
+
+        await issue(['--to-keychain']);
+
+        expect(printed()).toMatch(/Keychain storage failed/);
+        expect(printed()).toContain(SECRET);
+    });
+});

--- a/packages/cli/src/commands/ops/index.ts
+++ b/packages/cli/src/commands/ops/index.ts
@@ -18,7 +18,7 @@ import {
     invokeOpsCommand,
     type OpsCommandDescriptor,
 } from '../../utils/ops/client.js';
-import { renderCommandUsage } from '../../utils/ops/describe.js';
+import { plain, renderCommandUsage } from '../../utils/ops/describe.js';
 import { collectKeyValue, resolveAppUrl, resolveToken, type OpsTargetOptions } from './resolve.js';
 import { buildTokenCommand } from './token.js';
 
@@ -57,7 +57,7 @@ async function listCommands(options: OpsTargetOptions): Promise<void>
     console.log(chalk.bold(`Ops commands at ${appUrl}:\n`));
     for (const command of manifest.commands)
     {
-        console.log(`  ${chalk.cyan(command.name)}  ${chalk.gray(`${command.method} ${command.path}`)}  input: ${inputSummary(command)}`);
+        console.log(`  ${chalk.cyan(plain(command.name))}  ${chalk.gray(`${command.method} ${plain(command.path)}`)}  input: ${inputSummary(command)}`);
     }
     console.log(chalk.gray('\n💡 Invoke: spfn ops call <name> [--param k=v] [--query k=v] [--data \'{"..."}\']'));
     console.log(chalk.gray('   Usage of one: spfn ops call <name> --describe'));
@@ -81,8 +81,8 @@ async function callCommand(
     const command = manifest.commands.find(c => c.name === name);
     if (!command)
     {
-        console.error(chalk.red(`❌ Unknown ops command "${name}".`));
-        console.error(chalk.gray(`   Known: ${manifest.commands.map(c => c.name).join(', ') || '(none)'}`));
+        console.error(chalk.red(`❌ Unknown ops command "${plain(name)}".`));
+        console.error(chalk.gray(`   Known: ${manifest.commands.map(c => plain(c.name)).join(', ') || '(none)'}`));
         process.exit(1);
     }
 
@@ -100,7 +100,7 @@ async function callCommand(
         {
             // fetch throws a raw TypeError on a GET with a body; say which
             // flag was wrong instead of printing a stack trace.
-            console.error(chalk.red(`❌ "${name}" is a ${command.method} command and takes no request body.`));
+            console.error(chalk.red(`❌ "${plain(name)}" is a ${command.method} command and takes no request body.`));
             console.error(chalk.gray('   Pass its input with --query k=v (or --param k=v for path segments).'));
             process.exit(1);
         }
@@ -133,7 +133,7 @@ async function callCommand(
         return;
     }
 
-    console.error(chalk.red(`❌ ${command.method} ${command.path} answered ${response.status}`));
+    console.error(chalk.red(`❌ ${command.method} ${plain(command.path)} answered ${response.status}`));
     console.error(rendered);
     process.exit(1);
 }

--- a/packages/cli/src/commands/ops/resolve.ts
+++ b/packages/cli/src/commands/ops/resolve.ts
@@ -13,6 +13,50 @@ export interface OpsTargetOptions
     token?: string;
 }
 
+/**
+ * Where `http` is not a mistake: a machine talking to itself, which has no
+ * certificate to present and no network for anyone to listen on.
+ *
+ * The scaffold's own API runs on `http://localhost:8790`, so local development
+ * has to keep working — but that is the whole of the exception.
+ */
+function isLoopback(hostname: string): boolean
+{
+    return hostname === 'localhost'
+        || hostname === '127.0.0.1'
+        || hostname === '[::1]'
+        || hostname.endsWith('.localhost');
+}
+
+/**
+ * Refuse an app URL that would carry a secret in the clear.
+ *
+ * Every `spfn ops` command sends one: `token issue` prompts for an
+ * administrator's password and posts it, and `list` / `call` present an ops
+ * token. A stale `SPFN_OPS_APP` left over from a local run, or a typo'd
+ * `--app`, is enough to put either on the wire unencrypted — and nothing about
+ * the command's output would say so.
+ */
+function assertTransportSafe(parsed: URL, appUrl: string): void
+{
+    if (parsed.protocol === 'https:' || (parsed.protocol === 'http:' && isLoopback(parsed.hostname)))
+    {
+        return;
+    }
+
+    if (parsed.protocol === 'http:')
+    {
+        console.error(chalk.red(`❌ Refusing to talk to ${appUrl} over http.`));
+        console.error(chalk.gray('   An administrator password and an ops token cross this connection, and http sends both in the clear.'));
+        console.error(chalk.gray('   Use https. http is allowed only against localhost.'));
+        process.exit(1);
+    }
+
+    console.error(chalk.red(`❌ App URL must be https, got "${parsed.protocol}//".`));
+    console.error(chalk.gray('   The ops surface is reached over HTTP(S) — http is allowed only against localhost.'));
+    process.exit(1);
+}
+
 export function resolveAppUrl(options: OpsTargetOptions): string
 {
     const appUrl = options.app ?? process.env.SPFN_OPS_APP;
@@ -23,15 +67,19 @@ export function resolveAppUrl(options: OpsTargetOptions): string
         process.exit(1);
     }
 
+    let parsed: URL;
+
     try
     {
-        new URL(appUrl);
+        parsed = new URL(appUrl);
     }
     catch
     {
         console.error(chalk.red(`❌ Invalid app URL: ${appUrl}`));
         process.exit(1);
     }
+
+    assertTransportSafe(parsed, appUrl);
 
     return appUrl;
 }
@@ -59,7 +107,21 @@ export async function resolveToken(options: OpsTargetOptions, appUrl: string): P
 
     if (keychainSupported())
     {
-        const stored = await loadOpsToken(appAccount(appUrl));
+        // A keychain that cannot be read is not the same as one holding
+        // nothing: a locked keychain, or a denied access prompt, rejects here.
+        // Left uncaught it reaches the CLI's top-level handler, which prints
+        // the raw error object — so the operator gets a stack trace where the
+        // answer is one flag away.
+        const stored = await loadOpsToken(appAccount(appUrl)).catch((err: unknown) =>
+        {
+            console.error(chalk.yellow(
+                `⚠️  Could not read the keychain (${err instanceof Error ? err.message : String(err)}).`,
+            ));
+            console.error(chalk.gray('   Unlock it, or pass --token / set SPFN_OPS_TOKEN for this run.'));
+
+            return null;
+        });
+
         if (stored)
         {
             return stored;

--- a/packages/cli/src/utils/__tests__/ops-auth-crypto.test.ts
+++ b/packages/cli/src/utils/__tests__/ops-auth-crypto.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Where `@spfn/auth/crypto` is loaded from.
+ *
+ * The CLI does not depend on `@spfn/auth` in any form; it borrows the app's.
+ * Which app, though, is decided by where resolution starts — and the documented
+ * way to run this CLI (`npx spfn@beta`) unpacks it into the npx cache, nowhere
+ * near the app. Resolution therefore starts at the directory the command runs
+ * in, and these tests pin that along with the two failures the operator is told
+ * apart: a package that is absent, and one too old to carry the entry point.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Module from 'node:module';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadAuthCrypto } from '../ops/auth-crypto.js';
+
+let appDir: string;
+let originalCwd: string;
+let originalNodePath: string | undefined;
+
+/**
+ * Take the test runner's `NODE_PATH` out of the picture.
+ *
+ * vitest sets it to pnpm's hoisted store, and CommonJS resolution consults it
+ * after the directory walk — so a temp app with nothing installed would still
+ * find this monorepo's own `@spfn/auth` and the absent-package case could never
+ * be observed. Nothing sets `NODE_PATH` for a real `spfn` run. The paths are
+ * recomputed from the variable, which is why clearing it alone is not enough.
+ */
+function withoutInheritedNodePath(): void
+{
+    originalNodePath = process.env.NODE_PATH;
+    delete process.env.NODE_PATH;
+    (Module as unknown as { _initPaths(): void })._initPaths();
+}
+
+function restoreNodePath(): void
+{
+    if (originalNodePath === undefined)
+    {
+        delete process.env.NODE_PATH;
+    }
+    else
+    {
+        process.env.NODE_PATH = originalNodePath;
+    }
+
+    (Module as unknown as { _initPaths(): void })._initPaths();
+}
+
+/** An app directory with `@spfn/auth` installed, exporting what is asked for. */
+function installAuth(exports: Record<string, string>, files: Record<string, string> = {}): void
+{
+    const pkgDir = join(appDir, 'node_modules', '@spfn', 'auth');
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({
+        name: '@spfn/auth',
+        version: '0.0.0-test',
+        type: 'module',
+        exports,
+    }));
+
+    for (const [name, source] of Object.entries(files))
+    {
+        writeFileSync(join(pkgDir, name), source);
+    }
+}
+
+beforeEach(() =>
+{
+    originalCwd = process.cwd();
+    appDir = mkdtempSync(join(tmpdir(), 'spfn-ops-auth-'));
+    writeFileSync(join(appDir, 'package.json'), JSON.stringify({ name: 'an-app', type: 'module' }));
+    process.chdir(appDir);
+    withoutInheritedNodePath();
+});
+
+afterEach(() =>
+{
+    restoreNodePath();
+    process.chdir(originalCwd);
+    rmSync(appDir, { recursive: true, force: true });
+});
+
+describe('loadAuthCrypto', () =>
+{
+    it("loads the app's package even though the CLI lives elsewhere", async () =>
+    {
+        installAuth(
+            { './crypto': './crypto.js' },
+            { 'crypto.js': 'export const generateKeyPair = () => ({}); export const generateClientToken = () => "";' },
+        );
+
+        const crypto = await loadAuthCrypto();
+
+        expect(typeof crypto.generateKeyPair).toBe('function');
+        expect(typeof crypto.generateClientToken).toBe('function');
+    });
+
+    it('names the directory it looked in when the package is absent', async () =>
+    {
+        // Before resolution moved to the app, this was what an `npx` run got
+        // even when the app did have the package — the operator was sent to
+        // install what they already had.
+        await expect(loadAuthCrypto()).rejects.toThrow(/No @spfn\/auth is installed in/);
+    });
+
+    it('tells an older package apart from a missing one', async () =>
+    {
+        installAuth({ '.': './index.js' }, { 'index.js': 'export const x = 1;' });
+
+        await expect(loadAuthCrypto()).rejects.toThrow(/older than 0\.3\.0-beta\.2/);
+    });
+});

--- a/packages/cli/src/utils/__tests__/ops-manifest-trust.test.ts
+++ b/packages/cli/src/utils/__tests__/ops-manifest-trust.test.ts
@@ -1,0 +1,135 @@
+/**
+ * What the CLI accepts from an app's manifest.
+ *
+ * The manifest is the application's own description of itself, and the CLI
+ * turns it into a request carrying an ops token — so it is the one input on
+ * this surface that is not the operator's. These tests pin what happens to a
+ * manifest that is malformed, hostile, or simply newer than this CLI.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchOpsManifest, joinUrl, type OpsCommandDescriptor } from '../ops/client.js';
+import { plain, renderCommandUsage } from '../ops/describe.js';
+
+const ESC = String.fromCharCode(27);
+
+function manifestAnswer(commands: unknown[]): void
+{
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(
+        JSON.stringify({ manifestVersion: 1, commands }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+}
+
+beforeEach(() =>
+{
+    vi.spyOn(console, 'error').mockImplementation(() => 
+    {});
+});
+
+afterEach(() =>
+{
+    vi.restoreAllMocks();
+});
+
+describe('joinUrl', () =>
+{
+    it('keeps the app URL base path, which `new URL(path, base)` would drop', () =>
+    {
+        expect(joinUrl('https://example.com/api', '/_ops/signups'))
+            .toBe('https://example.com/api/_ops/signups');
+        expect(new URL('/_ops/signups', 'https://example.com/api').href)
+            .toBe('https://example.com/_ops/signups');
+    });
+
+    it('does not double a trailing slash', () =>
+    {
+        expect(joinUrl('https://example.com/', '/_ops/x')).toBe('https://example.com/_ops/x');
+    });
+});
+
+describe('fetchOpsManifest', () =>
+{
+    const good = { name: 'listSignups', method: 'GET', path: '/_ops/signups', input: {} };
+
+    it('keeps a well-formed command', async () =>
+    {
+        manifestAnswer([good]);
+        const manifest = await fetchOpsManifest('https://api.example.com', 'spfn_ops_x');
+
+        expect(manifest.commands).toEqual([good]);
+    });
+
+    it.each([
+        ['an absolute URL', { ...good, path: 'https://evil.example/steal' }],
+        ['a path outside the ops namespace', { ...good, path: '/internal/admin' }],
+        ['a path climbing out of it', { ...good, path: '/_ops/../../internal/admin' }],
+        ['a method the CLI cannot send', { ...good, method: 'TRACE' }],
+        ['a missing method', { name: 'x', path: '/_ops/x', input: {} }],
+        ['a missing name', { method: 'GET', path: '/_ops/x', input: {} }],
+    ])('drops a command declaring %s', async (_label, command) =>
+    {
+        manifestAnswer([command, good]);
+        const manifest = await fetchOpsManifest('https://api.example.com', 'spfn_ops_x');
+
+        expect(manifest.commands).toEqual([good]);
+    });
+
+    it('says so rather than dropping a command silently', async () =>
+    {
+        manifestAnswer([{ ...good, path: '/internal/admin' }]);
+        await fetchOpsManifest('https://api.example.com', 'spfn_ops_x');
+
+        expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/Ignoring an ops command/);
+    });
+
+    it('gives a command with no input section an empty one, so rendering cannot crash', async () =>
+    {
+        manifestAnswer([{ name: 'x', method: 'GET', path: '/_ops/x' }]);
+        const manifest = await fetchOpsManifest('https://api.example.com', 'spfn_ops_x');
+
+        expect(manifest.commands[0]!.input).toEqual({});
+        expect(() => renderCommandUsage(manifest.commands[0]!)).not.toThrow();
+    });
+});
+
+describe('rendering a manifest the app wrote', () =>
+{
+    it('replaces control characters so the app cannot redraw the terminal', () =>
+    {
+        expect(plain(`${ESC}[2J${ESC}[1;1Hspfn $ `)).toBe('?[2J?[1;1Hspfn $ ');
+    });
+
+    it('carries no escape sequence through to the usage block', () =>
+    {
+        const command = {
+            name: `list${ESC}[2J`,
+            method: 'GET',
+            path: `/_ops/x${ESC}[1;1H`,
+            input: {
+                query: {
+                    type: 'object',
+                    properties: { limit: { type: 'number', description: `${ESC}[31mred` } },
+                    required: [],
+                },
+            },
+        } as unknown as OpsCommandDescriptor;
+
+        expect(renderCommandUsage(command)).not.toContain(ESC);
+    });
+
+    it('stops following a schema deep enough to exhaust the stack', () =>
+    {
+        let schema: unknown = { type: 'string' };
+        for (let i = 0; i < 20000; i++)
+        {
+            schema = { type: 'object', properties: { n: schema }, required: ['n'] };
+        }
+
+        const command = {
+            name: 'deep', method: 'GET', path: '/_ops/deep', input: { body: schema },
+        } as unknown as OpsCommandDescriptor;
+
+        expect(() => renderCommandUsage(command)).not.toThrow();
+    });
+});

--- a/packages/cli/src/utils/ops/admin-session.ts
+++ b/packages/cli/src/utils/ops/admin-session.ts
@@ -17,6 +17,7 @@
 import prompts from 'prompts';
 import chalk from 'chalk';
 import { loadAuthCrypto } from './auth-crypto.js';
+import { joinUrl } from './client.js';
 
 export interface AdminSession
 {
@@ -25,9 +26,33 @@ export interface AdminSession
     keyId: string;
 }
 
+/**
+ * Read an answer that is supposed to be JSON.
+ *
+ * A proxy or load balancer in front of the app answers an error with HTML, and
+ * `JSON.parse` on that raises a parser's complaint about a `<` — which tells an
+ * operator nothing about what went wrong. The status is what matters there.
+ */
+function parseJsonAnswer(text: string, status: number, statusText: string): any
+{
+    if (!text)
+    {
+        return {};
+    }
+
+    try
+    {
+        return JSON.parse(text);
+    }
+    catch
+    {
+        throw new Error(`The app answered ${status} ${statusText} with something that is not JSON.`);
+    }
+}
+
 async function postJson(appUrl: string, path: string, body: unknown, authorization?: string): Promise<any>
 {
-    const response = await fetch(new URL(path, appUrl), {
+    const response = await fetch(joinUrl(appUrl, path), {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -37,7 +62,7 @@ async function postJson(appUrl: string, path: string, body: unknown, authorizati
     });
 
     const text = await response.text();
-    const parsed = text ? JSON.parse(text) : {};
+    const parsed = parseJsonAnswer(text, response.status, response.statusText);
 
     if (!response.ok)
     {
@@ -175,7 +200,7 @@ export async function adminRequest(
     body?: unknown,
 ): Promise<any>
 {
-    const response = await fetch(new URL(path, appUrl), {
+    const response = await fetch(joinUrl(appUrl, path), {
         method,
         headers: {
             Authorization: session.authorization,
@@ -185,7 +210,7 @@ export async function adminRequest(
     });
 
     const text = await response.text();
-    const parsed = text ? JSON.parse(text) : {};
+    const parsed = parseJsonAnswer(text, response.status, response.statusText);
 
     if (!response.ok)
     {

--- a/packages/cli/src/utils/ops/auth-crypto.ts
+++ b/packages/cli/src/utils/ops/auth-crypto.ts
@@ -27,7 +27,20 @@
  * resolving a package that is deliberately absent. The shape below is what is
  * promised in exchange; it must keep matching `@spfn/auth/crypto`, and the
  * integration tests in that package walk the real functions end to end.
+ *
+ * Resolution starts from the app's directory, not from this file. A bare
+ * `import('@spfn/auth/crypto')` resolves against the CLI's own location, which
+ * is the app only when the CLI happens to be installed inside it — and the
+ * documented way to run this CLI is `npx spfn@beta`, which unpacks it into the
+ * npx cache instead. From there the walk up the directory tree never reaches
+ * the app's `node_modules`, so an app that has `@spfn/auth` installed is told
+ * it does not: the operator is sent to install what they already have.
+ * `bin/spfn.js` resolves `tsx` the same way for the mirror-image reason.
  */
+
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 /** A client key pair. Both halves are base64-encoded DER. */
 export interface ClientKeyPair
@@ -68,11 +81,27 @@ const CRYPTO_ENTRY = '@spfn/auth/crypto';
  * while loading. Calling all three "not installed" sends an operator to
  * install what they already have.
  */
+/**
+ * Resolve the entry point from the app's directory and load it by file URL.
+ *
+ * `createRequire` is what gives resolution an anchor other than this file; the
+ * path it is anchored to need not exist, only its directory. The two failures
+ * `loadAuthCrypto` discriminates come out of `resolve` with the same codes a
+ * bare dynamic import raises — `MODULE_NOT_FOUND` for an absent package,
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` for one without the subpath.
+ */
+async function importFromApp(specifier: string): Promise<unknown>
+{
+    const requireFromApp = createRequire(join(process.cwd(), 'noop.js'));
+
+    return await import(pathToFileURL(requireFromApp.resolve(specifier)).href);
+}
+
 export async function loadAuthCrypto(): Promise<AuthCrypto>
 {
     try
     {
-        return await import(CRYPTO_ENTRY) as AuthCrypto;
+        return await importFromApp(CRYPTO_ENTRY) as AuthCrypto;
     }
     catch (err)
     {
@@ -81,9 +110,10 @@ export async function loadAuthCrypto(): Promise<AuthCrypto>
         if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND')
         {
             throw new Error(
-                'This project does not have @spfn/auth installed, and ops tokens live in its schema — '
+                `No @spfn/auth is installed in ${process.cwd()}, and ops tokens live in its schema — `
                 + 'so this app has none to issue, list or revoke.\n'
                 + '   An app that uses the ops surface installs @spfn/auth for opsTokenAuth; add it there.\n'
+                + '   Run this from the app directory — the package is resolved from where the command runs.\n'
                 + '   Invoking commands with a token you already hold (spfn ops list / call) does not need it.',
             );
         }

--- a/packages/cli/src/utils/ops/client.ts
+++ b/packages/cli/src/utils/ops/client.ts
@@ -38,7 +38,18 @@ export interface OpsResponse
     body: unknown;
 }
 
-function joinUrl(appUrl: string, path: string): string
+/**
+ * Append an absolute path to the app URL, keeping whatever base path the
+ * operator gave.
+ *
+ * Concatenation rather than `new URL(path, appUrl)`, because an absolute path
+ * resolved against a base replaces it: an app mounted at
+ * `https://example.com/api` would be called at `https://example.com/_ops/...`.
+ * Every request the CLI makes goes through here so the two halves of the
+ * surface — the ops calls and the administrator sign-in — agree about where
+ * the app is.
+ */
+export function joinUrl(appUrl: string, path: string): string
 {
     return appUrl.replace(/\/+$/, '') + path;
 }
@@ -98,7 +109,76 @@ export async function fetchOpsManifest(appUrl: string, token: string): Promise<O
         throw new Error('The manifest answer has an unknown shape.');
     }
 
-    return manifest;
+    return { manifestVersion: 1, commands: usableCommands(manifest.commands) };
+}
+
+const OPS_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+
+/** Every ops route lives under this prefix — `createOpsRouter` enforces it. */
+const OPS_PATH_PREFIX = '/_ops/';
+
+/**
+ * Why a command cannot be used, or null when it can.
+ *
+ * The manifest is the app's own description of itself, and the CLI turns it
+ * into a request carrying an ops token — so a command is checked before it can
+ * become one, rather than trusted and allowed to fail as a stack trace deep in
+ * `fetch`. The path rule is the server's own: `createOpsRouter` refuses a route
+ * outside `/_ops/`, so anything else here did not come from it.
+ */
+function unusableBecause(command: OpsCommandDescriptor): string | null
+{
+    if (typeof command?.name !== 'string' || command.name.length === 0)
+    {
+        return 'it has no name';
+    }
+    if (typeof command.method !== 'string' || !OPS_METHODS.has(command.method))
+    {
+        return `its method is ${JSON.stringify(command.method)}`;
+    }
+    if (typeof command.path !== 'string' || !command.path.startsWith(OPS_PATH_PREFIX))
+    {
+        return `its path ${JSON.stringify(command.path)} is outside ${OPS_PATH_PREFIX}`;
+    }
+    if (command.path.split('/').includes('..'))
+    {
+        return `its path ${JSON.stringify(command.path)} climbs out of the ops namespace`;
+    }
+
+    return null;
+}
+
+/**
+ * Keep the commands the CLI can invoke and say which it dropped.
+ *
+ * Dropping rather than refusing the whole manifest: a newer server may announce
+ * something this CLI has no way to call, and one such command must not cost the
+ * operator every other command on the surface. Silence would be worse than
+ * either — an operator would read a short list as the app's whole surface.
+ */
+function usableCommands(commands: OpsCommandDescriptor[]): OpsCommandDescriptor[]
+{
+    const usable: OpsCommandDescriptor[] = [];
+
+    for (const command of commands)
+    {
+        const reason = unusableBecause(command);
+
+        if (reason !== null)
+        {
+            console.error(`⚠️  Ignoring an ops command the manifest announced: ${reason}.`);
+            continue;
+        }
+
+        usable.push({ ...command, input: isPlainObject(command.input) ? command.input : {} });
+    }
+
+    return usable;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown>
+{
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**

--- a/packages/cli/src/utils/ops/describe.ts
+++ b/packages/cli/src/utils/ops/describe.ts
@@ -37,6 +37,32 @@ function isSchema(value: unknown): value is Schema
 }
 
 /**
+ * How deep a schema is followed before its fields stop being listed.
+ *
+ * `collectFields` recurses once per level of nesting, so a schema deep enough
+ * exhausts the stack and the command dies with `Maximum call stack size
+ * exceeded` instead of printing usage. The limit is far past anything an
+ * operator would read as a flat list anyway.
+ */
+const MAX_SCHEMA_DEPTH = 12;
+
+/**
+ * Strip what a terminal would act on rather than show.
+ *
+ * Every string rendered here — a field's description, its pattern, a command's
+ * name — is the app's, and it is written straight to the operator's terminal.
+ * Escape sequences left in it can clear the screen or redraw the lines above,
+ * so what the operator reads is no longer what the CLI wrote. Control
+ * characters are replaced rather than dropped, so text that contained them
+ * still reads as suspicious instead of quietly shrinking.
+ */
+export function plain(value: string): string
+{
+     
+    return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, '?');
+}
+
+/**
  * The type as an operator should read it: `string`, `number[]`, `a|b` for a
  * union, `object` for anything with its own fields.
  */
@@ -122,7 +148,7 @@ function constraintNotes(schema: Schema): string[]
  * contributes its own fields under a dotted name rather than a row saying
  * `object` and nothing else.
  */
-function collectFields(schema: Schema, prefix = ''): FieldRow[]
+function collectFields(schema: Schema, prefix = '', depth = 0): FieldRow[]
 {
     const properties = isSchema(schema.properties) ? schema.properties : {};
     const required = Array.isArray(schema.required) ? schema.required : [];
@@ -135,8 +161,10 @@ function collectFields(schema: Schema, prefix = ''): FieldRow[]
             continue;
         }
 
-        const path = prefix ? `${prefix}.${name}` : name;
-        const nested = isSchema(raw.properties) ? collectFields(raw, path) : [];
+        const path = prefix ? `${prefix}.${plain(name)}` : plain(name);
+        const nested = isSchema(raw.properties) && depth < MAX_SCHEMA_DEPTH
+            ? collectFields(raw, path, depth + 1)
+            : [];
 
         if (nested.length > 0)
         {
@@ -146,9 +174,9 @@ function collectFields(schema: Schema, prefix = ''): FieldRow[]
 
         rows.push({
             name: path,
-            type: typeName(raw),
+            type: plain(typeName(raw)),
             requirement: required.includes(name) ? 'required' : 'optional',
-            notes: constraintNotes(raw).join(', '),
+            notes: plain(constraintNotes(raw).join(', ')),
         });
     }
 
@@ -182,7 +210,7 @@ function renderSection(label: string, flag: string, rows: FieldRow[]): string[]
  */
 export function renderCommandUsage(command: OpsCommandDescriptor): string
 {
-    const lines = [`${command.name}  ${command.method} ${command.path}`, ''];
+    const lines = [`${plain(command.name)}  ${command.method} ${plain(command.path)}`, ''];
     let described = false;
 
     for (const section of SECTIONS)
@@ -208,7 +236,7 @@ export function renderCommandUsage(command: OpsCommandDescriptor): string
         lines.push('  Takes no input.', '');
     }
 
-    lines.push(`  Invoke: spfn ops call ${command.name}${exampleFlags(command)}`);
+    lines.push(`  Invoke: spfn ops call ${plain(command.name)}${exampleFlags(command)}`);
 
     return lines.join('\n');
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -448,7 +448,8 @@ Authentication is an ops token from [`@spfn/auth`](../auth/README.md#ops-tokens-
 scoped, revocable, hash-stored, issued with `spfn ops token issue` against the running app
 — the CLI signs in as an administrator, so issuance needs no database access. On macOS the
 CLI keeps the token in the keychain (`spfn ops token store`), and resolution order is
-`--token` → `SPFN_OPS_TOKEN` → keychain.
+`--token` → `SPFN_OPS_TOKEN` → keychain. The `--app` URL must be https, since every command
+carries a secret; `http` is accepted only against a loopback host.
 
 ---
 


### PR DESCRIPTION
## 왜 지금인가

`spfn@0.3.0-beta.1`은 **의도한 배포가 아니었다.** `publish-cli.yml`은 버전이 바뀔 때가 아니라 `packages/cli/package.json` **파일**이 바뀔 때 실행되고, #127이 lockfile 교착을 풀려고 그 파일을 건드리면서 트리거를 밟았다. 가드인 `npm view spfn@<version>`은 아직 배포된 적 없는 버전을 그대로 통과시켰다.

그래서 아무도 읽지 않은 ops CLI 표면이 `latest`로 공개 npmjs에 올라가 있다. 이 PR은 그 표면을 전부 읽은 결과이고, `0.3.0-beta.2`가 그것을 대체한다.

리뷰 범위는 약 1,400줄, 그중 3분의 2가 리뷰어의 눈을 거친 적 없는 코드였다.

## 고친 것

| 파일 | 결함 | 등급 |
| --- | --- | --- |
| `commands/ops/resolve.ts` | scheme 검사가 없어 `http://`로 관리자 비밀번호가 평문 전송 | 보안 |
| `utils/ops/auth-crypto.ts` | `@spfn/auth`를 CLI 자기 위치에서 해석 — README가 안내하는 `npx spfn@beta`는 앱에 닿지 못함 | 정합성 |
| `utils/ops/client.ts` | 매니페스트 명령을 검증 없이 요청 경로로 사용 | 견고성 |
| `utils/ops/describe.ts` | `input` 없으면 TypeError, 깊은 스키마에 RangeError, 제어문자 그대로 출력 | 견고성·보안 인접 |
| `utils/ops/admin-session.ts` | `--app`의 하위 경로를 ops 호출은 살리고 로그인은 버림 | 정합성 |
| `commands/ops/resolve.ts` | 잠긴 키체인이 스택 트레이스로 노출 | 견고성 |
| `auth/.../entities/ops-tokens.ts` | "토큰 생성 HTTP 표면 없음" — #126 이후 거짓 | 문서 |

각 항목은 실제 실행으로 확인했다. 추측으로 적은 것은 없다.

### https 강제 (BREAKING)

`spfn ops` 명령은 모두 비밀을 나른다 — `token issue`는 관리자 비밀번호를, `list`·`call`은 ops 토큰을. 이제 https를 요구하고 loopback 호스트(`localhost`·`127.0.0.1`·`::1`)에서만 http를 허용한다. 스캐폴드가 `:8790`을 http로 쓰므로 로컬 개발은 그대로 동작한다.

### 앱 기준 패키지 해석

`import('@spfn/auth/crypto')`는 CLI 자기 위치에서 해석된다. README가 안내하는 실행 방식은 `npx spfn@beta`이고, 그렇게 받은 CLI는 npx 캐시에 풀리므로 디렉터리를 거슬러 올라가도 앱의 `node_modules`에 닿지 못한다. **패키지를 설치해 둔 앱에게 "설치되어 있지 않다"고 말해 왔다.** 이제 명령이 실행된 디렉터리에서 해석한다.

### 매니페스트 신뢰 경계

매니페스트는 앱이 쓰는 데이터인데 검증 없이 명령과 요청 경로가 됐다. 이제 `/_ops/` 밖이거나 보낼 수 없는 메서드인 명령은 **이유를 밝히고 버린다** — 전체를 거부하지 않는 것은 이 CLI가 모르는 명령 하나가 나머지 전부를 앗아가면 안 되기 때문이다.

## 확인했으나 문제 없던 것

- 매니페스트 경로는 어떤 형태로도 앱 origin을 벗어나지 못한다 (절대 URL·`..`·프로토콜 상대 전부 실측)
- Node의 fetch는 cross-origin 리다이렉트에서 `Authorization`을 제거한다 (실측)
- `requireOpsScope`는 토큰이 없으면 401로 닫힌다
- `keychain.ts`의 `assertBatchSafe`는 batch 명령 인용부호를 깨뜨릴 수 없다
- `ERR_PACKAGE_PATH_NOT_EXPORTED` 분기와 그 문구는 정상 동작

## 수용한 위험

`extractBearer`의 `'Bearer '` 접두사 비교는 대소문자를 구분한다. RFC 7235 기준으로는 scheme이 대소문자 무관이지만 `authenticate.ts`의 두 곳도 같은 방식이라, 여기만 바꾸면 오히려 패키지 내 불일치가 된다. CLI는 항상 `Bearer`를 보낸다. 패키지 전체를 바꾸는 별도 작업의 몫이다.

## 검증

| 게이트 | 결과 |
| --- | --- |
| `pnpm build` | 17/17 |
| `pnpm test` | 2,383 passing · 0 failing (이전 2,344 + 신규 39) |
| `pnpm lint` | clean |
| `pnpm check:versions` | clean |
| `tsc --noEmit` (cli) | clean |

새 테스트는 모두 **수정 전 코드에서 실패하는 것을 확인**했다 — resolve 6/17, manifest 13/14, auth-crypto 3/3.

## 병합하면 배포된다

`packages/cli/package.json`의 버전 변경이 곧 `publish-cli.yml`의 트리거다. 이 PR을 병합하면 `spfn@0.3.0-beta.2`가 공개 npmjs로 나가고 `latest`가 그리로 옮겨간다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)